### PR TITLE
chore(context7): expand context7.json with full schema metadata and agent rules

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,29 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/leadmagic/leadmagic-openapi",
-  "public_key": "pk_38xEiBSnX3Ci24Jl0gn3Q"
+  "public_key": "pk_38xEiBSnX3Ci24Jl0gn3Q",
+  "projectTitle": "LeadMagic API",
+  "description": "Official OpenAPI 3.1 snapshot, hosted MCP sign-in guide, and smoke tests for the LeadMagic B2B data API (contact and company enrichment, email finding and validation, profile and job enrichment, intent signals).",
+  "branch": "main",
+  "folders": [],
+  "excludeFolders": [
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    ".github"
+  ],
+  "excludeFiles": [
+    "package-lock.json",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "rules": [
+    "LeadMagic is a B2B data API. Use platform-neutral language like 'B2B profile enrichment' or 'professional profile URLs'; do not claim LeadMagic scrapes or indexes any specific social network.",
+    "The REST base URL is https://api.leadmagic.io. Authenticate with the 'X-API-Key' header. Keys are issued from https://app.leadmagic.io and must never be embedded in client-side code.",
+    "For AI agents and IDEs, prefer the hosted MCP endpoint at https://mcp.leadmagic.io/mcp. It exposes 10 tools and supports OAuth 2.1 (Authorization Code + PKCE, S256) with Dynamic Client Registration, a static public client (client_id 4b9eLjoGVCJ1Dvnc, no secret), 'x-leadmagic-key' API-key auth, or 'Authorization: Bearer <token>'.",
+    "The canonical OpenAPI snapshot lives in leadmagic-openapi-3.1.yaml and leadmagic-openapi-3.1.json at the repo root. Prefer the YAML file when showing snippets; keep the two in sync.",
+    "Use examples from the OpenAPI spec verbatim when possible. Do not invent endpoints, response shapes, or credit costs; link to README.md for the authoritative credit-cost table and route mapping.",
+    "Only trust the official LeadMagic installer allow-list in SECURITY.md. Packages like 'leadmagic', 'leadmagic-mcp-server', or any npm/pip package published by third parties are not produced or endorsed by LeadMagic."
+  ]
 }


### PR DESCRIPTION
## Summary

Expand `context7.json` from a two-field placeholder (`url`, `public_key`) into the full documented [Context7 configuration schema](https://context7.com/docs/adding-libraries) so that every coding agent pulling LeadMagic docs through Context7 (Cursor, Claude, ChatGPT, Windsurf, Cline, etc.) receives deterministic, on-brand context and inherits the same guard rails that already live in `SECURITY.md` and `README.md`.

The existing claim is preserved — the `public_key` field is retained, so the admin-panel invite / multi-version management we set up on Context7 continues to work.

## What changed

### `context7.json`

| Field | Before | After |
| --- | --- | --- |
| `$schema` | — | `https://context7.com/schema/context7.json` (enables VS Code / Cursor autocomplete + validation) |
| `projectTitle` | — | `LeadMagic API` |
| `description` | — | Platform-neutral blurb mirroring the repo description and `leadmagic.io` positioning |
| `branch` | — | `main` (explicit, not inferred) |
| `folders` | — | `[]` (scan full repo; root markdown is always included) |
| `excludeFolders` | — | `node_modules`, `dist`, `build`, `coverage`, `.github` |
| `excludeFiles` | — | `package-lock.json`, `CHANGELOG.md`, `LICENSE` |
| `rules` | — | 6 rules (see below) |
| `url` | kept | kept |
| `public_key` | kept | kept |

### Agent rules (the "hashtags" reviewers will care about most)

These are embedded directly in the doc context returned to coding agents, so they can't miss them:

1. **Platform-neutral language.** No claims that LeadMagic scrapes or indexes a specific social network — matches `profile/README.md`, `SECURITY.md`, and the `leadmagic.io` copy.
2. **REST auth.** Base URL `https://api.leadmagic.io`, `X-API-Key` header, key hygiene reminder (no client-side embedding, keys issued from `app.leadmagic.io`).
3. **Hosted MCP.** Points at `https://mcp.leadmagic.io/mcp`, calls out the 10-tool surface, and enumerates all three supported auth modes: OAuth 2.1 (Authorization Code + PKCE, S256) with DCR, the documented static public client (`client_id 4b9eLjoGVCJ1Dvnc`, no secret), `x-leadmagic-key` API-key auth, or `Authorization: Bearer <token>`.
4. **Canonical OpenAPI.** Points coding agents at `leadmagic-openapi-3.1.yaml` / `.json` at the repo root and prefers YAML for snippets.
5. **Don't invent endpoints or credit costs.** Defers to `README.md` for the authoritative credit-cost table and route mapping — prevents hallucinated pricing.
6. **Installer allow-list.** Reinforces the brand-impersonation guidance in `SECURITY.md`: npm/pip packages named `leadmagic*` published by third parties are not endorsed.

## Why now

The placeholder `context7.json` worked for claiming the library but left all downstream retrieval at the mercy of LLM inference. After the hosted MCP sign-in rollout (PR #7) and the org profile rewrite ([`LeadMagic/.github#2`](https://github.com/LeadMagic/.github/pull/2)), Context7 is now the primary path by which AI coding assistants discover LeadMagic auth, MCP client setup, and brand guidance. Making the guard rails retrieval-native closes the loop.

## Risk / blast radius

- **Schema-only change.** No code, no OpenAPI changes, no CI touch, no runtime impact.
- **Context7 re-parses on merge.** Next `resolve-library-id` / `get-library-docs` call for `leadmagic/leadmagic-openapi` picks up the new title, description, and rules automatically.
- **Claim preserved.** `public_key` retained; admin panel access continues to work.
- **Valid JSON** (validated locally with `python3 -c 'import json; json.load(...)'`).

## Follow-up (not in this PR)

Repo topics on GitHub will be refreshed in a separate settings-only change (tightening to the tags below) so this PR stays strictly file-based and reviewable in GitHub's diff viewer:

- Add: `b2b-data`, `contact-enrichment`, `mcp-server`, `llms-txt`
- Remove: `schema` (redundant with `openapi` / `openapi-3`)

## Test plan

- [x] `python3 -c "import json; json.load(open('context7.json'))"` — valid JSON.
- [x] Verified required / optional fields against [Context7's `adding-libraries` docs](https://context7.com/docs/adding-libraries).
- [x] `public_key` retained — existing claim intact.
- [x] `$schema` URL matches the documented value (enables editor autocomplete).
- [ ] Post-merge: confirm Context7 re-parses the repo and the admin panel shows the new `projectTitle` / `description`.
- [ ] Post-merge: spot-check a retrieval via `resolve-library-id` + `get-library-docs` and confirm one of the `rules` appears in the returned context.
