### PR TITLE
Full 81-path spec sync, zero-vuln deps, refreshed LLM docs

### DIFF
--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -102,9 +102,10 @@ jobs:
 
     - name: ✅ Check for OpenAPI 3.1 examples format
       run: |
-        # Detect the deprecated singular 'example:' / '"example":' fields from OpenAPI 3.0
-        # without matching the valid 3.1 'examples:' / '"examples":' form.
-        if grep -nE '(^|[^s])"example"[[:space:]]*:|(^|[^s])example[[:space:]]*:' \
+        # Detect the deprecated singular 'example:' / '"example":' KEYS from OpenAPI 3.0
+        # without matching the valid 3.1 'examples:' form or data fields that merely
+        # end in "example" (e.g. `email_pattern_example:` in example payloads).
+        if grep -nE '(^|[^[:alnum:]_"])"example"[[:space:]]*:|(^[[:space:]]*|[{,][[:space:]]*)example[[:space:]]*:' \
             leadmagic-openapi-3.1.yaml leadmagic-openapi-3.1.json; then
           echo "❌ Found deprecated 'example' fields. Use 'examples' for OpenAPI 3.1"
           exit 1

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ try {
 - Only install LeadMagic-branded MCP servers, skills, or plugins from the official locations listed in [`SECURITY.md`](SECURITY.md). The authoritative install paths are `github.com/LeadMagic/*` and `mcp.leadmagic.io`.
 
 ## Files
-- `leadmagic-openapi-3.1.yaml`: Local OpenAPI snapshot
+- `leadmagic-openapi-3.1.yaml`: Local OpenAPI snapshot (normalized to strict 3.1 `examples` style via `scripts/normalize-31-examples.mjs`)
 - `leadmagic-openapi-3.1.json`: JSON form of the local snapshot
 - `.spectral.yml`: OpenAPI lint configuration
 - `llms.txt`: Short, current LLM-oriented overview

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LeadMagic OpenAPI Snapshot
 
-This repository contains a maintained OpenAPI snapshot, LLM-friendly docs, and a live API smoke-test script for LeadMagic. It should stay aligned with the current LeadMagic MCP positioning, but it is an **API / REST** snapshot repo—not a mirror of the full Cursor plugin bundle.
+OpenAPI 3.1 specification, LLM-friendly reference (`llms.txt`), and live smoke tests for the **LeadMagic B2B data enrichment API** — people search (400M+ profiles), company search (25M+), job-postings search (46M+), email finding & validation, mobile numbers, ads intelligence, and bulk CSV enrichment. Use it for codegen, Postman/Insomnia imports, agent/LLM context, and API integration testing.
 
 **Pairing:** For **Cursor** and hosted **MCP** (OAuth by default), use the official plugin repo: [github.com/LeadMagic/leadmagic-cursor-plugin](https://github.com/LeadMagic/leadmagic-cursor-plugin). That package follows the usual Cursor plugin layout (rules, skills, **agent**, **commands**, and MCP)—similar in shape to community examples such as [encoredev/cursor-plugin](https://github.com/encoredev/cursor-plugin), but with **remote HTTP MCP** to LeadMagic’s cloud instead of a local stdio server.
 
@@ -11,9 +11,12 @@ The authoritative product documentation is the public docs site:
 - Dashboard: [https://app.leadmagic.io](https://app.leadmagic.io)
 
 ## Status
-The public API docs now use versioned routes under `/v1/...` and expose more endpoints than this repo currently models. This repo currently focuses on the 19 core endpoints already represented in the local OpenAPI files, plus current route mappings and a cleaner validation script.
 
-If you need the full current product surface, treat `https://leadmagic.io/docs` as the source of truth.
+The snapshot models the **full current public surface — 81 paths** — synced from the live docs contract at [leadmagic.io/docs](https://leadmagic.io/docs): versioned `/v1/*` enrichment routes, the `/v3/*` search family (people, companies, jobs — with route aliases), `/bulk/*` and `/v1/batch/*` job pipelines, analytics, and ads.
+
+**Unlimited search on Professional & Ultimate plans:** `POST /v3/people/search`, `POST /v3/companies/search`, and `POST /v3/jobs/search` are credit-free with no volume cap — rate-limited only (5 req/s Professional, 10 req/s Ultimate). See the [agent guide](https://leadmagic.io/docs/mcp/agent-guide) for pagination and best practices.
+
+When the product moves ahead of this snapshot, [leadmagic.io/docs](https://leadmagic.io/docs) is the source of truth.
 
 ## Companion surfaces
 
@@ -28,27 +31,11 @@ LeadMagic's developer surface spans a few aligned entry points:
 
 This repo should stay aligned with live API behavior, but [leadmagic.io/docs](https://leadmagic.io/docs) remains the source of truth when the product moves ahead of the snapshot.
 
-## Hosted MCP tool surface (Cursor)
+## Hosted MCP tool surface
 
-The public **hosted MCP** exposes **10 tools** (a subset of the REST API), plus:
+The hosted MCP exposes **35+ tools** covering the whole product: people/company/jobs search, decision-makers, email find/validate, mobile, account intelligence, technographics, competitors, job-change detection, ads research, bulk jobs, and credits — plus the `leadmagic://docs` resource and built-in prompts (`account_research`, `contact_lookup`). Full tool reference: [leadmagic.io/docs/mcp/tools](https://leadmagic.io/docs/mcp/tools).
 
-- 1 shared docs resource: `leadmagic://docs`
-- 2 built-in prompts (for example `account_research`, `contact_lookup`)
-
-| MCP tool | Typical REST backing (see docs / OpenAPI) |
-| --- | --- |
-| `check_credit_balance` | `GET /v1/credits` |
-| `validate_work_email` | `POST /v1/people/email-validation` |
-| `find_work_email` | `POST /v1/people/email-finder` |
-| `find_mobile_number` | `POST /v1/people/mobile-finder` |
-| `linkedin_profile_to_work_email` | `POST /v1/people/b2b-profile-email` |
-| `detect_job_change` | Job-change detector endpoint (see product docs) |
-| `research_account` | Company search + funding (e.g. `/v1/companies/...`) |
-| `list_company_competitors` | Competitors endpoint |
-| `get_company_technographics` | Technographics endpoint |
-| `find_people_by_role` | `POST /v1/people/role-finder` |
-
-**Important:** This OpenAPI snapshot includes **jobs** and **ads** routes and other endpoints that are **not** exposed as MCP tools today. When updating copy here, keep that gap explicit and cross-check [leadmagic-cursor-plugin](https://github.com/LeadMagic/leadmagic-cursor-plugin) and [MCP tools docs](https://leadmagic.io/docs/mcp/tools).
+Agent skills that teach correct usage (plans, cursors, credit safety): [LeadMagic/leadmagic-skills](https://github.com/LeadMagic/leadmagic-skills) — `npx skills add LeadMagic/leadmagic-skills`.
 
 ## Hosted MCP sign-in
 
@@ -192,7 +179,9 @@ Current docs group routes under:
 - `/v1/jobs/*`
 - `/v1/ads/*`
 
-## Current Route Map
+## Legacy → current route map
+
+The snapshot no longer carries the old unversioned routes; this map is for migrating pre-`/v1` integrations.
 
 | Legacy repo route | Current documented route |
 | --- | --- |
@@ -242,7 +231,7 @@ These values are aligned to the public docs as of this cleanup pass.
 | `POST /v1/ads/b2b-ads-search` | 0.2 | 5 searches per credit |
 | `POST /v1/ads/b2b-ads-details` | 2 | Free if not found |
 
-Docs-only endpoints not yet represented in the local snapshot include analytics, job change detection, technographics, competitors search, job company types, job industries, job regions, and credits helper endpoints.
+V3 search pricing: 1 credit per returned row on metered plans; **credit-free and volume-unlimited on Professional (5 req/s) and Ultimate (10 req/s)**. Contact-detail unlocks, lookalikes (5), and jobs export stay metered on every plan.
 
 ## Use Case Examples
 

--- a/leadmagic-openapi-3.1.json
+++ b/leadmagic-openapi-3.1.json
@@ -36,7 +36,11 @@
           "type": "string",
           "format": "uuid"
         },
-        "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        "examples": {
+          "default": {
+            "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          }
+        }
       }
     },
     "headers": {
@@ -88,8 +92,10 @@
         "properties": {
           "success": {
             "type": "boolean",
-            "example": false,
-            "description": "Always false for error responses"
+            "description": "Always false for error responses",
+            "examples": [
+              false
+            ]
           },
           "errors": {
             "type": "array",
@@ -116,33 +122,45 @@
             "type": "string",
             "format": "uri",
             "description": "RFC 9457 - URI reference identifying the error type",
-            "example": "https://api.leadmagic.io/errors/validation_error"
+            "examples": [
+              "https://api.leadmagic.io/errors/validation_error"
+            ]
           },
           "title": {
             "type": "string",
             "description": "RFC 9457 - Short human-readable summary",
-            "example": "Request validation failed. Check your input parameters."
+            "examples": [
+              "Request validation failed. Check your input parameters."
+            ]
           },
           "status": {
             "type": "integer",
             "description": "RFC 9457 - HTTP status code",
-            "example": 400
+            "examples": [
+              400
+            ]
           },
           "detail": {
             "type": "string",
             "description": "RFC 9457 - Human-readable explanation specific to this occurrence",
-            "example": "The email field is required but was not provided."
+            "examples": [
+              "The email field is required but was not provided."
+            ]
           },
           "instance": {
             "type": "string",
             "format": "uri-reference",
             "description": "RFC 9457 - URI reference for this specific occurrence",
-            "example": "/v1/people/email-validation#req_abc123"
+            "examples": [
+              "/v1/people/email-validation#req_abc123"
+            ]
           },
           "code": {
             "type": "string",
             "description": "Machine-readable error code for programmatic handling",
-            "example": "validation_error"
+            "examples": [
+              "validation_error"
+            ]
           },
           "param": {
             "type": "array",
@@ -150,20 +168,26 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "email"
+            "examples": [
+              [
+                "email"
+              ]
             ]
           },
           "action": {
             "type": "string",
             "description": "Suggested action to resolve the error",
-            "example": "Provide a valid email address in the 'email' field."
+            "examples": [
+              "Provide a valid email address in the 'email' field."
+            ]
           },
           "docs": {
             "type": "string",
             "format": "uri",
             "description": "Link to relevant documentation",
-            "example": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            "examples": [
+              "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            ]
           },
           "context": {
             "type": "object",
@@ -180,18 +204,24 @@
             "type": "string",
             "format": "uuid",
             "description": "Unique identifier for this request (use for debugging/support)",
-            "example": "ea6e3248-f4d2-437d-bca3-20881b529129"
+            "examples": [
+              "ea6e3248-f4d2-437d-bca3-20881b529129"
+            ]
           },
           "timestamp": {
             "type": "string",
             "format": "date-time",
             "description": "ISO 8601 timestamp when the response was generated",
-            "example": "2024-02-01T12:00:00.000Z"
+            "examples": [
+              "2024-02-01T12:00:00.000Z"
+            ]
           },
           "environment": {
             "type": "string",
             "description": "API environment (production, staging)",
-            "example": "production"
+            "examples": [
+              "production"
+            ]
           }
         }
       },
@@ -201,27 +231,29 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/validation_error",
-              "title": "Request validation failed. Check your input parameters.",
-              "status": 400,
-              "code": "validation_error",
-              "param": [
-                "email"
-              ],
-              "detail": "Email format is invalid. Expected format: user@domain.com",
-              "action": "Provide a valid email address in the 'email' field.",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/validation_error",
+                "title": "Request validation failed. Check your input parameters.",
+                "status": 400,
+                "code": "validation_error",
+                "param": [
+                  "email"
+                ],
+                "detail": "Email format is invalid. Expected format: user@domain.com",
+                "action": "Provide a valid email address in the 'email' field.",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "MissingFieldError": {
         "allOf": [
@@ -229,25 +261,27 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/missing_required_field",
-              "title": "Missing required field: email. Add this field to your request.",
-              "status": 400,
-              "code": "missing_required_field",
-              "param": [
-                "email"
-              ],
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/missing_required_field",
+                "title": "Missing required field: email. Add this field to your request.",
+                "status": 400,
+                "code": "missing_required_field",
+                "param": [
+                  "email"
+                ],
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "InvalidJsonError": {
         "allOf": [
@@ -255,22 +289,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/invalid_json",
-              "title": "Invalid JSON in request body. Check your JSON syntax.",
-              "status": 400,
-              "code": "invalid_json",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/invalid_json",
+                "title": "Invalid JSON in request body. Check your JSON syntax.",
+                "status": 400,
+                "code": "invalid_json",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "InvalidParameterError": {
         "allOf": [
@@ -278,25 +314,27 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/invalid_parameter",
-              "title": "Invalid parameter: experience_level. Valid options: entry, mid, senior, executive.",
-              "status": 400,
-              "code": "invalid_parameter",
-              "param": [
-                "experience_level"
-              ],
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/invalid_parameter",
+                "title": "Invalid parameter: experience_level. Valid options: entry, mid, senior, executive.",
+                "status": 400,
+                "code": "invalid_parameter",
+                "param": [
+                  "experience_level"
+                ],
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "MissingAuthenticationError": {
         "allOf": [
@@ -304,22 +342,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/missing_authentication",
-              "title": "Authentication required. Provide a valid API key in the X-API-Key header (case-insensitive).",
-              "status": 401,
-              "code": "missing_authentication",
-              "docs": "https://leadmagic.io/docs/v1/authentication"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/missing_authentication",
+                "title": "Authentication required. Provide a valid API key in the X-API-Key header (case-insensitive).",
+                "status": 401,
+                "code": "missing_authentication",
+                "docs": "https://leadmagic.io/docs/v1/authentication"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "InvalidApiKeyError": {
         "allOf": [
@@ -327,22 +367,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/invalid_api_key",
-              "title": "Invalid API key. The key does not exist or is incorrect.",
-              "status": 401,
-              "code": "invalid_api_key",
-              "docs": "https://leadmagic.io/docs/v1/authentication"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/invalid_api_key",
+                "title": "Invalid API key. The key does not exist or is incorrect.",
+                "status": 401,
+                "code": "invalid_api_key",
+                "docs": "https://leadmagic.io/docs/v1/authentication"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "InsufficientPermissionsError": {
         "allOf": [
@@ -350,22 +392,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/insufficient_permissions",
-              "title": "Access denied to this resource. Upgrade your plan or contact support.",
-              "status": 403,
-              "code": "insufficient_permissions",
-              "docs": "https://leadmagic.io/docs/v1/authentication"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/insufficient_permissions",
+                "title": "Access denied to this resource. Upgrade your plan or contact support.",
+                "status": 403,
+                "code": "insufficient_permissions",
+                "docs": "https://leadmagic.io/docs/v1/authentication"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "InsufficientCreditsError": {
         "allOf": [
@@ -373,29 +417,31 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/insufficient_credits",
-              "title": "Insufficient credits: need 5, have 2.50. Add credits to continue.",
-              "status": 402,
-              "code": "insufficient_credits",
-              "detail": "This request requires 5 credit(s) but your account only has 2.50 credits remaining.",
-              "action": "Add credits to your account at https://app.leadmagic.io/settings/billing or contact support@leadmagic.io for enterprise plans.",
-              "docs": "https://leadmagic.io/docs/v1/credits",
-              "context": {
-                "credits_required": 5,
-                "credits_available": 2.5,
-                "credits_needed": 2.5
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/insufficient_credits",
+                "title": "Insufficient credits: need 5, have 2.50. Add credits to continue.",
+                "status": 402,
+                "code": "insufficient_credits",
+                "detail": "This request requires 5 credit(s) but your account only has 2.50 credits remaining.",
+                "action": "Add credits to your account at https://app.leadmagic.io/settings/billing or contact support@leadmagic.io for enterprise plans.",
+                "docs": "https://leadmagic.io/docs/v1/credits",
+                "context": {
+                  "credits_required": 5,
+                  "credits_available": 2.5,
+                  "credits_needed": 2.5
+                }
               }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "ResourceNotFoundError": {
         "allOf": [
@@ -403,22 +449,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/resource_not_found",
-              "title": "Resource not found.",
-              "status": 404,
-              "code": "resource_not_found",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/resource_not_found",
+                "title": "Resource not found.",
+                "status": 404,
+                "code": "resource_not_found",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "ProfileNotFoundError": {
         "allOf": [
@@ -426,22 +474,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/profile_not_found",
-              "title": "Profile not found or not accessible",
-              "status": 404,
-              "code": "profile_not_found",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/profile_not_found",
+                "title": "Profile not found or not accessible",
+                "status": 404,
+                "code": "profile_not_found",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "RateLimitExceededError": {
         "allOf": [
@@ -449,31 +499,33 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/rate_limit_exceeded",
-              "title": "Rate limit exceeded: 600 requests per 1 minute. Wait and try again.",
-              "status": 429,
-              "code": "rate_limit_exceeded",
-              "detail": "You have exceeded the maximum allowed request rate. Please wait before making additional requests.",
-              "action": "Wait 42 seconds before retrying. Consider implementing exponential backoff.",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#rate-limits",
-              "context": {
-                "limit": 600,
-                "window": "1 minute",
-                "remaining": 0,
-                "reset_at": 1706745642,
-                "retry_after_seconds": 42
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/rate_limit_exceeded",
+                "title": "Rate limit exceeded: 600 requests per 1 minute. Wait and try again.",
+                "status": 429,
+                "code": "rate_limit_exceeded",
+                "detail": "You have exceeded the maximum allowed request rate. Please wait before making additional requests.",
+                "action": "Wait 42 seconds before retrying. Consider implementing exponential backoff.",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#rate-limits",
+                "context": {
+                  "limit": 600,
+                  "window": "1 minute",
+                  "remaining": 0,
+                  "reset_at": 1706745642,
+                  "retry_after_seconds": 42
+                }
               }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "InternalServerError": {
         "allOf": [
@@ -481,24 +533,26 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/INTERNAL_ERROR",
-              "title": "Something went wrong on our end. Our team has been notified and is investigating.",
-              "status": 500,
-              "code": "INTERNAL_ERROR",
-              "detail": "This is a temporary server error. The issue has been automatically reported to our team.",
-              "action": "Wait 30 seconds and retry your request. If the problem persists, contact support@leadmagic.io",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/INTERNAL_ERROR",
+                "title": "Something went wrong on our end. Our team has been notified and is investigating.",
+                "status": 500,
+                "code": "INTERNAL_ERROR",
+                "detail": "This is a temporary server error. The issue has been automatically reported to our team.",
+                "action": "Wait 30 seconds and retry your request. If the problem persists, contact support@leadmagic.io",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "ExternalServiceError": {
         "allOf": [
@@ -506,22 +560,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/external_service_error",
-              "title": "Error communicating with external service. Please try again.",
-              "status": 502,
-              "code": "external_service_error",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/external_service_error",
+                "title": "Error communicating with external service. Please try again.",
+                "status": 502,
+                "code": "external_service_error",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "ServiceUnavailableError": {
         "allOf": [
@@ -529,22 +585,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/service_unavailable",
-              "title": "Service temporarily unavailable. Please try again later.",
-              "status": 503,
-              "code": "service_unavailable",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/service_unavailable",
+                "title": "Service temporarily unavailable. Please try again later.",
+                "status": 503,
+                "code": "service_unavailable",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "ConflictError": {
         "allOf": [
@@ -552,22 +610,24 @@
             "$ref": "#/components/schemas/ErrorResponse"
           }
         ],
-        "example": {
-          "success": false,
-          "errors": [
-            {
-              "type": "https://api.leadmagic.io/errors/conflict",
-              "title": "Resource conflict detected.",
-              "status": 409,
-              "code": "conflict",
-              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        "examples": [
+          {
+            "success": false,
+            "errors": [
+              {
+                "type": "https://api.leadmagic.io/errors/conflict",
+                "title": "Resource conflict detected.",
+                "status": 409,
+                "code": "conflict",
+                "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+              }
+            ],
+            "meta": {
+              "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+              "timestamp": "2024-02-01T12:00:00.000Z"
             }
-          ],
-          "meta": {
-            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
-            "timestamp": "2024-02-01T12:00:00.000Z"
           }
-        }
+        ]
       },
       "EmailValidationMessages": {
         "type": "string",
@@ -698,72 +758,100 @@
           "RateLimit-Limit": {
             "type": "integer",
             "description": "IETF Standard - Maximum requests per minute",
-            "example": 600
+            "examples": [
+              600
+            ]
           },
           "RateLimit-Remaining": {
             "type": "integer",
             "description": "IETF Standard - Requests remaining this minute",
-            "example": 587
+            "examples": [
+              587
+            ]
           },
           "RateLimit-Reset": {
             "type": "integer",
             "description": "IETF Standard - Seconds until limit resets",
-            "example": 42
+            "examples": [
+              42
+            ]
           },
           "X-RateLimit-Limit": {
             "type": "integer",
             "description": "Legacy - Maximum requests per minute",
-            "example": 600
+            "examples": [
+              600
+            ]
           },
           "X-RateLimit-Remaining": {
             "type": "integer",
             "description": "Legacy - Requests remaining this minute",
-            "example": 587
+            "examples": [
+              587
+            ]
           },
           "X-RateLimit-Reset": {
             "type": "integer",
             "description": "Legacy - Unix timestamp when limit resets",
-            "example": 1706745600
+            "examples": [
+              1706745600
+            ]
           },
           "X-RateLimit-Limit-Daily": {
             "type": "integer",
             "description": "Daily request limit",
-            "example": 500000
+            "examples": [
+              500000
+            ]
           },
           "X-RateLimit-Remaining-Daily": {
             "type": "integer",
             "description": "Requests remaining today",
-            "example": 485000
+            "examples": [
+              485000
+            ]
           },
           "X-RateLimit-Reset-Daily": {
             "type": "integer",
             "description": "Unix timestamp when daily limit resets",
-            "example": 1706832000
+            "examples": [
+              1706832000
+            ]
           },
           "X-Credits-Remaining": {
             "type": "number",
             "description": "Wallet credits remaining after this request",
-            "example": 15432.5
+            "examples": [
+              15432.5
+            ]
           },
           "X-Credits-Cost": {
             "type": "number",
             "description": "Credits reserved for this route before finalization (may exceed credits actually charged)",
-            "example": 1
+            "examples": [
+              1
+            ]
           },
           "X-Credits-Consumed": {
             "type": "number",
             "description": "Credits actually charged after finalization (matches body credits_consumed)",
-            "example": 1
+            "examples": [
+              1
+            ]
           },
           "X-Credits-Total": {
             "type": "number",
             "description": "Wallet credit balance at authorization",
-            "example": 15433.5
+            "examples": [
+              15433.5
+            ]
           },
           "X-Credits-Max-Cost": {
             "type": "number",
             "description": "Maximum credits that could be charged for this request",
-            "example": 1
+            "examples": [
+              1
+            ]
           },
           "X-Request-Id": {
             "type": "string",
@@ -772,22 +860,30 @@
           "X-RateLimit-Soft-Mode": {
             "type": "string",
             "description": "Whether soft mode is enabled (warn but don't block)",
-            "example": "true"
+            "examples": [
+              "true"
+            ]
           },
           "X-RateLimit-Daily-Usage-Percent": {
             "type": "integer",
             "description": "Daily usage as percentage",
-            "example": 15
+            "examples": [
+              15
+            ]
           },
           "X-RateLimit-RPM-Usage-Percent": {
             "type": "integer",
             "description": "Current minute usage as percentage",
-            "example": 5
+            "examples": [
+              5
+            ]
           },
           "Retry-After": {
             "type": "integer",
             "description": "Seconds to wait before retrying (only on 429 responses)",
-            "example": 42
+            "examples": [
+              42
+            ]
           }
         }
       },
@@ -801,7 +897,9 @@
           "product": {
             "type": "string",
             "description": "The enrichment product to run on each row (e.g. email_finder, email_validation, mobile_finder, profile_search, company_search).",
-            "example": "email_finder"
+            "examples": [
+              "email_finder"
+            ]
           },
           "rows": {
             "type": "array",
@@ -938,7 +1036,9 @@
             "properties": {
               "model": {
                 "type": "string",
-                "example": "llama-3.1-8b-instruct"
+                "examples": [
+                  "llama-3.1-8b-instruct"
+                ]
               },
               "prompt": {
                 "type": "string"
@@ -971,7 +1071,9 @@
             "type": "string",
             "format": "uuid",
             "description": "UUID identifier for the bulk job.",
-            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            "examples": [
+              "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            ]
           },
           "product": {
             "type": "string",
@@ -988,7 +1090,9 @@
           "status": {
             "type": "string",
             "description": "Always 'uploaded' for a freshly submitted job.",
-            "example": "uploaded"
+            "examples": [
+              "uploaded"
+            ]
           },
           "queue": {
             "type": "object",
@@ -1776,7 +1880,9 @@
                   "properties": {
                     "credits": {
                       "type": "number",
-                      "example": 2200
+                      "examples": [
+                        2200
+                      ]
                     }
                   }
                 }
@@ -1810,11 +1916,15 @@
                       "properties": {
                         "id": {
                           "type": "string",
-                          "example": "user_abc123"
+                          "examples": [
+                            "user_abc123"
+                          ]
                         },
                         "email": {
                           "type": "string",
-                          "example": "developer@leadmagic.io"
+                          "examples": [
+                            "developer@leadmagic.io"
+                          ]
                         }
                       }
                     },
@@ -1823,11 +1933,15 @@
                       "properties": {
                         "current": {
                           "type": "number",
-                          "example": 15432.5
+                          "examples": [
+                            15432.5
+                          ]
                         },
                         "formatted": {
                           "type": "string",
-                          "example": "$154.33"
+                          "examples": [
+                            "$154.33"
+                          ]
                         }
                       }
                     },
@@ -1839,19 +1953,27 @@
                           "properties": {
                             "limit": {
                               "type": "integer",
-                              "example": 600
+                              "examples": [
+                                600
+                              ]
                             },
                             "used": {
                               "type": "integer",
-                              "example": 45
+                              "examples": [
+                                45
+                              ]
                             },
                             "remaining": {
                               "type": "integer",
-                              "example": 555
+                              "examples": [
+                                555
+                              ]
                             },
                             "utilization": {
                               "type": "number",
-                              "example": 15
+                              "examples": [
+                                15
+                              ]
                             }
                           }
                         },
@@ -1860,19 +1982,27 @@
                           "properties": {
                             "limit": {
                               "type": "integer",
-                              "example": 500000
+                              "examples": [
+                                500000
+                              ]
                             },
                             "used": {
                               "type": "integer",
-                              "example": 12500
+                              "examples": [
+                                12500
+                              ]
                             },
                             "remaining": {
                               "type": "integer",
-                              "example": 487500
+                              "examples": [
+                                487500
+                              ]
                             },
                             "utilization": {
                               "type": "number",
-                              "example": 2.5
+                              "examples": [
+                                2.5
+                              ]
                             }
                           }
                         }
@@ -1883,15 +2013,21 @@
                       "properties": {
                         "current": {
                           "type": "integer",
-                          "example": 0
+                          "examples": [
+                            0
+                          ]
                         },
                         "peak": {
                           "type": "integer",
-                          "example": 23
+                          "examples": [
+                            23
+                          ]
                         },
                         "active_reservations": {
                           "type": "integer",
-                          "example": 0
+                          "examples": [
+                            0
+                          ]
                         }
                       }
                     },
@@ -1903,23 +2039,33 @@
                           "properties": {
                             "requests": {
                               "type": "integer",
-                              "example": 1250
+                              "examples": [
+                                1250
+                              ]
                             },
                             "credits": {
                               "type": "number",
-                              "example": 875.5
+                              "examples": [
+                                875.5
+                              ]
                             },
                             "chargeable_requests": {
                               "type": "integer",
-                              "example": 1100
+                              "examples": [
+                                1100
+                              ]
                             },
                             "chargeable_rate": {
                               "type": "number",
-                              "example": 88
+                              "examples": [
+                                88
+                              ]
                             },
                             "unique_products": {
                               "type": "integer",
-                              "example": 5
+                              "examples": [
+                                5
+                              ]
                             }
                           }
                         },
@@ -1928,23 +2074,33 @@
                           "properties": {
                             "requests": {
                               "type": "integer",
-                              "example": 8500
+                              "examples": [
+                                8500
+                              ]
                             },
                             "credits": {
                               "type": "number",
-                              "example": 5200.25
+                              "examples": [
+                                5200.25
+                              ]
                             },
                             "chargeable_requests": {
                               "type": "integer",
-                              "example": 7200
+                              "examples": [
+                                7200
+                              ]
                             },
                             "chargeable_rate": {
                               "type": "number",
-                              "example": 84.7
+                              "examples": [
+                                84.7
+                              ]
                             },
                             "unique_products": {
                               "type": "integer",
-                              "example": 8
+                              "examples": [
+                                8
+                              ]
                             }
                           }
                         },
@@ -1953,23 +2109,33 @@
                           "properties": {
                             "requests": {
                               "type": "integer",
-                              "example": 45000
+                              "examples": [
+                                45000
+                              ]
                             },
                             "credits": {
                               "type": "number",
-                              "example": 28500
+                              "examples": [
+                                28500
+                              ]
                             },
                             "chargeable_requests": {
                               "type": "integer",
-                              "example": 38000
+                              "examples": [
+                                38000
+                              ]
                             },
                             "chargeable_rate": {
                               "type": "number",
-                              "example": 84.4
+                              "examples": [
+                                84.4
+                              ]
                             },
                             "unique_products": {
                               "type": "integer",
-                              "example": 12
+                              "examples": [
+                                12
+                              ]
                             }
                           }
                         }
@@ -2021,16 +2187,22 @@
                         "start": {
                           "type": "string",
                           "format": "date",
-                          "example": "2024-01-02"
+                          "examples": [
+                            "2024-01-02"
+                          ]
                         },
                         "end": {
                           "type": "string",
                           "format": "date",
-                          "example": "2024-02-01"
+                          "examples": [
+                            "2024-02-01"
+                          ]
                         },
                         "days": {
                           "type": "integer",
-                          "example": 30
+                          "examples": [
+                            30
+                          ]
                         }
                       }
                     },
@@ -2039,27 +2211,39 @@
                       "properties": {
                         "total_requests": {
                           "type": "integer",
-                          "example": 45000
+                          "examples": [
+                            45000
+                          ]
                         },
                         "chargeable_requests": {
                           "type": "integer",
-                          "example": 38000
+                          "examples": [
+                            38000
+                          ]
                         },
                         "total_credits": {
                           "type": "number",
-                          "example": 28500
+                          "examples": [
+                            28500
+                          ]
                         },
                         "avg_credits_per_request": {
                           "type": "number",
-                          "example": 0.63
+                          "examples": [
+                            0.63
+                          ]
                         },
                         "chargeable_rate": {
                           "type": "number",
-                          "example": 84.4
+                          "examples": [
+                            84.4
+                          ]
                         },
                         "unique_products": {
                           "type": "integer",
-                          "example": 12
+                          "examples": [
+                            12
+                          ]
                         }
                       }
                     },
@@ -2071,23 +2255,33 @@
                           "date": {
                             "type": "string",
                             "format": "date",
-                            "example": "2024-02-01"
+                            "examples": [
+                              "2024-02-01"
+                            ]
                           },
                           "total_requests": {
                             "type": "integer",
-                            "example": 1250
+                            "examples": [
+                              1250
+                            ]
                           },
                           "chargeable_requests": {
                             "type": "integer",
-                            "example": 1100
+                            "examples": [
+                              1100
+                            ]
                           },
                           "total_credits": {
                             "type": "number",
-                            "example": 875.5
+                            "examples": [
+                              875.5
+                            ]
                           },
                           "unique_products_used": {
                             "type": "integer",
-                            "example": 5
+                            "examples": [
+                              5
+                            ]
                           }
                         }
                       }
@@ -2158,27 +2352,39 @@
                         "properties": {
                           "total_requests": {
                             "type": "integer",
-                            "example": 20000
+                            "examples": [
+                              20000
+                            ]
                           },
                           "total_credits": {
                             "type": "number",
-                            "example": 1000
+                            "examples": [
+                              1000
+                            ]
                           },
                           "successful_requests": {
                             "type": "integer",
-                            "example": 19500
+                            "examples": [
+                              19500
+                            ]
                           },
                           "failed_requests": {
                             "type": "integer",
-                            "example": 500
+                            "examples": [
+                              500
+                            ]
                           },
                           "success_rate": {
                             "type": "number",
-                            "example": 97.5
+                            "examples": [
+                              97.5
+                            ]
                           },
                           "avg_credits_per_request": {
                             "type": "number",
-                            "example": 0.25
+                            "examples": [
+                              0.25
+                            ]
                           }
                         }
                       }
@@ -2250,23 +2456,33 @@
                       "properties": {
                         "total_credits": {
                           "type": "number",
-                          "example": 28500
+                          "examples": [
+                            28500
+                          ]
                         },
                         "total_requests": {
                           "type": "integer",
-                          "example": 45000
+                          "examples": [
+                            45000
+                          ]
                         },
                         "chargeable_requests": {
                           "type": "integer",
-                          "example": 38000
+                          "examples": [
+                            38000
+                          ]
                         },
                         "avg_credits_per_request": {
                           "type": "number",
-                          "example": 0.63
+                          "examples": [
+                            0.63
+                          ]
                         },
                         "chargeable_rate": {
                           "type": "number",
-                          "example": 84.4
+                          "examples": [
+                            84.4
+                          ]
                         }
                       }
                     },
@@ -2340,43 +2556,61 @@
                   "properties": {
                     "total_api_requests": {
                       "type": "integer",
-                      "example": 1250000
+                      "examples": [
+                        1250000
+                      ]
                     },
                     "total_credits_consumed": {
                       "type": "number",
-                      "example": 425000.5
+                      "examples": [
+                        425000.5
+                      ]
                     },
                     "unique_products_used": {
                       "type": "integer",
-                      "example": 15
+                      "examples": [
+                        15
+                      ]
                     },
                     "successful_requests": {
                       "type": "integer",
-                      "example": 1150000
+                      "examples": [
+                        1150000
+                      ]
                     },
                     "failed_requests": {
                       "type": "integer",
-                      "example": 100000
+                      "examples": [
+                        100000
+                      ]
                     },
                     "success_rate": {
                       "type": "number",
-                      "example": 92
+                      "examples": [
+                        92
+                      ]
                     },
                     "avg_response_time_ms": {
                       "type": "number",
-                      "example": 245
+                      "examples": [
+                        245
+                      ]
                     },
                     "first_request": {
                       "type": "string",
                       "format": "date-time",
                       "nullable": true,
-                      "example": "2023-06-15T10:30:00.000Z"
+                      "examples": [
+                        "2023-06-15T10:30:00.000Z"
+                      ]
                     },
                     "last_request": {
                       "type": "string",
                       "format": "date-time",
                       "nullable": true,
-                      "example": "2024-02-01T14:22:00.000Z"
+                      "examples": [
+                        "2024-02-01T14:22:00.000Z"
+                      ]
                     }
                   }
                 }
@@ -2512,22 +2746,30 @@
                     "date": {
                       "type": "string",
                       "format": "date",
-                      "example": "2024-02-01"
+                      "examples": [
+                        "2024-02-01"
+                      ]
                     },
                     "summary": {
                       "type": "object",
                       "properties": {
                         "total_credits": {
                           "type": "number",
-                          "example": 875.5
+                          "examples": [
+                            875.5
+                          ]
                         },
                         "total_requests": {
                           "type": "integer",
-                          "example": 1250
+                          "examples": [
+                            1250
+                          ]
                         },
                         "products_count": {
                           "type": "integer",
-                          "example": 8
+                          "examples": [
+                            8
+                          ]
                         }
                       }
                     },
@@ -2538,27 +2780,39 @@
                         "properties": {
                           "product_id": {
                             "type": "string",
-                            "example": "email_validation"
+                            "examples": [
+                              "email_validation"
+                            ]
                           },
                           "requests": {
                             "type": "integer",
-                            "example": 500
+                            "examples": [
+                              500
+                            ]
                           },
                           "credits": {
                             "type": "number",
-                            "example": 25
+                            "examples": [
+                              25
+                            ]
                           },
                           "credits_percentage": {
                             "type": "number",
-                            "example": 2.86
+                            "examples": [
+                              2.86
+                            ]
                           },
                           "avg_credits_per_request": {
                             "type": "number",
-                            "example": 0.25
+                            "examples": [
+                              0.25
+                            ]
                           },
                           "max_credits": {
                             "type": "number",
-                            "example": 0.25
+                            "examples": [
+                              0.25
+                            ]
                           }
                         }
                       }
@@ -2596,7 +2850,9 @@
                     "type": "string",
                     "format": "email",
                     "description": "Email address to validate",
-                    "example": "alex.rivera@example.com"
+                    "examples": [
+                      "alex.rivera@example.com"
+                    ]
                   }
                 },
                 "required": [
@@ -2616,129 +2872,185 @@
                   "properties": {
                     "email": {
                       "type": "string",
-                      "example": "alex.rivera@example.com"
+                      "examples": [
+                        "alex.rivera@example.com"
+                      ]
                     },
                     "email_status": {
                       "type": "string",
-                      "example": "valid"
+                      "examples": [
+                        "valid"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
-                      "example": 0.25
+                      "examples": [
+                        0.25
+                      ]
                     },
                     "message": {
                       "type": "string",
-                      "example": "Email is valid."
+                      "examples": [
+                        "Email is valid."
+                      ]
                     },
                     "mx_record": {
                       "type": "string",
-                      "example": "mx1.example.com"
+                      "examples": [
+                        "mx1.example.com"
+                      ]
                     },
                     "mx_provider": {
                       "type": "string",
-                      "example": "Example Mail"
+                      "examples": [
+                        "Example Mail"
+                      ]
                     },
                     "mx_gateway": {
                       "type": "string",
                       "nullable": true,
                       "description": "Security gateway vendor name",
-                      "example": null
+                      "examples": [
+                        null
+                      ]
                     },
                     "mx_gateway_type": {
                       "type": "string",
                       "nullable": true,
                       "description": "Security gateway type",
-                      "example": null
+                      "examples": [
+                        null
+                      ]
                     },
                     "mx_security_gateway": {
                       "type": "boolean",
-                      "example": false
+                      "examples": [
+                        false
+                      ]
                     },
                     "company_name": {
                       "type": "string",
-                      "example": "Leadmagic"
+                      "examples": [
+                        "Leadmagic"
+                      ]
                     },
                     "company_industry": {
                       "type": "string",
-                      "example": "Internet"
+                      "examples": [
+                        "Internet"
+                      ]
                     },
                     "company_size": {
                       "type": "string",
-                      "example": "11-50"
+                      "examples": [
+                        "11-50"
+                      ]
                     },
                     "company_founded": {
                       "type": "integer",
-                      "example": 2022
+                      "examples": [
+                        2022
+                      ]
                     },
                     "company_type": {
                       "type": "string",
-                      "example": "Private"
+                      "examples": [
+                        "Private"
+                      ]
                     },
                     "company_location": {
                       "type": "object",
                       "properties": {
                         "name": {
                           "type": "string",
-                          "example": "Boston, Massachusetts, United States"
+                          "examples": [
+                            "Boston, Massachusetts, United States"
+                          ]
                         },
                         "locality": {
                           "type": "string",
-                          "example": "Boston"
+                          "examples": [
+                            "Boston"
+                          ]
                         },
                         "region": {
                           "type": "string",
-                          "example": "Massachusetts"
+                          "examples": [
+                            "Massachusetts"
+                          ]
                         },
                         "metro": {
                           "type": "string",
-                          "example": "Boston"
+                          "examples": [
+                            "Boston"
+                          ]
                         },
                         "country": {
                           "type": "string",
-                          "example": "United States"
+                          "examples": [
+                            "United States"
+                          ]
                         },
                         "continent": {
                           "type": "string",
-                          "example": "North America"
+                          "examples": [
+                            "North America"
+                          ]
                         },
                         "street_address": {
                           "type": "string",
-                          "example": "1 Seaport Lane"
+                          "examples": [
+                            "1 Seaport Lane"
+                          ]
                         },
                         "address_line_2": {
                           "type": "string",
                           "nullable": true,
-                          "example": null
+                          "examples": [
+                            null
+                          ]
                         },
                         "postal_code": {
                           "type": "string",
-                          "example": "02210"
+                          "examples": [
+                            "02210"
+                          ]
                         },
                         "geo": {
                           "type": "string",
                           "nullable": true,
-                          "example": null
+                          "examples": [
+                            null
+                          ]
                         }
                       }
                     },
                     "company_linkedin_url": {
                       "type": "string",
                       "description": "Legacy field name for the B2B company profile.",
-                      "example": "example.com/company/acme"
+                      "examples": [
+                        "example.com/company/acme"
+                      ]
                     },
                     "company_linkedin_id": {
                       "type": "string",
-                      "example": "75153174"
+                      "examples": [
+                        "75153174"
+                      ]
                     },
                     "company_facebook_url": {
                       "type": "string",
                       "nullable": true,
-                      "example": null
+                      "examples": [
+                        null
+                      ]
                     },
                     "company_twitter_url": {
                       "type": "string",
                       "nullable": true,
-                      "example": null
+                      "examples": [
+                        null
+                      ]
                     }
                   }
                 }
@@ -2820,48 +3132,70 @@
                   "properties": {
                     "email": {
                       "type": "string",
-                      "example": "alex.rivera@example.com"
+                      "examples": [
+                        "alex.rivera@example.com"
+                      ]
                     },
                     "status": {
                       "type": "string",
-                      "example": "valid"
+                      "examples": [
+                        "valid"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 1
+                      "examples": [
+                        1
+                      ]
                     },
                     "message": {
                       "type": "string",
-                      "example": "Valid email found."
+                      "examples": [
+                        "Valid email found."
+                      ]
                     },
                     "first_name": {
                       "type": "string",
-                      "example": "Alex"
+                      "examples": [
+                        "Alex"
+                      ]
                     },
                     "last_name": {
                       "type": "string",
-                      "example": "Rivera"
+                      "examples": [
+                        "Rivera"
+                      ]
                     },
                     "domain": {
                       "type": "string",
-                      "example": "leadmagic.io"
+                      "examples": [
+                        "leadmagic.io"
+                      ]
                     },
                     "mx_record": {
                       "type": "string",
-                      "example": "alt3.mx1.example.com"
+                      "examples": [
+                        "alt3.mx1.example.com"
+                      ]
                     },
                     "mx_provider": {
                       "type": "string",
-                      "example": "Example Mail"
+                      "examples": [
+                        "Example Mail"
+                      ]
                     },
                     "mx_security_gateway": {
                       "type": "boolean",
-                      "example": false
+                      "examples": [
+                        false
+                      ]
                     },
                     "has_mx": {
                       "type": "boolean",
                       "description": "Whether the domain has MX records",
-                      "example": true
+                      "examples": [
+                        true
+                      ]
                     },
                     "mx_records_full": {
                       "type": "array",
@@ -2871,100 +3205,142 @@
                         "properties": {
                           "priority": {
                             "type": "integer",
-                            "example": 10
+                            "examples": [
+                              10
+                            ]
                           },
                           "exchange": {
                             "type": "string",
-                            "example": "mx1.example.com"
+                            "examples": [
+                              "mx1.example.com"
+                            ]
                           }
                         }
                       }
                     },
                     "company_name": {
                       "type": "string",
-                      "example": "Leadmagic"
+                      "examples": [
+                        "Leadmagic"
+                      ]
                     },
                     "company_industry": {
                       "type": "string",
-                      "example": ""
+                      "examples": [
+                        ""
+                      ]
                     },
                     "company_size": {
                       "type": "string",
-                      "example": "11-50"
+                      "examples": [
+                        "11-50"
+                      ]
                     },
                     "company_founded": {
                       "type": "integer",
-                      "example": 2022
+                      "examples": [
+                        2022
+                      ]
                     },
                     "company_location": {
                       "type": "object",
                       "properties": {
                         "name": {
                           "type": "string",
-                          "example": "boston, massachusetts, united states"
+                          "examples": [
+                            "boston, massachusetts, united states"
+                          ]
                         },
                         "locality": {
                           "type": "string",
-                          "example": "boston"
+                          "examples": [
+                            "boston"
+                          ]
                         },
                         "region": {
                           "type": "string",
-                          "example": "massachusetts"
+                          "examples": [
+                            "massachusetts"
+                          ]
                         },
                         "metro": {
                           "type": "string",
-                          "example": "boston, massachusetts"
+                          "examples": [
+                            "boston, massachusetts"
+                          ]
                         },
                         "country": {
                           "type": "string",
-                          "example": "united states"
+                          "examples": [
+                            "united states"
+                          ]
                         },
                         "continent": {
                           "type": "string",
-                          "example": "north america"
+                          "examples": [
+                            "north america"
+                          ]
                         },
                         "street_address": {
                           "type": "string",
-                          "example": "1 seaport lane"
+                          "examples": [
+                            "1 seaport lane"
+                          ]
                         },
                         "address_line_2": {
                           "type": "string"
                         },
                         "postal_code": {
                           "type": "string",
-                          "example": "02210"
+                          "examples": [
+                            "02210"
+                          ]
                         },
                         "geo": {
                           "type": "string",
-                          "example": "42.35,-71.06"
+                          "examples": [
+                            "42.35,-71.06"
+                          ]
                         }
                       }
                     },
                     "company_profile_url": {
                       "type": "string",
-                      "example": "leadmagichq"
+                      "examples": [
+                        "leadmagichq"
+                      ]
                     },
                     "company_profile_id": {
                       "type": "string",
-                      "example": "75153174"
+                      "examples": [
+                        "75153174"
+                      ]
                     },
                     "company_facebook_url": {
                       "type": "string",
-                      "example": ""
+                      "examples": [
+                        ""
+                      ]
                     },
                     "company_twitter_url": {
                       "type": "string",
-                      "example": ""
+                      "examples": [
+                        ""
+                      ]
                     },
                     "company_type": {
                       "type": "string",
-                      "example": "private"
+                      "examples": [
+                        "private"
+                      ]
                     },
                     "employment_verified": {
                       "type": "boolean",
                       "nullable": true,
                       "description": "Whether the employment at the domain was verified",
-                      "example": true
+                      "examples": [
+                        true
+                      ]
                     }
                   }
                 }
@@ -3027,31 +3403,43 @@
                   "properties": {
                     "profile_url": {
                       "type": "string",
-                      "example": "alex-rivera"
+                      "examples": [
+                        "alex-rivera"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 2
+                      "examples": [
+                        2
+                      ]
                     },
                     "message": {
                       "type": "string",
-                      "example": "Personal Email Found."
+                      "examples": [
+                        "Personal Email Found."
+                      ]
                     },
                     "name": {
                       "type": "string",
-                      "example": "Alex Rivera"
+                      "examples": [
+                        "Alex Rivera"
+                      ]
                     },
                     "first_personal_email": {
                       "type": "string",
-                      "example": "alex-riveral@gmail.com"
+                      "examples": [
+                        "alex-riveral@gmail.com"
+                      ]
                     },
                     "personal_emails": {
                       "type": "array",
                       "items": {
                         "type": "string"
                       },
-                      "example": [
-                        "alex-riveral@gmail.com"
+                      "examples": [
+                        [
+                          "alex-riveral@gmail.com"
+                        ]
                       ]
                     }
                   }
@@ -3118,19 +3506,27 @@
                   "properties": {
                     "profile_url": {
                       "type": "string",
-                      "example": "alex-rivera"
+                      "examples": [
+                        "alex-rivera"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 5
+                      "examples": [
+                        5
+                      ]
                     },
                     "message": {
                       "type": "string",
-                      "example": "Email Found."
+                      "examples": [
+                        "Email Found."
+                      ]
                     },
                     "email": {
                       "type": "string",
-                      "example": "alex.rivera@example.com"
+                      "examples": [
+                        "alex.rivera@example.com"
+                      ]
                     }
                   }
                 }
@@ -3176,7 +3572,9 @@
                   "profile_url": {
                     "type": "string",
                     "description": "B2B person profile URL or slug",
-                    "example": "alex-rivera"
+                    "examples": [
+                      "alex-rivera"
+                    ]
                   }
                 },
                 "required": [
@@ -3196,72 +3594,100 @@
                   "properties": {
                     "profile_url": {
                       "type": "string",
-                      "example": "alex-rivera"
+                      "examples": [
+                        "alex-rivera"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 1
+                      "examples": [
+                        1
+                      ]
                     },
                     "first_name": {
                       "type": "string",
                       "nullable": true,
-                      "example": "Alex"
+                      "examples": [
+                        "Alex"
+                      ]
                     },
                     "last_name": {
                       "type": "string",
                       "nullable": true,
-                      "example": "Rivera"
+                      "examples": [
+                        "Rivera"
+                      ]
                     },
                     "full_name": {
                       "type": "string",
                       "nullable": true,
-                      "example": "Alex Rivera"
+                      "examples": [
+                        "Alex Rivera"
+                      ]
                     },
                     "professional_title": {
                       "type": "string",
                       "nullable": true,
-                      "example": "Growth & AI Expert | Founder LeadMagic"
+                      "examples": [
+                        "Growth & AI Expert | Founder LeadMagic"
+                      ]
                     },
                     "bio": {
                       "type": "string",
                       "nullable": true,
-                      "example": "SaaS Founder"
+                      "examples": [
+                        "SaaS Founder"
+                      ]
                     },
                     "company_name": {
                       "type": "string",
                       "nullable": true,
-                      "example": "LeadMagic"
+                      "examples": [
+                        "LeadMagic"
+                      ]
                     },
                     "company_industry": {
                       "type": "string",
                       "nullable": true,
-                      "example": "Internet"
+                      "examples": [
+                        "Internet"
+                      ]
                     },
                     "company_website": {
                       "type": "string",
                       "nullable": true,
-                      "example": "leadmagic.io"
+                      "examples": [
+                        "leadmagic.io"
+                      ]
                     },
                     "total_tenure_months": {
                       "type": "string",
                       "nullable": true,
-                      "example": "205"
+                      "examples": [
+                        "205"
+                      ]
                     },
                     "total_tenure_days": {
                       "type": "string",
                       "nullable": true,
-                      "example": "6240"
+                      "examples": [
+                        "6240"
+                      ]
                     },
                     "total_tenure_years": {
                       "type": "string",
                       "nullable": true,
-                      "example": "17"
+                      "examples": [
+                        "17"
+                      ]
                     },
                     "followers_range": {
                       "type": "string",
                       "nullable": true,
-                      "example": "45K-50K",
-                      "description": "Follower count range for privacy (e.g. \"45K-50K\", \"1M+\")"
+                      "description": "Follower count range for privacy (e.g. \"45K-50K\", \"1M+\")",
+                      "examples": [
+                        "45K-50K"
+                      ]
                     },
                     "personal_website": {
                       "type": "object",
@@ -3269,23 +3695,31 @@
                       "properties": {
                         "name": {
                           "type": "string",
-                          "example": "https://leadmagic.io"
+                          "examples": [
+                            "https://leadmagic.io"
+                          ]
                         },
                         "link": {
                           "type": "string",
-                          "example": "https://leadmagic.io"
+                          "examples": [
+                            "https://leadmagic.io"
+                          ]
                         }
                       }
                     },
                     "country": {
                       "type": "string",
                       "nullable": true,
-                      "example": "United States"
+                      "examples": [
+                        "United States"
+                      ]
                     },
                     "location": {
                       "type": "string",
                       "nullable": true,
-                      "example": "Greater Boston"
+                      "examples": [
+                        "Greater Boston"
+                      ]
                     },
                     "work_experience": {
                       "type": "array",
@@ -3295,27 +3729,37 @@
                         "properties": {
                           "position_title": {
                             "type": "string",
-                            "example": "Founder"
+                            "examples": [
+                              "Founder"
+                            ]
                           },
                           "company_name": {
                             "type": "string",
-                            "example": "LeadMagic"
+                            "examples": [
+                              "LeadMagic"
+                            ]
                           },
                           "employment_period": {
                             "type": "string",
-                            "example": "Sep 2022 - Present · 3 yrs 2 mos"
+                            "examples": [
+                              "Sep 2022 - Present · 3 yrs 2 mos"
+                            ]
                           },
                           "company_website": {
                             "type": "string",
                             "nullable": true,
-                            "example": "leadmagic.io",
-                            "description": "Only included when domain is available"
+                            "description": "Only included when domain is available",
+                            "examples": [
+                              "leadmagic.io"
+                            ]
                           },
                           "company_logo_url": {
                             "type": "string",
                             "nullable": true,
-                            "example": "https://logo.leadmagic.io/leadmagic.io",
-                            "description": "Only included when domain is available"
+                            "description": "Only included when domain is available",
+                            "examples": [
+                              "https://logo.leadmagic.io/leadmagic.io"
+                            ]
                           }
                         }
                       }
@@ -3328,15 +3772,21 @@
                         "properties": {
                           "institution_name": {
                             "type": "string",
-                            "example": "University of Maine"
+                            "examples": [
+                              "University of Maine"
+                            ]
                           },
                           "degree": {
                             "type": "string",
-                            "example": "University of Maine"
+                            "examples": [
+                              "University of Maine"
+                            ]
                           },
                           "attendance_period": {
                             "type": "string",
-                            "example": ""
+                            "examples": [
+                              ""
+                            ]
                           }
                         }
                       }
@@ -3349,15 +3799,21 @@
                         "properties": {
                           "certification_name": {
                             "type": "string",
-                            "example": "Revenue Architect"
+                            "examples": [
+                              "Revenue Architect"
+                            ]
                           },
                           "issuing_organization": {
                             "type": "string",
-                            "example": "Winning by Design"
+                            "examples": [
+                              "Winning by Design"
+                            ]
                           },
                           "issue_date": {
                             "type": "string",
-                            "example": "Issued Nov 2020"
+                            "examples": [
+                              "Issued Nov 2020"
+                            ]
                           }
                         }
                       }
@@ -3370,11 +3826,15 @@
                         "properties": {
                           "title": {
                             "type": "string",
-                            "example": "Hortonworks - MVP NorthEast - Region - 2016"
+                            "examples": [
+                              "Hortonworks - MVP NorthEast - Region - 2016"
+                            ]
                           },
                           "description": {
                             "type": "string",
-                            "example": "Issued by Hortonworks · Jan 2016"
+                            "examples": [
+                              "Issued by Hortonworks · Jan 2016"
+                            ]
                           }
                         }
                       }
@@ -3445,15 +3905,21 @@
                   "properties": {
                     "profile_url": {
                       "type": "string",
-                      "example": "jouellette"
+                      "examples": [
+                        "jouellette"
+                      ]
                     },
                     "message": {
                       "type": "string",
-                      "example": "Profile URL found"
+                      "examples": [
+                        "Profile URL found"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 10
+                      "examples": [
+                        10
+                      ]
                     }
                   }
                 }
@@ -3527,28 +3993,38 @@
                     "profile_url": {
                       "type": "string",
                       "nullable": true,
-                      "example": "alex-rivera"
+                      "examples": [
+                        "alex-rivera"
+                      ]
                     },
                     "email": {
                       "type": "string",
                       "nullable": true,
                       "description": "Email address used in lookup (if provided)",
-                      "example": "alex.rivera@example.com"
+                      "examples": [
+                        "alex.rivera@example.com"
+                      ]
                     },
                     "mobile_number": {
                       "type": "string",
                       "nullable": true,
                       "description": "Mobile phone number if found",
-                      "example": "12077523358"
+                      "examples": [
+                        "12077523358"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
-                      "example": 5
+                      "examples": [
+                        5
+                      ]
                     },
                     "message": {
                       "type": "string",
                       "description": "Status message about the result",
-                      "example": "Mobile number found."
+                      "examples": [
+                        "Mobile number found."
+                      ]
                     }
                   }
                 }
@@ -3591,17 +4067,23 @@
                   "profile_url": {
                     "type": "string",
                     "description": "Professional profile URL or identifier",
-                    "example": "alex-rivera"
+                    "examples": [
+                      "alex-rivera"
+                    ]
                   },
                   "company_name": {
                     "type": "string",
                     "description": "Expected company name (either company_name or company_domain is required)",
-                    "example": "Example Robotics"
+                    "examples": [
+                      "Example Robotics"
+                    ]
                   },
                   "company_domain": {
                     "type": "string",
                     "description": "Expected company domain (either company_name or company_domain is required)",
-                    "example": "smartlead.ai"
+                    "examples": [
+                      "smartlead.ai"
+                    ]
                   }
                 },
                 "required": [
@@ -3621,7 +4103,9 @@
                   "properties": {
                     "job_change_detected": {
                       "type": "boolean",
-                      "example": false
+                      "examples": [
+                        false
+                      ]
                     },
                     "status": {
                       "type": "string",
@@ -3630,50 +4114,72 @@
                         "JOB_CHANGE_DETECTED",
                         "NEVER_WORKED_THERE"
                       ],
-                      "example": "NEVER_WORKED_THERE"
+                      "examples": [
+                        "NEVER_WORKED_THERE"
+                      ]
                     },
                     "summary": {
                       "type": "string",
-                      "example": "Alex Rivera has never worked at Example Robotics according to their comprehensive employment history. They are currently working at Leadmagic as Founder for 3 years. Their complete employment history shows experience at Leadmagic, Atlas Guild, Northstar Labs, and 7 other companies. The expected company does not appear in any current or past positions, confirming they have never been employed there."
+                      "examples": [
+                        "Alex Rivera has never worked at Example Robotics according to their comprehensive employment history. They are currently working at Leadmagic as Founder for 3 years. Their complete employment history shows experience at Leadmagic, Atlas Guild, Northstar Labs, and 7 other companies. The expected company does not appear in any current or past positions, confirming they have never been employed there."
+                      ]
                     },
                     "employee_name": {
                       "type": "string",
-                      "example": "Alex Rivera"
+                      "examples": [
+                        "Alex Rivera"
+                      ]
                     },
                     "expected_company": {
                       "type": "string",
-                      "example": "Example Robotics"
+                      "examples": [
+                        "Example Robotics"
+                      ]
                     },
                     "current_company": {
                       "type": "string",
-                      "example": "Leadmagic"
+                      "examples": [
+                        "Leadmagic"
+                      ]
                     },
                     "current_position": {
                       "type": "object",
                       "properties": {
                         "title": {
                           "type": "string",
-                          "example": "Founder"
+                          "examples": [
+                            "Founder"
+                          ]
                         },
                         "company": {
                           "type": "string",
-                          "example": "Leadmagic"
+                          "examples": [
+                            "Leadmagic"
+                          ]
                         },
                         "start_date": {
                           "type": "string",
-                          "example": "Sep 2022"
+                          "examples": [
+                            "Sep 2022"
+                          ]
                         },
                         "days_at_job": {
                           "type": "integer",
-                          "example": 1111
+                          "examples": [
+                            1111
+                          ]
                         },
                         "tenure_formatted": {
                           "type": "string",
-                          "example": "3 years"
+                          "examples": [
+                            "3 years"
+                          ]
                         },
                         "is_current_position": {
                           "type": "boolean",
-                          "example": true
+                          "examples": [
+                            true
+                          ]
                         }
                       }
                     },
@@ -3682,31 +4188,45 @@
                       "properties": {
                         "average_tenure_months": {
                           "type": "integer",
-                          "example": 26
+                          "examples": [
+                            26
+                          ]
                         },
                         "average_tenure_formatted": {
                           "type": "string",
-                          "example": "2 years 2 months"
+                          "examples": [
+                            "2 years 2 months"
+                          ]
                         },
                         "total_positions": {
                           "type": "integer",
-                          "example": 10
+                          "examples": [
+                            10
+                          ]
                         },
                         "longest_tenure_months": {
                           "type": "integer",
-                          "example": 73
+                          "examples": [
+                            73
+                          ]
                         },
                         "longest_tenure_formatted": {
                           "type": "string",
-                          "example": "6 years 1 month"
+                          "examples": [
+                            "6 years 1 month"
+                          ]
                         },
                         "shortest_tenure_months": {
                           "type": "integer",
-                          "example": 1
+                          "examples": [
+                            1
+                          ]
                         },
                         "shortest_tenure_formatted": {
                           "type": "string",
-                          "example": "1 month"
+                          "examples": [
+                            "1 month"
+                          ]
                         }
                       }
                     },
@@ -3717,66 +4237,82 @@
                         "properties": {
                           "title": {
                             "type": "string",
-                            "example": "Founder"
+                            "examples": [
+                              "Founder"
+                            ]
                           },
                           "company": {
                             "type": "string",
-                            "example": "LeadMagic"
+                            "examples": [
+                              "LeadMagic"
+                            ]
                           },
                           "duration": {
                             "type": "string",
-                            "example": "Sep 2022 - Present"
+                            "examples": [
+                              "Sep 2022 - Present"
+                            ]
                           },
                           "is_present": {
                             "type": "boolean",
-                            "example": true
+                            "examples": [
+                              true
+                            ]
                           }
                         }
                       },
-                      "example": [
-                        {
-                          "title": "Founder",
-                          "company": "Leadmagic",
-                          "duration": "Sep 2022 - Present",
-                          "is_present": true
-                        },
-                        {
-                          "title": "Executive Member",
-                          "company": "Atlas Guild",
-                          "duration": "Aug 2019 - Present",
-                          "is_present": true
-                        },
-                        {
-                          "title": "Advisor",
-                          "company": "Northstar Labs",
-                          "duration": "Feb 2023 - Jan 2024",
-                          "is_present": false
-                        },
-                        {
-                          "title": "Advisor",
-                          "company": "Sales Community",
-                          "duration": "May 2020 - Dec 2023",
-                          "is_present": false
-                        },
-                        {
-                          "title": "Advisor",
-                          "company": "Astronomer",
-                          "duration": "Jul 2020 - Sep 2023",
-                          "is_present": false
-                        }
+                      "examples": [
+                        [
+                          {
+                            "title": "Founder",
+                            "company": "Leadmagic",
+                            "duration": "Sep 2022 - Present",
+                            "is_present": true
+                          },
+                          {
+                            "title": "Executive Member",
+                            "company": "Atlas Guild",
+                            "duration": "Aug 2019 - Present",
+                            "is_present": true
+                          },
+                          {
+                            "title": "Advisor",
+                            "company": "Northstar Labs",
+                            "duration": "Feb 2023 - Jan 2024",
+                            "is_present": false
+                          },
+                          {
+                            "title": "Advisor",
+                            "company": "Sales Community",
+                            "duration": "May 2020 - Dec 2023",
+                            "is_present": false
+                          },
+                          {
+                            "title": "Advisor",
+                            "company": "Astronomer",
+                            "duration": "Jul 2020 - Sep 2023",
+                            "is_present": false
+                          }
+                        ]
                       ]
                     },
                     "profile_found": {
                       "type": "boolean",
-                      "example": true
+                      "examples": [
+                        true
+                      ]
                     },
                     "profile_url": {
                       "type": "string",
-                      "example": "alex-rivera"
+                      "examples": [
+                        "alex-rivera"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 2
+                      "examples": [
+                        2
+                      ]
                     }
                   }
                 }
@@ -3850,20 +4386,28 @@
                     "message": {
                       "type": "string",
                       "description": "Status message",
-                      "example": "Company found"
+                      "examples": [
+                        "Company found"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
                       "description": "Number of credits consumed for this request",
-                      "example": 1
+                      "examples": [
+                        1
+                      ]
                     },
                     "companyName": {
                       "type": "string",
-                      "example": "LeadMagic"
+                      "examples": [
+                        "LeadMagic"
+                      ]
                     },
                     "companyId": {
                       "type": "integer",
-                      "example": 75153174
+                      "examples": [
+                        75153174
+                      ]
                     },
                     "locations": {
                       "type": "array",
@@ -3872,66 +4416,92 @@
                         "properties": {
                           "country": {
                             "type": "string",
-                            "example": "US"
+                            "examples": [
+                              "US"
+                            ]
                           },
                           "city": {
                             "type": "string",
-                            "example": "Boston"
+                            "examples": [
+                              "Boston"
+                            ]
                           },
                           "geographicArea": {
                             "type": "string",
-                            "example": "Massachusetts"
+                            "examples": [
+                              "Massachusetts"
+                            ]
                           },
                           "postalCode": {
                             "type": "string",
-                            "example": "02210"
+                            "examples": [
+                              "02210"
+                            ]
                           },
                           "line1": {
                             "type": "string",
-                            "example": "1 Seaport Ln"
+                            "examples": [
+                              "1 Seaport Ln"
+                            ]
                           },
                           "line2": {
                             "type": "string",
                             "nullable": true,
-                            "example": null
+                            "examples": [
+                              null
+                            ]
                           },
                           "description": {
                             "type": "string",
-                            "example": "Headquarters"
+                            "examples": [
+                              "Headquarters"
+                            ]
                           },
                           "headquarter": {
                             "type": "boolean",
-                            "example": true
+                            "examples": [
+                              true
+                            ]
                           },
                           "localizedName": {
                             "type": "string",
-                            "example": "Boston"
+                            "examples": [
+                              "Boston"
+                            ]
                           },
                           "latitude": {
                             "type": "number",
-                            "example": 42.36041
+                            "examples": [
+                              42.36041
+                            ]
                           },
                           "longitude": {
                             "type": "number",
-                            "example": -71.05798
+                            "examples": [
+                              -71.05798
+                            ]
                           }
                         }
                       }
                     },
                     "employeeCount": {
                       "type": "integer",
-                      "example": 9
+                      "examples": [
+                        9
+                      ]
                     },
                     "specialities": {
                       "type": "array",
                       "items": {
                         "type": "string"
                       },
-                      "example": [
-                        "Sales",
-                        "Marketing",
-                        "ABM",
-                        "RevOps"
+                      "examples": [
+                        [
+                          "Sales",
+                          "Marketing",
+                          "ABM",
+                          "RevOps"
+                        ]
                       ]
                     },
                     "employeeCountRange": {
@@ -3939,65 +4509,93 @@
                       "properties": {
                         "start": {
                           "type": "integer",
-                          "example": 11
+                          "examples": [
+                            11
+                          ]
                         },
                         "end": {
                           "type": "integer",
-                          "example": 50
+                          "examples": [
+                            50
+                          ]
                         }
                       }
                     },
                     "tagline": {
                       "type": "string",
-                      "example": "Example Robotics provides enterprise software solutions for B2B companies. Their platform helps teams streamline operations and drive growth."
+                      "examples": [
+                        "Example Robotics provides enterprise software solutions for B2B companies. Their platform helps teams streamline operations and drive growth."
+                      ]
                     },
                     "followerCount": {
                       "type": "integer",
-                      "example": 4663
+                      "examples": [
+                        4663
+                      ]
                     },
                     "industry": {
                       "type": "string",
-                      "example": "Internet"
+                      "examples": [
+                        "Internet"
+                      ]
                     },
                     "description": {
                       "type": "string",
-                      "example": "LeadMagic tells you exactly what businesses are on your website and helps you enrich your contact and company data."
+                      "examples": [
+                        "LeadMagic tells you exactly what businesses are on your website and helps you enrich your contact and company data."
+                      ]
                     },
                     "websiteUrl": {
                       "type": "string",
-                      "example": "https://leadmagic.io"
+                      "examples": [
+                        "https://leadmagic.io"
+                      ]
                     },
                     "headquarter": {
                       "type": "object",
                       "properties": {
                         "country": {
                           "type": "string",
-                          "example": "US"
+                          "examples": [
+                            "US"
+                          ]
                         },
                         "city": {
                           "type": "string",
-                          "example": "Boston"
+                          "examples": [
+                            "Boston"
+                          ]
                         },
                         "geographicArea": {
                           "type": "string",
-                          "example": "Massachusetts"
+                          "examples": [
+                            "Massachusetts"
+                          ]
                         },
                         "postalCode": {
                           "type": "string",
-                          "example": "02210"
+                          "examples": [
+                            "02210"
+                          ]
                         },
                         "line1": {
                           "type": "string",
-                          "example": "1 Seaport Ln"
+                          "examples": [
+                            "1 Seaport Ln"
+                          ]
                         },
                         "line2": {
                           "type": "string",
                           "nullable": true,
-                          "example": null
+                          "examples": [
+                            null
+                          ]
                         },
                         "description": {
                           "type": "string",
-                          "example": "Headquarters"
+                          "examples": [
+                            "Headquarters"
+                          ]
                         }
                       }
                     },
@@ -4007,96 +4605,130 @@
                         "month": {
                           "type": "integer",
                           "nullable": true,
-                          "example": null
+                          "examples": [
+                            null
+                          ]
                         },
                         "year": {
                           "type": "integer",
-                          "example": 2022
+                          "examples": [
+                            2022
+                          ]
                         },
                         "day": {
                           "type": "integer",
                           "nullable": true,
-                          "example": null
+                          "examples": [
+                            null
+                          ]
                         }
                       }
                     },
                     "universalName": {
                       "type": "string",
-                      "example": "leadmagichq"
+                      "examples": [
+                        "leadmagichq"
+                      ]
                     },
                     "hashtag": {
                       "type": "string",
-                      "example": "#abm"
+                      "examples": [
+                        "#abm"
+                      ]
                     },
                     "url": {
                       "type": "string",
-                      "example": "leadmagichq"
+                      "examples": [
+                        "leadmagichq"
+                      ]
                     },
                     "logo_url": {
                       "type": "string",
                       "nullable": true,
                       "description": "Company logo URL from logo.leadmagic.io (generated from company domain)",
-                      "example": "https://logo.leadmagic.io/leadmagic.io"
+                      "examples": [
+                        "https://logo.leadmagic.io/leadmagic.io"
+                      ]
                     },
                     "founded_year": {
                       "type": "string",
                       "nullable": true,
                       "description": "Year the company was founded",
-                      "example": "2009"
+                      "examples": [
+                        "2009"
+                      ]
                     },
                     "ownership_status": {
                       "type": "string",
                       "nullable": true,
                       "description": "Ownership type (Public, Private, or Acquired)",
-                      "example": "Private"
+                      "examples": [
+                        "Private"
+                      ]
                     },
                     "revenue": {
                       "type": "number",
                       "nullable": true,
                       "description": "Estimated annual revenue",
-                      "example": 5100000000
+                      "examples": [
+                        5100000000
+                      ]
                     },
                     "revenue_formatted": {
                       "type": "string",
                       "nullable": true,
                       "description": "Human-readable revenue format",
-                      "example": "5.1B"
+                      "examples": [
+                        "5.1B"
+                      ]
                     },
                     "employee_range": {
                       "type": "string",
                       "nullable": true,
                       "description": "Employee count range",
-                      "example": "5,000 - 10,000"
+                      "examples": [
+                        "5,000 - 10,000"
+                      ]
                     },
                     "total_funding": {
                       "type": "string",
                       "nullable": true,
                       "description": "Total funding raised",
-                      "example": "9.8B"
+                      "examples": [
+                        "9.8B"
+                      ]
                     },
                     "funding_rounds": {
                       "type": "integer",
                       "nullable": true,
                       "description": "Number of funding rounds completed",
-                      "example": 5
+                      "examples": [
+                        5
+                      ]
                     },
                     "last_funding_round": {
                       "type": "string",
                       "nullable": true,
                       "description": "Type of most recent funding round",
-                      "example": "Equity"
+                      "examples": [
+                        "Equity"
+                      ]
                     },
                     "last_funding_amount": {
                       "type": "number",
                       "nullable": true,
                       "description": "Amount raised in most recent funding round",
-                      "example": 694159778
+                      "examples": [
+                        694159778
+                      ]
                     },
                     "last_funding_date": {
                       "type": "string",
                       "nullable": true,
                       "description": "Date of most recent funding round",
-                      "example": "Apr 2024"
+                      "examples": [
+                        "Apr 2024"
+                      ]
                     },
                     "competitors": {
                       "type": "array",
@@ -4105,43 +4737,55 @@
                       "items": {
                         "type": "string"
                       },
-                      "example": [
-                        "Rapyd",
-                        "Square",
-                        "PayPal",
-                        "Clover",
-                        "Payment Depot"
+                      "examples": [
+                        [
+                          "Rapyd",
+                          "Square",
+                          "PayPal",
+                          "Clover",
+                          "Payment Depot"
+                        ]
                       ]
                     },
                     "acquisitions_count": {
                       "type": "integer",
                       "nullable": true,
                       "description": "Number of acquisitions made by the company",
-                      "example": 3
+                      "examples": [
+                        3
+                      ]
                     },
                     "twitter_url": {
                       "type": "string",
                       "nullable": true,
                       "description": "Twitter/X profile URL",
-                      "example": "https://twitter.com/leadmagichq"
+                      "examples": [
+                        "https://twitter.com/leadmagichq"
+                      ]
                     },
                     "b2b_profile_url": {
                       "type": "string",
                       "nullable": true,
                       "description": "B2B company profile URL",
-                      "example": "leadmagichq"
+                      "examples": [
+                        "leadmagichq"
+                      ]
                     },
                     "facebook_url": {
                       "type": "string",
                       "nullable": true,
                       "description": "Facebook page URL",
-                      "example": ""
+                      "examples": [
+                        ""
+                      ]
                     },
                     "stock_ticker": {
                       "type": "string",
                       "nullable": true,
                       "description": "Stock ticker symbol (if publicly traded)",
-                      "example": "STRP"
+                      "examples": [
+                        "STRP"
+                      ]
                     }
                   }
                 }
@@ -4212,60 +4856,86 @@
                       "properties": {
                         "companyName": {
                           "type": "string",
-                          "example": "LeadMagic Inc"
+                          "examples": [
+                            "LeadMagic Inc"
+                          ]
                         },
                         "description": {
                           "type": "string",
-                          "example": "Example Robotics provides enterprise software solutions for B2B companies."
+                          "examples": [
+                            "Example Robotics provides enterprise software solutions for B2B companies."
+                          ]
                         },
                         "shortName": {
                           "type": "string",
-                          "example": "LeadMagic"
+                          "examples": [
+                            "LeadMagic"
+                          ]
                         },
                         "founded": {
                           "type": "string",
-                          "example": "2015"
+                          "examples": [
+                            "2015"
+                          ]
                         },
                         "headquarters": {
                           "type": "object",
                           "properties": {
                             "city": {
                               "type": "string",
-                              "example": "Palo Alto"
+                              "examples": [
+                                "Palo Alto"
+                              ]
                             },
                             "state": {
                               "type": "string",
-                              "example": "California"
+                              "examples": [
+                                "California"
+                              ]
                             },
                             "country": {
                               "type": "string",
-                              "example": "USA"
+                              "examples": [
+                                "USA"
+                              ]
                             },
                             "fullAddress": {
                               "type": "string",
-                              "example": "Palo Alto, California, USA"
+                              "examples": [
+                                "Palo Alto, California, USA"
+                              ]
                             }
                           }
                         },
                         "primaryDomain": {
                           "type": "string",
-                          "example": "leadmagic.io"
+                          "examples": [
+                            "leadmagic.io"
+                          ]
                         },
                         "phone": {
                           "type": "string",
-                          "example": "1-650-276-3068"
+                          "examples": [
+                            "1-650-276-3068"
+                          ]
                         },
                         "status": {
                           "type": "string",
-                          "example": "NEW"
+                          "examples": [
+                            "NEW"
+                          ]
                         },
                         "followers": {
                           "type": "integer",
-                          "example": 2422
+                          "examples": [
+                            2422
+                          ]
                         },
                         "ownership": {
                           "type": "string",
-                          "example": "Private"
+                          "examples": [
+                            "Private"
+                          ]
                         }
                       }
                     },
@@ -4274,35 +4944,49 @@
                       "properties": {
                         "revenue": {
                           "type": "integer",
-                          "example": 178000000
+                          "examples": [
+                            178000000
+                          ]
                         },
                         "formattedRevenue": {
                           "type": "string",
-                          "example": "178M"
+                          "examples": [
+                            "178M"
+                          ]
                         },
                         "totalFunding": {
                           "type": "integer",
-                          "example": 584000000
+                          "examples": [
+                            584000000
+                          ]
                         },
                         "formattedFunding": {
                           "type": "string",
-                          "example": "584M"
+                          "examples": [
+                            "584M"
+                          ]
                         },
                         "lastFundingRound": {
                           "type": "object",
                           "properties": {
                             "round": {
                               "type": "string",
-                              "example": "Series E"
+                              "examples": [
+                                "Series E"
+                              ]
                             },
                             "date": {
                               "type": "string",
                               "format": "date-time",
-                              "example": "2021-05-01T00:00:00.000Z"
+                              "examples": [
+                                "2021-05-01T00:00:00.000Z"
+                              ]
                             },
                             "amount": {
                               "type": "integer",
-                              "example": 250000000
+                              "examples": [
+                                250000000
+                              ]
                             }
                           }
                         }
@@ -4315,73 +4999,83 @@
                         "properties": {
                           "round": {
                             "type": "string",
-                            "example": "Series E"
+                            "examples": [
+                              "Series E"
+                            ]
                           },
                           "date": {
                             "type": "string",
                             "format": "date-time",
-                            "example": "2021-05-01T00:00:00.000Z"
+                            "examples": [
+                              "2021-05-01T00:00:00.000Z"
+                            ]
                           },
                           "amount": {
                             "type": "string",
-                            "example": "$250,000,000"
+                            "examples": [
+                              "$250,000,000"
+                            ]
                           },
                           "investors": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "example": [
+                            "examples": [
+                              [
+                                "Franklin Templeton",
+                                "Coatue",
+                                "Sequoia",
+                                "Thrive Capital",
+                                "Tiger Global"
+                              ]
+                            ]
+                          }
+                        }
+                      },
+                      "examples": [
+                        [
+                          {
+                            "round": "Series E",
+                            "date": "2021-05-01T00:00:00.000Z",
+                            "amount": "$250,000,000",
+                            "investors": [
                               "Franklin Templeton",
                               "Coatue",
                               "Sequoia",
                               "Thrive Capital",
                               "Tiger Global"
                             ]
+                          },
+                          {
+                            "round": "Series D",
+                            "date": "2020-08-01T00:00:00.000Z",
+                            "amount": "$200,000,000",
+                            "investors": [
+                              "Coatue",
+                              "Index Ventures",
+                              "Thrive Capital",
+                              "Battery Ventures",
+                              "NextWorld Capital",
+                              "Norwest Venture Partners",
+                              "Sequoia Capital",
+                              "Wing Venture Capital"
+                            ]
+                          },
+                          {
+                            "round": "Series C",
+                            "date": "2019-12-01T00:00:00.000Z",
+                            "amount": "$65,000,000",
+                            "investors": [
+                              "Sequoia Capital",
+                              "Battery Ventures",
+                              "Norwest Venture Partners",
+                              "Wing Venture Capital",
+                              "NextWorld Capital",
+                              "Cisco Investments"
+                            ]
                           }
-                        }
-                      },
-                      "example": [
-                        {
-                          "round": "Series E",
-                          "date": "2021-05-01T00:00:00.000Z",
-                          "amount": "$250,000,000",
-                          "investors": [
-                            "Franklin Templeton",
-                            "Coatue",
-                            "Sequoia",
-                            "Thrive Capital",
-                            "Tiger Global"
-                          ]
-                        },
-                        {
-                          "round": "Series D",
-                          "date": "2020-08-01T00:00:00.000Z",
-                          "amount": "$200,000,000",
-                          "investors": [
-                            "Coatue",
-                            "Index Ventures",
-                            "Thrive Capital",
-                            "Battery Ventures",
-                            "NextWorld Capital",
-                            "Norwest Venture Partners",
-                            "Sequoia Capital",
-                            "Wing Venture Capital"
-                          ]
-                        },
-                        {
-                          "round": "Series C",
-                          "date": "2019-12-01T00:00:00.000Z",
-                          "amount": "$65,000,000",
-                          "investors": [
-                            "Sequoia Capital",
-                            "Battery Ventures",
-                            "Norwest Venture Partners",
-                            "Wing Venture Capital",
-                            "NextWorld Capital",
-                            "Cisco Investments"
-                          ]
-                        }
+                        ]
                       ]
                     },
                     "companySize": {
@@ -4389,15 +5083,21 @@
                       "properties": {
                         "employees": {
                           "type": "integer",
-                          "example": 1100
+                          "examples": [
+                            1100
+                          ]
                         },
                         "employeeRange": {
                           "type": "string",
-                          "example": "1,000 - 5,000"
+                          "examples": [
+                            "1,000 - 5,000"
+                          ]
                         },
                         "employeeGrowth": {
                           "type": "string",
-                          "example": "N/A"
+                          "examples": [
+                            "N/A"
+                          ]
                         }
                       }
                     },
@@ -4409,23 +5109,33 @@
                           "properties": {
                             "firstName": {
                               "type": "string",
-                              "example": "Amit"
+                              "examples": [
+                                "Amit"
+                              ]
                             },
                             "lastName": {
                               "type": "string",
-                              "example": "Bendov"
+                              "examples": [
+                                "Bendov"
+                              ]
                             },
                             "designation": {
                               "type": "string",
-                              "example": "Co-Founder & CEO"
+                              "examples": [
+                                "Co-Founder & CEO"
+                              ]
                             },
                             "b2b_profile": {
                               "type": "string",
-                              "example": "amitbendov"
+                              "examples": [
+                                "amitbendov"
+                              ]
                             },
                             "twitter": {
                               "type": "string",
-                              "example": "https://twitter.com/banditmove"
+                              "examples": [
+                                "https://twitter.com/banditmove"
+                              ]
                             }
                           }
                         }
@@ -4439,9 +5149,11 @@
                           "items": {
                             "type": "string"
                           },
-                          "example": [
-                            "Sales Enablement Software",
-                            "Business Intelligence (BI)"
+                          "examples": [
+                            [
+                              "Sales Enablement Software",
+                              "Business Intelligence (BI)"
+                            ]
                           ]
                         },
                         "industries": {
@@ -4449,13 +5161,17 @@
                           "items": {
                             "type": "string"
                           },
-                          "example": [
-                            "Software, Internet & Computer Services"
+                          "examples": [
+                            [
+                              "Software, Internet & Computer Services"
+                            ]
                           ]
                         },
                         "technologyStack": {
                           "type": "string",
-                          "example": "N/A"
+                          "examples": [
+                            "N/A"
+                          ]
                         }
                       }
                     },
@@ -4466,102 +5182,126 @@
                         "properties": {
                           "name": {
                             "type": "string",
-                            "example": "Chorus"
+                            "examples": [
+                              "Chorus"
+                            ]
                           },
                           "revenue": {
                             "type": "string",
-                            "example": "$21"
+                            "examples": [
+                              "$21"
+                            ]
                           },
                           "employees": {
                             "type": "string",
-                            "example": "200"
+                            "examples": [
+                              "200"
+                            ]
                           },
                           "totalFunding": {
                             "type": "string",
-                            "example": "$1,003"
+                            "examples": [
+                              "$1,003"
+                            ]
                           },
                           "headquarters": {
                             "type": "object",
                             "properties": {
                               "city": {
                                 "type": "string",
-                                "example": "San Francisco"
+                                "examples": [
+                                  "San Francisco"
+                                ]
                               },
                               "state": {
                                 "type": "string",
-                                "example": "US-CA"
+                                "examples": [
+                                  "US-CA"
+                                ]
                               },
                               "country": {
                                 "type": "string",
-                                "example": "USA"
+                                "examples": [
+                                  "USA"
+                                ]
                               },
                               "fullAddress": {
                                 "type": "string",
-                                "example": "San Francisco, US-CA, USA"
+                                "examples": [
+                                  "San Francisco, US-CA, USA"
+                                ]
                               }
                             }
                           },
                           "founded": {
                             "type": "string",
                             "format": "date-time",
-                            "example": "2015-01-01T00:00:00.000Z"
+                            "examples": [
+                              "2015-01-01T00:00:00.000Z"
+                            ]
                           },
                           "ownership": {
                             "type": "string",
-                            "example": "Private"
+                            "examples": [
+                              "Private"
+                            ]
                           },
                           "website": {
                             "type": "string",
-                            "example": "https://www.chorus.ai"
+                            "examples": [
+                              "https://www.chorus.ai"
+                            ]
                           }
                         }
                       },
-                      "example": [
-                        {
-                          "name": "BoostUp",
-                          "revenue": "$6",
-                          "employees": "85",
-                          "totalFunding": "$425",
-                          "headquarters": {
-                            "city": "Santa Clara",
-                            "state": "US-CA",
-                            "country": "USA",
-                            "fullAddress": "Santa Clara, US-CA, USA"
+                      "examples": [
+                        [
+                          {
+                            "name": "BoostUp",
+                            "revenue": "$6",
+                            "employees": "85",
+                            "totalFunding": "$425",
+                            "headquarters": {
+                              "city": "Santa Clara",
+                              "state": "US-CA",
+                              "country": "USA",
+                              "fullAddress": "Santa Clara, US-CA, USA"
+                            },
+                            "founded": "2018-01-01T00:00:00.000Z",
+                            "ownership": "Private",
+                            "website": "https://www.boostup.ai"
                           },
-                          "founded": "2018-01-01T00:00:00.000Z",
-                          "ownership": "Private",
-                          "website": "https://www.boostup.ai"
-                        },
-                        {
-                          "name": "ExecVision",
-                          "revenue": "$43",
-                          "employees": "31",
-                          "totalFunding": "$81",
-                          "headquarters": {
-                            "city": "Arlington",
-                            "state": "US-VA",
-                            "country": "USA",
-                            "fullAddress": "Arlington, US-VA, USA"
+                          {
+                            "name": "ExecVision",
+                            "revenue": "$43",
+                            "employees": "31",
+                            "totalFunding": "$81",
+                            "headquarters": {
+                              "city": "Arlington",
+                              "state": "US-VA",
+                              "country": "USA",
+                              "fullAddress": "Arlington, US-VA, USA"
+                            },
+                            "founded": "2015-01-01T00:00:00.000Z",
+                            "ownership": "Private",
+                            "website": "https://www.execvision.io"
                           },
-                          "founded": "2015-01-01T00:00:00.000Z",
-                          "ownership": "Private",
-                          "website": "https://www.execvision.io"
-                        },
-                        {
-                          "name": "Seismic",
-                          "revenue": "$375",
-                          "employees": "1,000",
-                          "totalFunding": "$940",
-                          "headquarters": {
-                            "city": "San Diego",
-                            "state": "US-CA",
-                            "country": "USA",
-                            "fullAddress": "San Diego, US-CA, USA"
-                          },
-                          "founded": "2010-01-01T00:00:00.000Z",
-                          "ownership": "Private",
-                          "website": "https://seismic.com"
-                        }
+                          {
+                            "name": "Seismic",
+                            "revenue": "$375",
+                            "employees": "1,000",
+                            "totalFunding": "$940",
+                            "headquarters": {
+                              "city": "San Diego",
+                              "state": "US-CA",
+                              "country": "USA",
+                              "fullAddress": "San Diego, US-CA, USA"
+                            },
+                            "founded": "2010-01-01T00:00:00.000Z",
+                            "ownership": "Private",
+                            "website": "https://seismic.com"
+                          }
+                        ]
                       ]
                     },
                     "acquisitions": {
@@ -4571,36 +5311,46 @@
                         "properties": {
                           "companyName": {
                             "type": "string",
-                            "example": "Vayo"
+                            "examples": [
+                              "Vayo"
+                            ]
                           },
                           "acquisitionDate": {
                             "type": "string",
                             "format": "date-time",
-                            "example": "2020-09-01T00:00:00.000Z"
+                            "examples": [
+                              "2020-09-01T00:00:00.000Z"
+                            ]
                           },
                           "description": {
                             "type": "string",
-                            "example": "Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business"
+                            "examples": [
+                              "Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business"
+                            ]
                           },
                           "source": {
                             "type": "string",
-                            "example": "https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo"
+                            "examples": [
+                              "https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo"
+                            ]
                           }
                         }
                       },
-                      "example": [
-                        {
-                          "companyName": "Vayo",
-                          "acquisitionDate": "2020-09-01T00:00:00.000Z",
-                          "description": "Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business",
-                          "source": "https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo"
-                        },
-                        {
-                          "companyName": "ONDiGO",
-                          "acquisitionDate": "2018-04-01T00:00:00.000Z",
-                          "description": "ONDiGO is a CRM platform that offers customer retention and management services to professionals and micro-businesses.",
-                          "source": "https://www.prnewswire.com/news-releases/leadmagic-acquires-ondigo-to-extend-its-conversation-intelligence-platform-300630168.html"
-                        }
+                      "examples": [
+                        [
+                          {
+                            "companyName": "Vayo",
+                            "acquisitionDate": "2020-09-01T00:00:00.000Z",
+                            "description": "Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business",
+                            "source": "https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo"
+                          },
+                          {
+                            "companyName": "ONDiGO",
+                            "acquisitionDate": "2018-04-01T00:00:00.000Z",
+                            "description": "ONDiGO is a CRM platform that offers customer retention and management services to professionals and micro-businesses.",
+                            "source": "https://www.prnewswire.com/news-releases/leadmagic-acquires-ondigo-to-extend-its-conversation-intelligence-platform-300630168.html"
+                          }
+                        ]
                       ]
                     },
                     "socialMedia": {
@@ -4610,27 +5360,33 @@
                         "properties": {
                           "platform": {
                             "type": "string",
-                            "example": "twitter"
+                            "examples": [
+                              "twitter"
+                            ]
                           },
                           "url": {
                             "type": "string",
-                            "example": "https://twitter.com/leadmagic"
+                            "examples": [
+                              "https://twitter.com/leadmagic"
+                            ]
                           }
                         }
                       },
-                      "example": [
-                        {
-                          "platform": "twitter",
-                          "url": "https://twitter.com/leadmagic"
-                        },
-                        {
-                          "platform": "facebook",
-                          "url": "https://www.facebook.com/To.LeadMagicHQ"
-                        },
-                        {
-                          "platform": "b2b_profile",
-                          "url": "leadmagichq"
-                        }
+                      "examples": [
+                        [
+                          {
+                            "platform": "twitter",
+                            "url": "https://twitter.com/leadmagic"
+                          },
+                          {
+                            "platform": "facebook",
+                            "url": "https://www.facebook.com/To.LeadMagicHQ"
+                          },
+                          {
+                            "platform": "b2b_profile",
+                            "url": "leadmagichq"
+                          }
+                        ]
                       ]
                     },
                     "news": {
@@ -4640,35 +5396,43 @@
                         "properties": {
                           "title": {
                             "type": "string",
-                            "example": "Example Robotics: Example Robotics Launches New Enterprise Platform"
+                            "examples": [
+                              "Example Robotics: Example Robotics Launches New Enterprise Platform"
+                            ]
                           },
                           "source": {
                             "type": "string",
-                            "example": "Martech Cube"
+                            "examples": [
+                              "Martech Cube"
+                            ]
                           },
                           "date": {
                             "type": "string",
                             "format": "date-time",
-                            "example": "2024-08-07T08:40:00.000Z"
+                            "examples": [
+                              "2024-08-07T08:40:00.000Z"
+                            ]
                           }
                         }
                       },
-                      "example": [
-                        {
-                          "title": "Example Robotics: Example Robotics Launches New Enterprise Platform",
-                          "source": "TechCrunch",
-                          "date": "2024-08-07T08:40:00.000Z"
-                        },
-                        {
-                          "title": "Example Robotics: Example Robotics Partners with Example CRM",
-                          "source": "Business Wire",
-                          "date": "2024-06-26T22:15:00.000Z"
-                        },
-                        {
-                          "title": "Example Robotics Named Best SaaS Solution in 2024 Industry Awards",
-                          "source": "Forbes",
-                          "date": "2024-06-26T00:00:00.000Z"
-                        }
+                      "examples": [
+                        [
+                          {
+                            "title": "Example Robotics: Example Robotics Launches New Enterprise Platform",
+                            "source": "TechCrunch",
+                            "date": "2024-08-07T08:40:00.000Z"
+                          },
+                          {
+                            "title": "Example Robotics: Example Robotics Partners with Example CRM",
+                            "source": "Business Wire",
+                            "date": "2024-06-26T22:15:00.000Z"
+                          },
+                          {
+                            "title": "Example Robotics Named Best SaaS Solution in 2024 Industry Awards",
+                            "source": "Forbes",
+                            "date": "2024-06-26T00:00:00.000Z"
+                          }
+                        ]
                       ]
                     },
                     "pressReleases": {
@@ -4678,35 +5442,43 @@
                         "properties": {
                           "title": {
                             "type": "string",
-                            "example": "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
+                            "examples": [
+                              "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
+                            ]
                           },
                           "source": {
                             "type": "string",
-                            "example": "PR Newswire"
+                            "examples": [
+                              "PR Newswire"
+                            ]
                           },
                           "date": {
                             "type": "string",
                             "format": "date-time",
-                            "example": "2024-10-17T22:21:00.000Z"
+                            "examples": [
+                              "2024-10-17T22:21:00.000Z"
+                            ]
                           }
                         }
                       },
-                      "example": [
-                        {
-                          "title": "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics",
-                          "source": "PR Newswire",
-                          "date": "2024-10-17T22:21:00.000Z"
-                        },
-                        {
-                          "title": "Press Release: Example Robotics Named a Winner in The Cloud Awards",
-                          "source": "PR Newswire",
-                          "date": "2024-10-09T18:28:00.000Z"
-                        },
-                        {
-                          "title": "Press Release: Example Robotics Recognized as Industry Leader by Example Research",
-                          "source": "Business Wire",
-                          "date": "2024-09-04T18:50:00.000Z"
-                        }
+                      "examples": [
+                        [
+                          {
+                            "title": "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics",
+                            "source": "PR Newswire",
+                            "date": "2024-10-17T22:21:00.000Z"
+                          },
+                          {
+                            "title": "Press Release: Example Robotics Named a Winner in The Cloud Awards",
+                            "source": "PR Newswire",
+                            "date": "2024-10-09T18:28:00.000Z"
+                          },
+                          {
+                            "title": "Press Release: Example Robotics Recognized as Industry Leader by Example Research",
+                            "source": "Business Wire",
+                            "date": "2024-09-04T18:50:00.000Z"
+                          }
+                        ]
                       ]
                     },
                     "keyHighlights": {
@@ -4716,51 +5488,67 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "example": "partnership"
+                            "examples": [
+                              "partnership"
+                            ]
                           },
                           "text": {
                             "type": "string",
-                            "example": "Example Robotics Announces Strategic Partnership with Example Robotics"
+                            "examples": [
+                              "Example Robotics Announces Strategic Partnership with Example Robotics"
+                            ]
                           },
                           "date": {
                             "type": "string",
                             "format": "date-time",
-                            "example": "2024-10-17T22:21:00.000Z"
+                            "examples": [
+                              "2024-10-17T22:21:00.000Z"
+                            ]
                           },
                           "src": {
                             "type": "string",
-                            "example": "https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html"
+                            "examples": [
+                              "https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html"
+                            ]
                           },
                           "source": {
                             "type": "string",
-                            "example": "PR Newswire"
+                            "examples": [
+                              "PR Newswire"
+                            ]
                           }
                         }
                       },
-                      "example": [
-                        {
-                          "type": "partnership",
-                          "text": "Example Robotics Announces Strategic Partnership with Example Robotics",
-                          "date": "2024-10-17T22:21:00.000Z",
-                          "src": "https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html",
-                          "source": "PR Newswire"
-                        },
-                        {
-                          "type": "award",
-                          "text": "Example Robotics Named a Winner in The Cloud Awards",
-                          "date": "2024-10-09T18:28:00.000Z",
-                          "src": "https://www.prnewswire.com/news-releases/acme-corp-cloud-awards-302271452.html",
-                          "source": "PR Newswire"
-                        }
+                      "examples": [
+                        [
+                          {
+                            "type": "partnership",
+                            "text": "Example Robotics Announces Strategic Partnership with Example Robotics",
+                            "date": "2024-10-17T22:21:00.000Z",
+                            "src": "https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html",
+                            "source": "PR Newswire"
+                          },
+                          {
+                            "type": "award",
+                            "text": "Example Robotics Named a Winner in The Cloud Awards",
+                            "date": "2024-10-09T18:28:00.000Z",
+                            "src": "https://www.prnewswire.com/news-releases/acme-corp-cloud-awards-302271452.html",
+                            "source": "PR Newswire"
+                          }
+                        ]
                       ]
                     },
                     "summarySection": {
                       "type": "string",
-                      "example": "Example Robotics provides enterprise software solutions for B2B companies. Example Robotics was founded in 2018. Example Robotics's headquarters is located in San Francisco, California, USA."
+                      "examples": [
+                        "Example Robotics provides enterprise software solutions for B2B companies. Example Robotics was founded in 2018. Example Robotics's headquarters is located in San Francisco, California, USA."
+                      ]
                     },
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 4
+                      "examples": [
+                        4
+                      ]
                     }
                   }
                 }
@@ -4806,17 +5594,23 @@
                   "company_domain": {
                     "type": "string",
                     "description": "Company website domain",
-                    "example": "leadmagic.io"
+                    "examples": [
+                      "leadmagic.io"
+                    ]
                   },
                   "company_url": {
                     "type": "string",
                     "description": "Company profile URL or identifier (optional)",
-                    "example": "leadmagichq"
+                    "examples": [
+                      "leadmagichq"
+                    ]
                   },
                   "company_name": {
                     "type": "string",
                     "description": "Company name",
-                    "example": "LeadMagic"
+                    "examples": [
+                      "LeadMagic"
+                    ]
                   }
                 }
               }
@@ -4838,31 +5632,45 @@
                         "properties": {
                           "name": {
                             "type": "string",
-                            "example": "LeadMagic"
+                            "examples": [
+                              "LeadMagic"
+                            ]
                           },
                           "shortDescription": {
                             "type": "string",
-                            "example": "LeadMagic is a company that develops a conversation intelligence platform for B2B sales teams. "
+                            "examples": [
+                              "LeadMagic is a company that develops a conversation intelligence platform for B2B sales teams. "
+                            ]
                           },
                           "founded_year": {
                             "type": "string",
-                            "example": "2015"
+                            "examples": [
+                              "2015"
+                            ]
                           },
                           "companyType": {
                             "type": "string",
-                            "example": "private"
+                            "examples": [
+                              "private"
+                            ]
                           },
                           "hq": {
                             "type": "string",
-                            "example": "San Francisco, US"
+                            "examples": [
+                              "San Francisco, US"
+                            ]
                           },
                           "employeesCount": {
                             "type": "integer",
-                            "example": 1504
+                            "examples": [
+                              1504
+                            ]
                           },
                           "valuation": {
                             "type": "integer",
-                            "example": 7250000000
+                            "examples": [
+                              7250000000
+                            ]
                           },
                           "tags": {
                             "type": "array",
@@ -4871,72 +5679,98 @@
                               "properties": {
                                 "name": {
                                   "type": "string",
-                                  "example": "Technology"
+                                  "examples": [
+                                    "Technology"
+                                  ]
                                 },
                                 "slug": {
                                   "type": "string",
-                                  "example": "technology"
+                                  "examples": [
+                                    "technology"
+                                  ]
                                 },
                                 "primary": {
                                   "type": "boolean",
-                                  "example": true
+                                  "examples": [
+                                    true
+                                  ]
                                 }
                               }
                             }
                           },
                           "twitter_followers": {
                             "type": "integer",
-                            "example": 7611
+                            "examples": [
+                              7611
+                            ]
                           },
                           "growth": {
                             "type": "integer",
-                            "example": 1
+                            "examples": [
+                              1
+                            ]
                           },
                           "non_hq_locations": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "example": [
-                              "Dublin, IE",
-                              "Ramat Gan, IL",
-                              "Atlanta, US",
-                              "Chicago, US"
+                            "examples": [
+                              [
+                                "Dublin, IE",
+                                "Ramat Gan, IL",
+                                "Atlanta, US",
+                                "Chicago, US"
+                              ]
                             ]
                           },
                           "more_locations": {
                             "type": "boolean",
-                            "example": false
+                            "examples": [
+                              false
+                            ]
                           },
                           "financial_metrics": {
                             "type": "object",
                             "properties": {
                               "currency_code": {
                                 "type": "string",
-                                "example": "USD"
+                                "examples": [
+                                  "USD"
+                                ]
                               },
                               "period": {
                                 "type": "string",
-                                "example": "Y, 2020"
+                                "examples": [
+                                  "Y, 2020"
+                                ]
                               },
                               "revenue": {
                                 "type": "integer",
-                                "example": 37500000
+                                "examples": [
+                                  37500000
+                                ]
                               },
                               "cost_of_goods_sold": {
                                 "type": "integer",
                                 "nullable": true,
-                                "example": null
+                                "examples": [
+                                  null
+                                ]
                               },
                               "gross_profit": {
                                 "type": "integer",
                                 "nullable": true,
-                                "example": null
+                                "examples": [
+                                  null
+                                ]
                               },
                               "net_income": {
                                 "type": "integer",
                                 "nullable": true,
-                                "example": null
+                                "examples": [
+                                  null
+                                ]
                               }
                             }
                           },
@@ -4947,24 +5781,34 @@
                               "properties": {
                                 "period": {
                                   "type": "string",
-                                  "example": "Dec, 2019"
+                                  "examples": [
+                                    "Dec, 2019"
+                                  ]
                                 },
                                 "value": {
                                   "type": "string",
-                                  "example": "700.0"
+                                  "examples": [
+                                    "700.0"
+                                  ]
                                 },
                                 "definition": {
                                   "type": "string",
-                                  "example": "Enterprise Customers"
+                                  "examples": [
+                                    "Enterprise Customers"
+                                  ]
                                 },
                                 "operating_metric_group": {
                                   "type": "string",
-                                  "example": "Customers"
+                                  "examples": [
+                                    "Customers"
+                                  ]
                                 },
                                 "currency_code": {
                                   "type": "string",
                                   "nullable": true,
-                                  "example": null
+                                  "examples": [
+                                    null
+                                  ]
                                 }
                               }
                             }
@@ -4974,19 +5818,27 @@
                             "properties": {
                               "date": {
                                 "type": "string",
-                                "example": "about 3 years"
+                                "examples": [
+                                  "about 3 years"
+                                ]
                               },
                               "latest": {
                                 "type": "integer",
-                                "example": 250000000
+                                "examples": [
+                                  250000000
+                                ]
                               },
                               "currency_code": {
                                 "type": "string",
-                                "example": "USD"
+                                "examples": [
+                                  "USD"
+                                ]
                               },
                               "total": {
                                 "type": "integer",
-                                "example": 581000000
+                                "examples": [
+                                  581000000
+                                ]
                               }
                             }
                           },
@@ -4995,7 +5847,9 @@
                             "properties": {
                               "handle": {
                                 "type": "string",
-                                "example": "leadmagichq"
+                                "examples": [
+                                  "leadmagichq"
+                                ]
                               },
                               "analytics": {
                                 "type": "array",
@@ -5004,39 +5858,57 @@
                                   "properties": {
                                     "collectedAt": {
                                       "type": "string",
-                                      "example": "2023-07-12T00:00:00"
+                                      "examples": [
+                                        "2023-07-12T00:00:00"
+                                      ]
                                     },
                                     "tweets": {
                                       "type": "integer",
-                                      "example": 6384
+                                      "examples": [
+                                        6384
+                                      ]
                                     },
                                     "following": {
                                       "type": "integer",
-                                      "example": 1854
+                                      "examples": [
+                                        1854
+                                      ]
                                     },
                                     "followers": {
                                       "type": "integer",
-                                      "example": 7611
+                                      "examples": [
+                                        7611
+                                      ]
                                     },
                                     "tweetsForPeriod": {
                                       "type": "integer",
-                                      "example": 0
+                                      "examples": [
+                                        0
+                                      ]
                                     },
                                     "avgTweetsPerDay": {
                                       "type": "number",
-                                      "example": 0
+                                      "examples": [
+                                        0
+                                      ]
                                     },
                                     "avgRetweetsPerTweet": {
                                       "type": "number",
-                                      "example": 0
+                                      "examples": [
+                                        0
+                                      ]
                                     },
                                     "avgLikesPerTweet": {
                                       "type": "number",
-                                      "example": 0
+                                      "examples": [
+                                        0
+                                      ]
                                     },
                                     "tweetsPercentageEngagementForPeriod": {
                                       "type": "number",
-                                      "example": 0
+                                      "examples": [
+                                        0
+                                      ]
                                     }
                                   }
                                 }
@@ -5093,7 +5965,9 @@
                   "company_domain": {
                     "type": "string",
                     "description": "The domain of the company to analyze",
-                    "example": "leadmagic.io"
+                    "examples": [
+                      "leadmagic.io"
+                    ]
                   }
                 }
               }
@@ -5110,11 +5984,15 @@
                   "properties": {
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 1
+                      "examples": [
+                        1
+                      ]
                     },
                     "message": {
                       "type": "string",
-                      "example": "Technology stack information retrieved successfully"
+                      "examples": [
+                        "Technology stack information retrieved successfully"
+                      ]
                     },
                     "data": {
                       "type": "array",
@@ -5125,12 +6003,16 @@
                           "name": {
                             "type": "string",
                             "description": "The name of the technology",
-                            "example": "Google Analytics"
+                            "examples": [
+                              "Google Analytics"
+                            ]
                           },
                           "description": {
                             "type": "string",
                             "description": "Description of the technology",
-                            "example": "Google Analytics is a web analytics service offered by Google that tracks and reports website traffic."
+                            "examples": [
+                              "Google Analytics is a web analytics service offered by Google that tracks and reports website traffic."
+                            ]
                           },
                           "categories": {
                             "type": "array",
@@ -5138,9 +6020,11 @@
                             "items": {
                               "type": "string"
                             },
-                            "example": [
-                              "Analytics",
-                              "Marketing"
+                            "examples": [
+                              [
+                                "Analytics",
+                                "Marketing"
+                              ]
                             ]
                           },
                           "sub_technologies": {
@@ -5152,12 +6036,16 @@
                                 "name": {
                                   "type": "string",
                                   "description": "Name of the sub-technology",
-                                  "example": "Google Analytics 4"
+                                  "examples": [
+                                    "Google Analytics 4"
+                                  ]
                                 },
                                 "description": {
                                   "type": "string",
                                   "description": "Description of the sub-technology",
-                                  "example": "The latest version of Google Analytics with enhanced privacy features"
+                                  "examples": [
+                                    "The latest version of Google Analytics with enhanced privacy features"
+                                  ]
                                 },
                                 "categories": {
                                   "type": "array",
@@ -5165,9 +6053,11 @@
                                     "type": "string"
                                   },
                                   "description": "Categories for the sub-technology",
-                                  "example": [
-                                    "Analytics",
-                                    "Privacy-focused"
+                                  "examples": [
+                                    [
+                                      "Analytics",
+                                      "Privacy-focused"
+                                    ]
                                   ]
                                 }
                               }
@@ -5247,35 +6137,51 @@
                   "properties": {
                     "name": {
                       "type": "string",
-                      "example": "Alex Rivera"
+                      "examples": [
+                        "Alex Rivera"
+                      ]
                     },
                     "profile_url": {
                       "type": "string",
-                      "example": "alex-rivera"
+                      "examples": [
+                        "alex-rivera"
+                      ]
                     },
                     "first_name": {
                       "type": "string",
-                      "example": "Alex"
+                      "examples": [
+                        "Alex"
+                      ]
                     },
                     "last_name": {
                       "type": "string",
-                      "example": "Rivera"
+                      "examples": [
+                        "Rivera"
+                      ]
                     },
                     "message": {
                       "type": "string",
-                      "example": "Role found."
+                      "examples": [
+                        "Role found."
+                      ]
                     },
                     "credits_consumed": {
                       "type": "integer",
-                      "example": 2
+                      "examples": [
+                        2
+                      ]
                     },
                     "company_name": {
                       "type": "string",
-                      "example": "Leadmagic"
+                      "examples": [
+                        "Leadmagic"
+                      ]
                     },
                     "company_website": {
                       "type": "string",
-                      "example": "leadmagic.io"
+                      "examples": [
+                        "leadmagic.io"
+                      ]
                     }
                   }
                 }
@@ -5353,27 +6259,39 @@
                         "properties": {
                           "first_name": {
                             "type": "string",
-                            "example": "Alex"
+                            "examples": [
+                              "Alex"
+                            ]
                           },
                           "last_name": {
                             "type": "string",
-                            "example": "Rivera"
+                            "examples": [
+                              "Rivera"
+                            ]
                           },
                           "full_name": {
                             "type": "string",
-                            "example": "Alex Rivera"
+                            "examples": [
+                              "Alex Rivera"
+                            ]
                           },
                           "profile_url": {
                             "type": "string",
-                            "example": "example.com/in/alex-rivera"
+                            "examples": [
+                              "example.com/in/alex-rivera"
+                            ]
                           },
                           "job_title": {
                             "type": "string",
-                            "example": "VP of Sales"
+                            "examples": [
+                              "VP of Sales"
+                            ]
                           },
                           "location": {
                             "type": "string",
-                            "example": "San Francisco, CA"
+                            "examples": [
+                              "San Francisco, CA"
+                            ]
                           }
                         }
                       }
@@ -5381,12 +6299,16 @@
                     "total_count": {
                       "type": "integer",
                       "description": "Total employees found (may exceed returned count when limit is set)",
-                      "example": 150
+                      "examples": [
+                        150
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
                       "description": "Credits used (0.05 per employee returned)",
-                      "example": 0.5
+                      "examples": [
+                        0.5
+                      ]
                     },
                     "message": {
                       "$ref": "#/components/schemas/EmployeeFinderMessages"
@@ -5435,16 +6357,22 @@
                 "properties": {
                   "company_domain": {
                     "type": "string",
-                    "example": "leadmagic.io"
+                    "examples": [
+                      "leadmagic.io"
+                    ]
                   },
                   "company_name": {
                     "type": "string",
-                    "example": "LeadMagic"
+                    "examples": [
+                      "LeadMagic"
+                    ]
                   },
                   "linkedin_url": {
                     "type": "string",
                     "description": "B2B company profile URL or slug.",
-                    "example": "https://www.example.com/company/acme/"
+                    "examples": [
+                      "https://www.example.com/company/acme/"
+                    ]
                   },
                   "company_filters": {
                     "type": "object",
@@ -5458,11 +6386,15 @@
                   },
                   "title": {
                     "type": "string",
-                    "example": "VP Sales"
+                    "examples": [
+                      "VP Sales"
+                    ]
                   },
                   "job_title": {
                     "type": "string",
-                    "example": "Head of Revenue"
+                    "examples": [
+                      "Head of Revenue"
+                    ]
                   },
                   "titles": {
                     "type": "array",
@@ -5555,32 +6487,36 @@
                   }
                 }
               },
-              "example": {
-                "company_filters": {
-                  "company_domains": [
-                    "leadmagic.io"
-                  ],
-                  "crm_tech": [
-                    "Salesforce"
-                  ]
-                },
-                "people_filters": {
-                  "contact_job_level": [
-                    "VP",
-                    "Director"
-                  ],
-                  "contact_job_function": [
-                    "Sales"
-                  ],
-                  "is_sales": true,
-                  "min_contactability_score": 40
-                },
-                "titles": [
-                  "VP Sales",
-                  "Head of Revenue"
-                ],
-                "required_email": true,
-                "limit": 10
+              "examples": {
+                "default": {
+                  "value": {
+                    "company_filters": {
+                      "company_domains": [
+                        "leadmagic.io"
+                      ],
+                      "crm_tech": [
+                        "Salesforce"
+                      ]
+                    },
+                    "people_filters": {
+                      "contact_job_level": [
+                        "VP",
+                        "Director"
+                      ],
+                      "contact_job_function": [
+                        "Sales"
+                      ],
+                      "is_sales": true,
+                      "min_contactability_score": 40
+                    },
+                    "titles": [
+                      "VP Sales",
+                      "Head of Revenue"
+                    ],
+                    "required_email": true,
+                    "limit": 10
+                  }
+                }
               }
             }
           }
@@ -5922,93 +6858,97 @@
                     }
                   }
                 },
-                "example": {
-                  "message": "People found",
-                  "credits_consumed": 0,
-                  "count": 120,
-                  "returned_count": 25,
-                  "limit_applied": 25,
-                  "offset": 25,
-                  "has_more": true,
-                  "next_cursor": null,
-                  "metadata": {
-                    "query_name": "people_search_v3",
-                    "query_path": "full_search",
-                    "pagination": "offset"
-                  },
-                  "people": [
-                    {
-                      "contact_linkedin_url": "https://example.com/in/jane-doe",
-                      "contact_linkedin_username": "jesseoue",
-                      "contact_first_name": "Jesse",
-                      "contact_last_name": "Ouellette",
-                      "contact_full_name": "Jesse Ouellette",
-                      "contact_email": "jesse@leadmagic.io",
-                      "contact_email_domain": "leadmagic.io",
-                      "contact_mobile_phone": "+12073561898",
-                      "contact_direct_phone": null,
-                      "contact_linkedin_headline": "Growth & AI Expert | Founder LeadMagic",
-                      "contact_linkedin_about_me": "SaaS Founder",
-                      "contact_city": "Boston",
-                      "contact_state": "Massachusetts",
-                      "contact_state_code": "MA",
-                      "contact_country": "United States",
-                      "contact_country_code": "US",
-                      "contact_region": "NORAM",
-                      "contact_continent": "North America",
-                      "contact_job_title": "Founder",
-                      "contact_job_function": "General Business & Management",
-                      "contact_job_level": "C-Team",
-                      "contact_job_description": "LeadMagic is the Best B2B Email & Mobile Finder",
-                      "contact_job_start_date": "2022-09-01",
-                      "contact_job_count": 15,
-                      "contact_persona": "Founder/Co-Founder",
-                      "contact_company_name": "Leadmagic",
-                      "company_domain": "leadmagic.io",
-                      "seniority_score": 5,
-                      "has_email": true,
-                      "has_mobile_phone": true,
-                      "has_phone": false,
-                      "followers": 500,
-                      "company": {
-                        "company_domain": "leadmagic.io",
-                        "company_name": "Leadmagic",
-                        "company_website": "https://www.leadmagic.io",
-                        "company_industry_linkedin": "Internet Publishing",
-                        "employee_range": "11 to 50",
-                        "employee_min": 11,
-                        "employee_max": 50,
-                        "linkedin_employee_count": 10,
-                        "revenue_range": "$1M to <$10M",
-                        "revenue_min": "4000000",
-                        "revenue_max": "4000000",
-                        "hq_country": "United States",
-                        "hq_country_code": "US",
-                        "hq_city": "Boston",
-                        "hq_state": "Massachusetts",
-                        "founded_year": 2022,
-                        "linkedin_followers": 8804,
-                        "growth_rate": 14,
-                        "linkedin_url": "https://www.example.com/company/acme",
-                        "company_headline": "The data provider other data providers use. Emails, mobiles, and company data that don't bounce."
+                "examples": {
+                  "default": {
+                    "value": {
+                      "message": "People found",
+                      "credits_consumed": 0,
+                      "count": 120,
+                      "returned_count": 25,
+                      "limit_applied": 25,
+                      "offset": 25,
+                      "has_more": true,
+                      "next_cursor": null,
+                      "metadata": {
+                        "query_name": "people_search_v3",
+                        "query_path": "full_search",
+                        "pagination": "offset"
                       },
-                      "domain_intel": {
-                        "company_domain": "leadmagic.io",
-                        "company_name": "Leadmagic",
-                        "company_website": "https://www.leadmagic.io",
-                        "company_domain_tld": "leadmagic.io",
-                        "company_website_active": true,
-                        "primary_email_domain": "leadmagic.io",
-                        "email_pattern": "first",
-                        "email_pattern_example": "soufiane@leadmagic.io",
-                        "email_pattern_confidence": 100,
-                        "email_pattern_confidence_tier": "low",
-                        "total_email_count": 4,
-                        "valid_email_count": 4,
-                        "total_contacts": 10
-                      }
+                      "people": [
+                        {
+                          "contact_linkedin_url": "https://example.com/in/jane-doe",
+                          "contact_linkedin_username": "jesseoue",
+                          "contact_first_name": "Jesse",
+                          "contact_last_name": "Ouellette",
+                          "contact_full_name": "Jesse Ouellette",
+                          "contact_email": "jesse@leadmagic.io",
+                          "contact_email_domain": "leadmagic.io",
+                          "contact_mobile_phone": "+12073561898",
+                          "contact_direct_phone": null,
+                          "contact_linkedin_headline": "Growth & AI Expert | Founder LeadMagic",
+                          "contact_linkedin_about_me": "SaaS Founder",
+                          "contact_city": "Boston",
+                          "contact_state": "Massachusetts",
+                          "contact_state_code": "MA",
+                          "contact_country": "United States",
+                          "contact_country_code": "US",
+                          "contact_region": "NORAM",
+                          "contact_continent": "North America",
+                          "contact_job_title": "Founder",
+                          "contact_job_function": "General Business & Management",
+                          "contact_job_level": "C-Team",
+                          "contact_job_description": "LeadMagic is the Best B2B Email & Mobile Finder",
+                          "contact_job_start_date": "2022-09-01",
+                          "contact_job_count": 15,
+                          "contact_persona": "Founder/Co-Founder",
+                          "contact_company_name": "Leadmagic",
+                          "company_domain": "leadmagic.io",
+                          "seniority_score": 5,
+                          "has_email": true,
+                          "has_mobile_phone": true,
+                          "has_phone": false,
+                          "followers": 500,
+                          "company": {
+                            "company_domain": "leadmagic.io",
+                            "company_name": "Leadmagic",
+                            "company_website": "https://www.leadmagic.io",
+                            "company_industry_linkedin": "Internet Publishing",
+                            "employee_range": "11 to 50",
+                            "employee_min": 11,
+                            "employee_max": 50,
+                            "linkedin_employee_count": 10,
+                            "revenue_range": "$1M to <$10M",
+                            "revenue_min": "4000000",
+                            "revenue_max": "4000000",
+                            "hq_country": "United States",
+                            "hq_country_code": "US",
+                            "hq_city": "Boston",
+                            "hq_state": "Massachusetts",
+                            "founded_year": 2022,
+                            "linkedin_followers": 8804,
+                            "growth_rate": 14,
+                            "linkedin_url": "https://www.example.com/company/acme",
+                            "company_headline": "The data provider other data providers use. Emails, mobiles, and company data that don't bounce."
+                          },
+                          "domain_intel": {
+                            "company_domain": "leadmagic.io",
+                            "company_name": "Leadmagic",
+                            "company_website": "https://www.leadmagic.io",
+                            "company_domain_tld": "leadmagic.io",
+                            "company_website_active": true,
+                            "primary_email_domain": "leadmagic.io",
+                            "email_pattern": "first",
+                            "email_pattern_example": "soufiane@leadmagic.io",
+                            "email_pattern_confidence": 100,
+                            "email_pattern_confidence_tier": "low",
+                            "total_email_count": 4,
+                            "valid_email_count": 4,
+                            "total_contacts": 10
+                          }
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -6047,7 +6987,9 @@
                   "company_domain": {
                     "type": "string",
                     "description": "Direct one-company lookup input. Returns one rich company row plus legacy-friendly aliases when no broad filters or explicit limit are supplied.",
-                    "example": "leadmagic.io"
+                    "examples": [
+                      "leadmagic.io"
+                    ]
                   },
                   "domain": {
                     "type": "string",
@@ -6096,23 +7038,27 @@
                   }
                 }
               },
-              "example": {
-                "limit": 10,
-                "company_filters": {
-                  "company_domains": [
-                    "leadmagic.io"
-                  ],
-                  "country_codes": [
-                    "US"
-                  ],
-                  "location_country_codes": [
-                    "US"
-                  ],
-                  "crm_tech": [
-                    "Salesforce"
-                  ],
-                  "has_funding": true,
-                  "website_active": true
+              "examples": {
+                "default": {
+                  "value": {
+                    "limit": 10,
+                    "company_filters": {
+                      "company_domains": [
+                        "leadmagic.io"
+                      ],
+                      "country_codes": [
+                        "US"
+                      ],
+                      "location_country_codes": [
+                        "US"
+                      ],
+                      "crm_tech": [
+                        "Salesforce"
+                      ],
+                      "has_funding": true,
+                      "website_active": true
+                    }
+                  }
                 }
               }
             }
@@ -6498,26 +7444,30 @@
                     }
                   }
                 },
-                "example": {
-                  "message": "Companies found",
-                  "credits_consumed": 0,
-                  "count": 120,
-                  "returned_count": 25,
-                  "limit_applied": 25,
-                  "offset": 25,
-                  "has_more": true,
-                  "next_cursor": null,
-                  "metadata": {
-                    "pagination": "offset"
-                  },
-                  "companies": [
-                    {
-                      "company_domain": "leadmagic.io",
-                      "company_name": "Leadmagic",
-                      "company_website": "https://www.leadmagic.io",
-                      "employee_range": "11 to 50"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "message": "Companies found",
+                      "credits_consumed": 0,
+                      "count": 120,
+                      "returned_count": 25,
+                      "limit_applied": 25,
+                      "offset": 25,
+                      "has_more": true,
+                      "next_cursor": null,
+                      "metadata": {
+                        "pagination": "offset"
+                      },
+                      "companies": [
+                        {
+                          "company_domain": "leadmagic.io",
+                          "company_name": "Leadmagic",
+                          "company_website": "https://www.leadmagic.io",
+                          "employee_range": "11 to 50"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -6556,7 +7506,9 @@
                   "company_domain": {
                     "type": "string",
                     "description": "Seed company domain. Aliases include domain, website, company_website, seed.domain. Typos like companny_domain are remapped.",
-                    "example": "leadmagic.io"
+                    "examples": [
+                      "leadmagic.io"
+                    ]
                   },
                   "domain": {
                     "type": "string",
@@ -6620,26 +7572,30 @@
                   }
                 }
               },
-              "example": {
-                "company_domain": "leadmagic.io",
-                "company_filters": {
-                  "country_codes": [
-                    "US"
-                  ],
-                  "location_country_codes": [
-                    "US"
-                  ],
-                  "employee_ranges": [
-                    "51 to 200",
-                    "201 to 500"
-                  ],
-                  "crm_tech": [
-                    "Salesforce"
-                  ],
-                  "has_tech_stack": true,
-                  "website_active": true
-                },
-                "limit": 25
+              "examples": {
+                "default": {
+                  "value": {
+                    "company_domain": "leadmagic.io",
+                    "company_filters": {
+                      "country_codes": [
+                        "US"
+                      ],
+                      "location_country_codes": [
+                        "US"
+                      ],
+                      "employee_ranges": [
+                        "51 to 200",
+                        "201 to 500"
+                      ],
+                      "crm_tech": [
+                        "Salesforce"
+                      ],
+                      "has_tech_stack": true,
+                      "website_active": true
+                    },
+                    "limit": 25
+                  }
+                }
               }
             }
           }
@@ -6697,12 +7653,16 @@
                   "properties": {
                     "message": {
                       "type": "string",
-                      "example": "Lookalike companies found"
+                      "examples": [
+                        "Lookalike companies found"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
                       "description": "Flat 5 when results returned; 0 when empty",
-                      "example": 5
+                      "examples": [
+                        5
+                      ]
                     },
                     "companies": {
                       "type": "array",
@@ -6770,19 +7730,27 @@
                     },
                     "count": {
                       "type": "integer",
-                      "example": 5
+                      "examples": [
+                        5
+                      ]
                     },
                     "returned_count": {
                       "type": "integer",
-                      "example": 5
+                      "examples": [
+                        5
+                      ]
                     },
                     "limit_applied": {
                       "type": "integer",
-                      "example": 25
+                      "examples": [
+                        25
+                      ]
                     },
                     "offset": {
                       "type": "integer",
-                      "example": 0
+                      "examples": [
+                        0
+                      ]
                     },
                     "interpreted_search": {
                       "type": "object",
@@ -6795,11 +7763,15 @@
                       "properties": {
                         "query_name": {
                           "type": "string",
-                          "example": "company_lookalike_v3"
+                          "examples": [
+                            "company_lookalike_v3"
+                          ]
                         },
                         "query_path": {
                           "type": "string",
-                          "example": "lookalike"
+                          "examples": [
+                            "lookalike"
+                          ]
                         },
                         "preview": {
                           "type": "boolean"
@@ -6812,30 +7784,34 @@
                     }
                   }
                 },
-                "example": {
-                  "message": "Lookalike companies found",
-                  "credits_consumed": 5,
-                  "companies": [
-                    {
-                      "company_domain": "tomba.io",
-                      "company_name": "Tomba.Io",
-                      "similarity": 0.88
+                "examples": {
+                  "default": {
+                    "value": {
+                      "message": "Lookalike companies found",
+                      "credits_consumed": 5,
+                      "companies": [
+                        {
+                          "company_domain": "tomba.io",
+                          "company_name": "Tomba.Io",
+                          "similarity": 0.88
+                        }
+                      ],
+                      "count": 1,
+                      "returned_count": 1,
+                      "limit_applied": 25,
+                      "offset": 0,
+                      "interpreted_search": {
+                        "seed": {
+                          "domain": "leadmagic.io"
+                        },
+                        "company_filters": {}
+                      },
+                      "metadata": {
+                        "query_name": "company_lookalike_v3",
+                        "query_path": "lookalike",
+                        "preview": false
+                      }
                     }
-                  ],
-                  "count": 1,
-                  "returned_count": 1,
-                  "limit_applied": 25,
-                  "offset": 0,
-                  "interpreted_search": {
-                    "seed": {
-                      "domain": "leadmagic.io"
-                    },
-                    "company_filters": {}
-                  },
-                  "metadata": {
-                    "query_name": "company_lookalike_v3",
-                    "query_path": "lookalike",
-                    "preview": false
                   }
                 }
               }
@@ -6874,94 +7850,130 @@
                   "company_name": {
                     "type": "string",
                     "description": "Provide the Company Name. (Optional)",
-                    "example": "Clay"
+                    "examples": [
+                      "Clay"
+                    ]
                   },
                   "company_website": {
                     "type": "string",
                     "description": "Provide the Company Website. (Optional)",
-                    "example": "clay.com"
+                    "examples": [
+                      "clay.com"
+                    ]
                   },
                   "job_title": {
                     "type": "string",
                     "description": "Provide the Job Title.",
-                    "example": "RevOps Engineer"
+                    "examples": [
+                      "RevOps Engineer"
+                    ]
                   },
                   "location": {
                     "type": "string",
                     "description": "Location of the job",
-                    "example": "United States"
+                    "examples": [
+                      "United States"
+                    ]
                   },
                   "experience_level": {
                     "type": "string",
                     "description": "Indicates the required experience level for the job. Choose \"entry\" for Entry Level, \"mid\" for Mid Level, \"senior\" for Senior Level, or \"executive\" for Executive Level. If not specified, jobs from all experience levels will be included.",
-                    "example": "senior"
+                    "examples": [
+                      "senior"
+                    ]
                   },
                   "job_description": {
                     "type": "string",
                     "description": "Filters jobs based on specific keywords or phrases found in the job description.",
-                    "example": "leadmagic"
+                    "examples": [
+                      "leadmagic"
+                    ]
                   },
                   "city_name": {
                     "type": "string",
                     "description": "Filter jobs by city name. Pair with `country_id` to disambiguate cities that share a name.",
-                    "example": "Austin"
+                    "examples": [
+                      "Austin"
+                    ]
                   },
                   "country_id": {
                     "type": "string",
                     "description": "Filter jobs by country code, such as US or GB. Use the country helper for supported values.",
-                    "example": "US"
+                    "examples": [
+                      "US"
+                    ]
                   },
                   "region_id": {
                     "type": "integer",
                     "description": "Filter jobs by region ID.",
-                    "example": 5
+                    "examples": [
+                      5
+                    ]
                   },
                   "job_type_id": {
                     "type": "integer",
                     "description": "Filter jobs by job type ID.",
-                    "example": 1
+                    "examples": [
+                      1
+                    ]
                   },
                   "company_type_id": {
                     "type": "integer",
                     "description": "Filter jobs by company type ID.",
-                    "example": 1
+                    "examples": [
+                      1
+                    ]
                   },
                   "company_industry_id": {
                     "type": "integer",
                     "description": "Filter jobs by company industry ID.",
-                    "example": 7
+                    "examples": [
+                      7
+                    ]
                   },
                   "min_employees": {
                     "type": "integer",
                     "description": "Minimum number of employees",
-                    "example": 51
+                    "examples": [
+                      51
+                    ]
                   },
                   "max_employees": {
                     "type": "integer",
                     "description": "Maximum number of employees",
-                    "example": 10000
+                    "examples": [
+                      10000
+                    ]
                   },
                   "has_remote": {
                     "type": "boolean",
                     "description": "Determines whether the jobs offer remote work options. Set to true to include remote-only listings, or false to include non-remote listings.",
-                    "example": true
+                    "examples": [
+                      true
+                    ]
                   },
                   "posted_within": {
                     "type": "integer",
                     "description": "Specify the number of days within which the job was posted.",
-                    "example": 30
+                    "examples": [
+                      30
+                    ]
                   },
                   "posted_after": {
                     "type": "string",
                     "format": "date",
                     "description": "Filters jobs posted on or after a specific date. Use the format YYYY-MM-DD.",
-                    "example": "2026-05-01"
+                    "examples": [
+                      "2026-05-01"
+                    ]
                   },
                   "posted_before": {
                     "type": "string",
                     "format": "date",
                     "description": "Filters jobs posted on or before a specific date. Use the format YYYY-MM-DD.",
-                    "example": "2026-05-15"
+                    "examples": [
+                      "2026-05-15"
+                    ]
                   },
                   "page": {
                     "type": "integer",
@@ -6975,14 +7987,18 @@
                   }
                 }
               },
-              "example": {
-                "company_website": "clay.com",
-                "job_title": "RevOps Engineer",
-                "country_id": "US",
-                "has_remote": true,
-                "posted_within": 30,
-                "page": 1,
-                "per_page": 20
+              "examples": {
+                "default": {
+                  "value": {
+                    "company_website": "clay.com",
+                    "job_title": "RevOps Engineer",
+                    "country_id": "US",
+                    "has_remote": true,
+                    "posted_within": 30,
+                    "page": 1,
+                    "per_page": 20
+                  }
+                }
               }
             }
           }
@@ -7025,26 +8041,36 @@
                             "properties": {
                               "name": {
                                 "type": "string",
-                                "example": "LeadMagic"
+                                "examples": [
+                                  "LeadMagic"
+                                ]
                               },
                               "website_url": {
                                 "type": "string",
-                                "example": "https://leadmagic.io"
+                                "examples": [
+                                  "https://leadmagic.io"
+                                ]
                               },
                               "b2b_profile_url": {
                                 "type": "string",
                                 "nullable": true,
-                                "example": "leadmagichq"
+                                "examples": [
+                                  "leadmagichq"
+                                ]
                               },
                               "twitter_handle": {
                                 "type": "string",
                                 "nullable": true,
-                                "example": "leadmagichq"
+                                "examples": [
+                                  "leadmagichq"
+                                ]
                               },
                               "github_url": {
                                 "type": "string",
                                 "nullable": true,
-                                "example": "https://github.com/leadmagic"
+                                "examples": [
+                                  "https://github.com/leadmagic"
+                                ]
                               }
                             }
                           },
@@ -7171,76 +8197,78 @@
                       }
                     }
                   },
-                  "example": {
-                    "total_count": 50,
-                    "page": 1,
-                    "per_page": 20,
-                    "total_pages": 3,
-                    "credits_consumed": 20,
-                    "results": [
-                      {
-                        "company": {
-                          "name": "LeadMagic",
-                          "website_url": "https://leadmagic.io",
-                          "b2b_profile_url": "leadmagichq",
-                          "twitter_handle": "leadmagichq",
-                          "github_url": "https://github.com/leadmagic"
-                        },
-                        "title": "Senior Software Engineer",
-                        "location": "San Jose, San José, Costa Rica",
-                        "types": [
-                          {
-                            "id": 1,
-                            "name": "Full Time"
-                          }
-                        ],
-                        "cities": [
-                          {
-                            "geonameid": 3621849,
-                            "asciiname": "San Jose",
-                            "name": "San José",
-                            "country": {
+                  "examples": [
+                    {
+                      "total_count": 50,
+                      "page": 1,
+                      "per_page": 20,
+                      "total_pages": 3,
+                      "credits_consumed": 20,
+                      "results": [
+                        {
+                          "company": {
+                            "name": "LeadMagic",
+                            "website_url": "https://leadmagic.io",
+                            "b2b_profile_url": "leadmagichq",
+                            "twitter_handle": "leadmagichq",
+                            "github_url": "https://github.com/leadmagic"
+                          },
+                          "title": "Senior Software Engineer",
+                          "location": "San Jose, San José, Costa Rica",
+                          "types": [
+                            {
+                              "id": 1,
+                              "name": "Full Time"
+                            }
+                          ],
+                          "cities": [
+                            {
+                              "geonameid": 3621849,
+                              "asciiname": "San Jose",
+                              "name": "San José",
+                              "country": {
+                                "code": "CR",
+                                "name": "Costa Rica",
+                                "region": {
+                                  "id": 5,
+                                  "name": "North America"
+                                }
+                              },
+                              "timezone": "America/Costa_Rica",
+                              "latitude": "9.93333",
+                              "longitude": "-84.08333"
+                            }
+                          ],
+                          "countries": [
+                            {
                               "code": "CR",
                               "name": "Costa Rica",
                               "region": {
                                 "id": 5,
                                 "name": "North America"
                               }
-                            },
-                            "timezone": "America/Costa_Rica",
-                            "latitude": "9.93333",
-                            "longitude": "-84.08333"
-                          }
-                        ],
-                        "countries": [
-                          {
-                            "code": "CR",
-                            "name": "Costa Rica",
-                            "region": {
+                            }
+                          ],
+                          "regions": [
+                            {
                               "id": 5,
                               "name": "North America"
                             }
-                          }
-                        ],
-                        "regions": [
-                          {
-                            "id": 5,
-                            "name": "North America"
-                          }
-                        ],
-                        "has_remote": false,
-                        "published": "2024-07-23T15:25:00Z",
-                        "description": "",
-                        "application_url": "https://leadmagic.io/careers",
-                        "language": "en",
-                        "clearance_required": false,
-                        "salary_min": null,
-                        "salary_max": null,
-                        "salary_currency": null,
-                        "experience_level": "Senior Level"
-                      }
-                    ]
-                  }
+                          ],
+                          "has_remote": false,
+                          "published": "2024-07-23T15:25:00Z",
+                          "description": "",
+                          "application_url": "https://leadmagic.io/careers",
+                          "language": "en",
+                          "clearance_required": false,
+                          "salary_min": null,
+                          "salary_max": null,
+                          "salary_currency": null,
+                          "experience_level": "Senior Level"
+                        }
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -7559,28 +8587,32 @@
                   }
                 }
               },
-              "example": {
-                "titles": {
-                  "include": [
-                    "Engineer"
-                  ],
-                  "vector": false
-                },
-                "occupationTaxonomy": {
-                  "level2": [
-                    "DevOps"
-                  ]
-                },
-                "location": {
-                  "countries": [
-                    "US"
-                  ]
-                },
-                "postedWithin": 30,
-                "limit": 5,
-                "totalMode": "none",
-                "mode": "fast",
-                "autoResolve": true
+              "examples": {
+                "default": {
+                  "value": {
+                    "titles": {
+                      "include": [
+                        "Engineer"
+                      ],
+                      "vector": false
+                    },
+                    "occupationTaxonomy": {
+                      "level2": [
+                        "DevOps"
+                      ]
+                    },
+                    "location": {
+                      "countries": [
+                        "US"
+                      ]
+                    },
+                    "postedWithin": 30,
+                    "limit": 5,
+                    "totalMode": "none",
+                    "mode": "fast",
+                    "autoResolve": true
+                  }
+                }
               }
             }
           }
@@ -7658,34 +8690,38 @@
                     }
                   }
                 },
-                "example": {
-                  "signals": [
-                    {
-                      "title": "Full-Stack Software Engineer",
-                      "company": {
-                        "id": 102413,
-                        "name": "Example Company",
-                        "website_url": "https://example.com"
-                      },
-                      "occupation_taxonomy": {
-                        "level1": {
-                          "id": 1,
-                          "name": "Developer"
-                        },
-                        "level2": {
-                          "id": 20,
-                          "name": "Full-Stack Development"
-                        },
-                        "level3": {
-                          "id": 774,
-                          "name": "Full-stack software engineer"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "signals": [
+                        {
+                          "title": "Full-Stack Software Engineer",
+                          "company": {
+                            "id": 102413,
+                            "name": "Example Company",
+                            "website_url": "https://example.com"
+                          },
+                          "occupation_taxonomy": {
+                            "level1": {
+                              "id": 1,
+                              "name": "Developer"
+                            },
+                            "level2": {
+                              "id": 20,
+                              "name": "Full-Stack Development"
+                            },
+                            "level3": {
+                              "id": 774,
+                              "name": "Full-stack software engineer"
+                            }
+                          }
                         }
-                      }
+                      ],
+                      "total": 3,
+                      "totalMode": "capped",
+                      "credits_consumed": 1
                     }
-                  ],
-                  "total": 3,
-                  "totalMode": "capped",
-                  "credits_consumed": 1
+                  }
                 }
               }
             }
@@ -7766,17 +8802,21 @@
                   }
                 }
               },
-              "example": {
-                "products": [
-                  "jobs",
-                  "company",
-                  "people"
-                ],
-                "sections": [
-                  "coverage",
-                  "top"
-                ],
-                "limit": 10
+              "examples": {
+                "default": {
+                  "value": {
+                    "products": [
+                      "jobs",
+                      "company",
+                      "people"
+                    ],
+                    "sections": [
+                      "coverage",
+                      "top"
+                    ],
+                    "limit": 10
+                  }
+                }
               }
             }
           }
@@ -7873,21 +8913,25 @@
                   }
                 }
               },
-              "example": {
-                "titles": {
-                  "include": [
-                    "Software Engineer"
-                  ],
-                  "vector": false
-                },
-                "location": {
-                  "countries": [
-                    "US"
-                  ]
-                },
-                "limit": 5,
-                "totalMode": "none",
-                "mode": "fast"
+              "examples": {
+                "default": {
+                  "value": {
+                    "titles": {
+                      "include": [
+                        "Software Engineer"
+                      ],
+                      "vector": false
+                    },
+                    "location": {
+                      "countries": [
+                        "US"
+                      ]
+                    },
+                    "limit": 5,
+                    "totalMode": "none",
+                    "mode": "fast"
+                  }
+                }
               }
             }
           }
@@ -8087,33 +9131,35 @@
                     }
                   }
                 },
-                "example": {
-                  "companies": {
-                    "include": [
-                      "leadmagic.io"
-                    ]
-                  },
-                  "tags": {
-                    "include": [
-                      "kubernetes"
-                    ]
-                  },
-                  "occupationTaxonomy": {
-                    "level2": [
-                      "DevOps"
-                    ]
-                  },
-                  "location": {
-                    "countries": [
-                      "US"
-                    ]
-                  },
-                  "titles": {
-                    "include": [
-                      "Site Reliability Engineer"
-                    ]
+                "examples": [
+                  {
+                    "companies": {
+                      "include": [
+                        "leadmagic.io"
+                      ]
+                    },
+                    "tags": {
+                      "include": [
+                        "kubernetes"
+                      ]
+                    },
+                    "occupationTaxonomy": {
+                      "level2": [
+                        "DevOps"
+                      ]
+                    },
+                    "location": {
+                      "countries": [
+                        "US"
+                      ]
+                    },
+                    "titles": {
+                      "include": [
+                        "Site Reliability Engineer"
+                      ]
+                    }
                   }
-                }
+                ]
               }
             }
           }
@@ -8137,26 +9183,38 @@
           {
             "name": "q",
             "in": "query",
-            "example": "leadmagic",
             "schema": {
               "type": "string"
+            },
+            "examples": {
+              "default": {
+                "value": "leadmagic"
+              }
             }
           },
           {
             "name": "domain",
             "in": "query",
-            "example": "leadmagic.io",
             "schema": {
               "type": "string"
+            },
+            "examples": {
+              "default": {
+                "value": "leadmagic.io"
+              }
             }
           },
           {
             "name": "limit",
             "in": "query",
-            "example": 10,
             "schema": {
               "type": "integer",
               "default": 10
+            },
+            "examples": {
+              "default": {
+                "value": 10
+              }
             }
           }
         ],
@@ -8169,15 +9227,19 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "companies": [
-                    {
-                      "id": 102413,
-                      "name": "LeadMagic",
-                      "domain": "leadmagic.io",
-                      "logo_domain": "leadmagic.io"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "companies": [
+                        {
+                          "id": 102413,
+                          "name": "LeadMagic",
+                          "domain": "leadmagic.io",
+                          "logo_domain": "leadmagic.io"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -8197,26 +9259,38 @@
           {
             "name": "q",
             "in": "query",
-            "example": "kuber",
             "schema": {
               "type": "string"
+            },
+            "examples": {
+              "default": {
+                "value": "kuber"
+              }
             }
           },
           {
             "name": "tag_type",
             "in": "query",
-            "example": 2,
             "schema": {
               "type": "integer"
+            },
+            "examples": {
+              "default": {
+                "value": 2
+              }
             }
           },
           {
             "name": "limit",
             "in": "query",
-            "example": 10,
             "schema": {
               "type": "integer",
               "default": 10
+            },
+            "examples": {
+              "default": {
+                "value": 10
+              }
             }
           }
         ],
@@ -8229,24 +9303,28 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "tags": [
-                    {
-                      "id": 482,
-                      "name": "kubernetes",
-                      "tag_type": 2,
-                      "occupation_taxonomy": {
-                        "level1": {
-                          "id": 1,
-                          "name": "Developer"
-                        },
-                        "level2": {
-                          "id": 20,
-                          "name": "DevOps"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "tags": [
+                        {
+                          "id": 482,
+                          "name": "kubernetes",
+                          "tag_type": 2,
+                          "occupation_taxonomy": {
+                            "level1": {
+                              "id": 1,
+                              "name": "Developer"
+                            },
+                            "level2": {
+                              "id": 20,
+                              "name": "DevOps"
+                            }
+                          }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -8266,18 +9344,26 @@
           {
             "name": "q",
             "in": "query",
-            "example": "devops engineer",
             "schema": {
               "type": "string"
+            },
+            "examples": {
+              "default": {
+                "value": "devops engineer"
+              }
             }
           },
           {
             "name": "limit",
             "in": "query",
-            "example": 10,
             "schema": {
               "type": "integer",
               "default": 10
+            },
+            "examples": {
+              "default": {
+                "value": 10
+              }
             }
           }
         ],
@@ -8290,27 +9376,31 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "titles": [
-                    {
-                      "id": 774,
-                      "name": "DevOps Engineer",
-                      "occupation_taxonomy": {
-                        "level1": {
-                          "id": 1,
-                          "name": "Developer"
-                        },
-                        "level2": {
-                          "id": 20,
-                          "name": "DevOps"
-                        },
-                        "level3": {
+                "examples": {
+                  "default": {
+                    "value": {
+                      "titles": [
+                        {
                           "id": 774,
-                          "name": "DevOps Engineer"
+                          "name": "DevOps Engineer",
+                          "occupation_taxonomy": {
+                            "level1": {
+                              "id": 1,
+                              "name": "Developer"
+                            },
+                            "level2": {
+                              "id": 20,
+                              "name": "DevOps"
+                            },
+                            "level3": {
+                              "id": 774,
+                              "name": "DevOps Engineer"
+                            }
+                          }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -8330,15 +9420,18 @@
           {
             "name": "q",
             "in": "query",
-            "example": "DevOps",
             "schema": {
               "type": "string"
+            },
+            "examples": {
+              "default": {
+                "value": "DevOps"
+              }
             }
           },
           {
             "name": "level",
             "in": "query",
-            "example": "level2",
             "schema": {
               "type": "string",
               "enum": [
@@ -8346,15 +9439,24 @@
                 "level2",
                 "level3"
               ]
+            },
+            "examples": {
+              "default": {
+                "value": "level2"
+              }
             }
           },
           {
             "name": "limit",
             "in": "query",
-            "example": 10,
             "schema": {
               "type": "integer",
               "default": 10
+            },
+            "examples": {
+              "default": {
+                "value": 10
+              }
             }
           }
         ],
@@ -8367,25 +9469,29 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "occupation_taxonomy": [
-                    {
-                      "id": 1700834,
-                      "name": ".NET & DevOps",
-                      "type": 2,
-                      "level1": {
-                        "id": 7,
-                        "name": "Engineer"
-                      },
-                      "level2": {
-                        "id": 1700834,
-                        "name": ".NET & DevOps"
-                      },
-                      "level3": null,
-                      "path": "Engineer > .NET & DevOps"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "occupation_taxonomy": [
+                        {
+                          "id": 1700834,
+                          "name": ".NET & DevOps",
+                          "type": 2,
+                          "level1": {
+                            "id": 7,
+                            "name": "Engineer"
+                          },
+                          "level2": {
+                            "id": 1700834,
+                            "name": ".NET & DevOps"
+                          },
+                          "level3": null,
+                          "path": "Engineer > .NET & DevOps"
+                        }
+                      ],
+                      "credits_consumed": 0
                     }
-                  ],
-                  "credits_consumed": 0
+                  }
                 }
               }
             }
@@ -8405,15 +9511,18 @@
           {
             "name": "q",
             "in": "query",
-            "example": "United",
             "schema": {
               "type": "string"
+            },
+            "examples": {
+              "default": {
+                "value": "United"
+              }
             }
           },
           {
             "name": "type",
             "in": "query",
-            "example": "country",
             "schema": {
               "type": "string",
               "enum": [
@@ -8422,15 +9531,24 @@
                 "state",
                 "city"
               ]
+            },
+            "examples": {
+              "default": {
+                "value": "country"
+              }
             }
           },
           {
             "name": "limit",
             "in": "query",
-            "example": 10,
             "schema": {
               "type": "integer",
               "default": 10
+            },
+            "examples": {
+              "default": {
+                "value": 10
+              }
             }
           }
         ],
@@ -8443,19 +9561,23 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "locations": [
-                    {
-                      "id": 840,
-                      "name": "United States",
-                      "type": "country"
-                    },
-                    {
-                      "id": 826,
-                      "name": "United Kingdom",
-                      "type": "country"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "locations": [
+                        {
+                          "id": 840,
+                          "name": "United States",
+                          "type": "country"
+                        },
+                        {
+                          "id": 826,
+                          "name": "United Kingdom",
+                          "type": "country"
+                        }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -8480,60 +9602,64 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "countries": [
-                    {
-                      "id": 840,
-                      "name": "United States"
-                    },
-                    {
-                      "id": 826,
-                      "name": "United Kingdom"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "countries": [
+                        {
+                          "id": 840,
+                          "name": "United States"
+                        },
+                        {
+                          "id": 826,
+                          "name": "United Kingdom"
+                        }
+                      ],
+                      "job_types": [
+                        {
+                          "id": 1,
+                          "name": "Full-time"
+                        },
+                        {
+                          "id": 2,
+                          "name": "Part-time"
+                        },
+                        {
+                          "id": 3,
+                          "name": "Contract"
+                        }
+                      ],
+                      "industries": [
+                        {
+                          "id": 96,
+                          "name": "Software"
+                        }
+                      ],
+                      "company_types": [
+                        {
+                          "id": 1,
+                          "name": "Private"
+                        },
+                        {
+                          "id": 2,
+                          "name": "Public"
+                        }
+                      ],
+                      "seniority": [
+                        {
+                          "id": 1,
+                          "name": "Entry"
+                        },
+                        {
+                          "id": 5,
+                          "name": "VP"
+                        }
+                      ],
+                      "stats": {
+                        "total_jobs_indexed": 12500000,
+                        "freshness_days": 1
+                      }
                     }
-                  ],
-                  "job_types": [
-                    {
-                      "id": 1,
-                      "name": "Full-time"
-                    },
-                    {
-                      "id": 2,
-                      "name": "Part-time"
-                    },
-                    {
-                      "id": 3,
-                      "name": "Contract"
-                    }
-                  ],
-                  "industries": [
-                    {
-                      "id": 96,
-                      "name": "Software"
-                    }
-                  ],
-                  "company_types": [
-                    {
-                      "id": 1,
-                      "name": "Private"
-                    },
-                    {
-                      "id": 2,
-                      "name": "Public"
-                    }
-                  ],
-                  "seniority": [
-                    {
-                      "id": 1,
-                      "name": "Entry"
-                    },
-                    {
-                      "id": 5,
-                      "name": "VP"
-                    }
-                  ],
-                  "stats": {
-                    "total_jobs_indexed": 12500000,
-                    "freshness_days": 1
                   }
                 }
               }
@@ -8554,18 +9680,26 @@
           {
             "name": "q",
             "in": "query",
-            "example": "revenue operations",
             "schema": {
               "type": "string"
+            },
+            "examples": {
+              "default": {
+                "value": "revenue operations"
+              }
             }
           },
           {
             "name": "limit",
             "in": "query",
-            "example": 10,
             "schema": {
               "type": "integer",
               "default": 10
+            },
+            "examples": {
+              "default": {
+                "value": 10
+              }
             }
           }
         ],
@@ -8578,23 +9712,27 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "roles": [
-                    {
-                      "id": 20,
-                      "name": "Revenue Operations",
-                      "occupation_taxonomy": {
-                        "level1": {
-                          "id": 5,
-                          "name": "Operations"
-                        },
-                        "level2": {
+                "examples": {
+                  "default": {
+                    "value": {
+                      "roles": [
+                        {
                           "id": 20,
-                          "name": "Revenue Operations"
+                          "name": "Revenue Operations",
+                          "occupation_taxonomy": {
+                            "level1": {
+                              "id": 5,
+                              "name": "Operations"
+                            },
+                            "level2": {
+                              "id": 20,
+                              "name": "Revenue Operations"
+                            }
+                          }
                         }
-                      }
+                      ]
                     }
-                  ]
+                  }
                 }
               }
             }
@@ -8619,10 +9757,14 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "stats": {
-                    "total_jobs_indexed": 12500000,
-                    "freshness_days": 1
+                "examples": {
+                  "default": {
+                    "value": {
+                      "stats": {
+                        "total_jobs_indexed": 12500000,
+                        "freshness_days": 1
+                      }
+                    }
                   }
                 }
               }
@@ -8648,10 +9790,14 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "stats": {
-                    "total_jobs_indexed": 12500000,
-                    "freshness_days": 1
+                "examples": {
+                  "default": {
+                    "value": {
+                      "stats": {
+                        "total_jobs_indexed": 12500000,
+                        "freshness_days": 1
+                      }
+                    }
                   }
                 }
               }
@@ -8728,19 +9874,23 @@
                   }
                 }
               },
-              "example": {
-                "titles": {
-                  "include": [
-                    "Software Engineer"
-                  ]
-                },
-                "location": {
-                  "countries": [
-                    "US"
-                  ]
-                },
-                "postedWithin": 30,
-                "limit": 500
+              "examples": {
+                "default": {
+                  "value": {
+                    "titles": {
+                      "include": [
+                        "Software Engineer"
+                      ]
+                    },
+                    "location": {
+                      "countries": [
+                        "US"
+                      ]
+                    },
+                    "postedWithin": 30,
+                    "limit": 500
+                  }
+                }
               }
             }
           }
@@ -8754,22 +9904,26 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "jobs": [
-                    {
-                      "id": "j_01hxyz",
-                      "title": "Software Engineer",
-                      "company": {
-                        "name": "Example Corp",
-                        "domain": "example.com"
-                      },
-                      "location": "United States",
-                      "posted_at": "2026-08-01",
-                      "description": "Full posting text…"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "jobs": [
+                        {
+                          "id": "j_01hxyz",
+                          "title": "Software Engineer",
+                          "company": {
+                            "name": "Example Corp",
+                            "domain": "example.com"
+                          },
+                          "location": "United States",
+                          "posted_at": "2026-08-01",
+                          "description": "Full posting text…"
+                        }
+                      ],
+                      "total_returned": 500,
+                      "credits_consumed": 500
                     }
-                  ],
-                  "total_returned": 500,
-                  "credits_consumed": 500
+                  }
                 }
               }
             }
@@ -8803,27 +9957,29 @@
                       }
                     }
                   },
-                  "example": [
-                    {
-                      "id": "AL",
-                      "name": "Albania"
-                    },
-                    {
-                      "id": "DZ",
-                      "name": "Algeria"
-                    },
-                    {
-                      "id": "AD",
-                      "name": "Andorra"
-                    },
-                    {
-                      "id": "AO",
-                      "name": "Angola"
-                    },
-                    {
-                      "id": "AG",
-                      "name": "Antigua and Barbuda"
-                    }
+                  "examples": [
+                    [
+                      {
+                        "id": "AL",
+                        "name": "Albania"
+                      },
+                      {
+                        "id": "DZ",
+                        "name": "Algeria"
+                      },
+                      {
+                        "id": "AD",
+                        "name": "Andorra"
+                      },
+                      {
+                        "id": "AO",
+                        "name": "Angola"
+                      },
+                      {
+                        "id": "AG",
+                        "name": "Antigua and Barbuda"
+                      }
+                    ]
                   ]
                 }
               }
@@ -8865,31 +10021,33 @@
                       }
                     }
                   },
-                  "example": [
-                    {
-                      "id": 1,
-                      "name": "Africa"
-                    },
-                    {
-                      "id": 2,
-                      "name": "Asia/Pacific"
-                    },
-                    {
-                      "id": 3,
-                      "name": "Europe"
-                    },
-                    {
-                      "id": 4,
-                      "name": "Middle East"
-                    },
-                    {
-                      "id": 5,
-                      "name": "North America"
-                    },
-                    {
-                      "id": 6,
-                      "name": "South America"
-                    }
+                  "examples": [
+                    [
+                      {
+                        "id": 1,
+                        "name": "Africa"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Asia/Pacific"
+                      },
+                      {
+                        "id": 3,
+                        "name": "Europe"
+                      },
+                      {
+                        "id": 4,
+                        "name": "Middle East"
+                      },
+                      {
+                        "id": 5,
+                        "name": "North America"
+                      },
+                      {
+                        "id": 6,
+                        "name": "South America"
+                      }
+                    ]
                   ]
                 }
               }
@@ -8931,31 +10089,33 @@
                       }
                     }
                   },
-                  "example": [
-                    {
-                      "id": 1,
-                      "name": "Full Time"
-                    },
-                    {
-                      "id": 2,
-                      "name": "Part Time"
-                    },
-                    {
-                      "id": 3,
-                      "name": "Temporary"
-                    },
-                    {
-                      "id": 4,
-                      "name": "Internship"
-                    },
-                    {
-                      "id": 5,
-                      "name": "Freelance"
-                    },
-                    {
-                      "id": 6,
-                      "name": "Contract"
-                    }
+                  "examples": [
+                    [
+                      {
+                        "id": 1,
+                        "name": "Full Time"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Part Time"
+                      },
+                      {
+                        "id": 3,
+                        "name": "Temporary"
+                      },
+                      {
+                        "id": 4,
+                        "name": "Internship"
+                      },
+                      {
+                        "id": 5,
+                        "name": "Freelance"
+                      },
+                      {
+                        "id": 6,
+                        "name": "Contract"
+                      }
+                    ]
                   ]
                 }
               }
@@ -9037,27 +10197,29 @@
                       }
                     }
                   },
-                  "example": [
-                    {
-                      "id": 22,
-                      "name": "Accounting"
-                    },
-                    {
-                      "id": 318,
-                      "name": "Administration of Justice"
-                    },
-                    {
-                      "id": 297,
-                      "name": "Administrative and Support Services"
-                    },
-                    {
-                      "id": 8,
-                      "name": "Advertising Services"
-                    },
-                    {
-                      "id": 245,
-                      "name": "Agricultural Chemical Manufacturing"
-                    }
+                  "examples": [
+                    [
+                      {
+                        "id": 22,
+                        "name": "Accounting"
+                      },
+                      {
+                        "id": 318,
+                        "name": "Administration of Justice"
+                      },
+                      {
+                        "id": 297,
+                        "name": "Administrative and Support Services"
+                      },
+                      {
+                        "id": 8,
+                        "name": "Advertising Services"
+                      },
+                      {
+                        "id": 245,
+                        "name": "Agricultural Chemical Manufacturing"
+                      }
+                    ]
                   ]
                 }
               }
@@ -9091,20 +10253,26 @@
                     "type": "string",
                     "description": "Company domain name",
                     "default": "leadmagic.io",
-                    "example": "leadmagic.io"
+                    "examples": [
+                      "leadmagic.io"
+                    ]
                   },
                   "company_name": {
                     "type": "string",
                     "description": "Company name",
                     "default": "leadmagic",
-                    "example": "leadmagic"
+                    "examples": [
+                      "leadmagic"
+                    ]
                   },
                   "limit": {
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 100,
                     "description": "Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the credits spent on the request. Omit to return every ad found.",
-                    "example": 10
+                    "examples": [
+                      10
+                    ]
                   }
                 }
               }
@@ -9121,15 +10289,21 @@
                   "properties": {
                     "message": {
                       "type": "string",
-                      "example": "Google Ads retrieved successfully"
+                      "examples": [
+                        "Google Ads retrieved successfully"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
-                      "example": 2
+                      "examples": [
+                        2
+                      ]
                     },
                     "ads_count": {
                       "type": "integer",
-                      "example": 2
+                      "examples": [
+                        2
+                      ]
                     },
                     "ads": {
                       "type": "array",
@@ -9138,15 +10312,21 @@
                         "properties": {
                           "advertiser_id": {
                             "type": "string",
-                            "example": "123456"
+                            "examples": [
+                              "123456"
+                            ]
                           },
                           "creative_id": {
                             "type": "string",
-                            "example": "789012"
+                            "examples": [
+                              "789012"
+                            ]
                           },
                           "original_url": {
                             "type": "string",
-                            "example": "https://www.example.com/ad"
+                            "examples": [
+                              "https://www.example.com/ad"
+                            ]
                           },
                           "variants": {
                             "type": "array",
@@ -9155,78 +10335,94 @@
                               "properties": {
                                 "content": {
                                   "type": "string",
-                                  "example": "<img src=\"https://tpc.googlesyndication.com/archive/simgad/6399633577457746150\" height=\"173\" width=\"380\">"
+                                  "examples": [
+                                    "<img src=\"https://tpc.googlesyndication.com/archive/simgad/6399633577457746150\" height=\"173\" width=\"380\">"
+                                  ]
                                 },
                                 "height": {
                                   "type": "integer",
                                   "nullable": true,
-                                  "example": 173
+                                  "examples": [
+                                    173
+                                  ]
                                 },
                                 "width": {
                                   "type": "integer",
                                   "nullable": true,
-                                  "example": 380
+                                  "examples": [
+                                    380
+                                  ]
                                 }
                               }
                             }
                           },
                           "start": {
                             "type": "string",
-                            "example": "2023-01-01"
+                            "examples": [
+                              "2023-01-01"
+                            ]
                           },
                           "last_seen": {
                             "type": "string",
-                            "example": "2023-12-31"
+                            "examples": [
+                              "2023-12-31"
+                            ]
                           },
                           "advertiser_name": {
                             "type": "string",
-                            "example": "Example Company"
+                            "examples": [
+                              "Example Company"
+                            ]
                           },
                           "format": {
                             "type": "string",
-                            "example": "Text"
+                            "examples": [
+                              "Text"
+                            ]
                           }
                         }
                       }
                     }
                   },
-                  "example": {
-                    "ads": [
-                      {
-                        "advertiser_id": "AR14106062795078369281",
-                        "creative_id": "CR14003695067076755457",
-                        "original_url": "https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR14003695067076755457?region=anywhere",
-                        "variants": [
-                          {
-                            "content": "<img src=\"https://tpc.googlesyndication.com/archive/simgad/6399633577457746150\" height=\"173\" width=\"380\">",
-                            "height": 173,
-                            "width": 380
-                          }
-                        ],
-                        "start": "2024-07-03",
-                        "last_seen": "2025-03-06",
-                        "advertiser_name": "LeadMagic Inc",
-                        "format": "Text"
-                      },
-                      {
-                        "advertiser_id": "AR14106062795078369281",
-                        "creative_id": "CR16065875974473908225",
-                        "original_url": "https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR16065875974473908225?region=anywhere",
-                        "variants": [
-                          {
-                            "content": "<img src=\"https://tpc.googlesyndication.com/archive/simgad/14075255850026292628\" height=\"173\" width=\"380\">",
-                            "height": 173,
-                            "width": 380
-                          }
-                        ],
-                        "start": "2025-02-04",
-                        "last_seen": "2025-03-06",
-                        "advertiser_name": "LeadMagic Inc",
-                        "format": "Text"
-                      }
-                    ],
-                    "credits_consumed": 2
-                  }
+                  "examples": [
+                    {
+                      "ads": [
+                        {
+                          "advertiser_id": "AR14106062795078369281",
+                          "creative_id": "CR14003695067076755457",
+                          "original_url": "https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR14003695067076755457?region=anywhere",
+                          "variants": [
+                            {
+                              "content": "<img src=\"https://tpc.googlesyndication.com/archive/simgad/6399633577457746150\" height=\"173\" width=\"380\">",
+                              "height": 173,
+                              "width": 380
+                            }
+                          ],
+                          "start": "2024-07-03",
+                          "last_seen": "2025-03-06",
+                          "advertiser_name": "LeadMagic Inc",
+                          "format": "Text"
+                        },
+                        {
+                          "advertiser_id": "AR14106062795078369281",
+                          "creative_id": "CR16065875974473908225",
+                          "original_url": "https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR16065875974473908225?region=anywhere",
+                          "variants": [
+                            {
+                              "content": "<img src=\"https://tpc.googlesyndication.com/archive/simgad/14075255850026292628\" height=\"173\" width=\"380\">",
+                              "height": 173,
+                              "width": 380
+                            }
+                          ],
+                          "start": "2025-02-04",
+                          "last_seen": "2025-03-06",
+                          "advertiser_name": "LeadMagic Inc",
+                          "format": "Text"
+                        }
+                      ],
+                      "credits_consumed": 2
+                    }
+                  ]
                 }
               }
             }
@@ -9268,20 +10464,26 @@
                     "type": "string",
                     "description": "Company domain name",
                     "default": "leadmagic.io",
-                    "example": "leadmagic.io"
+                    "examples": [
+                      "leadmagic.io"
+                    ]
                   },
                   "company_name": {
                     "type": "string",
                     "description": "Company name",
                     "default": "leadmagic",
-                    "example": "leadmagic"
+                    "examples": [
+                      "leadmagic"
+                    ]
                   },
                   "limit": {
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 100,
                     "description": "Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the credits spent on the request. Omit to return every ad found.",
-                    "example": 10
+                    "examples": [
+                      10
+                    ]
                   }
                 }
               }
@@ -9298,15 +10500,21 @@
                   "properties": {
                     "message": {
                       "type": "string",
-                      "example": "Meta Ads retrieved successfully"
+                      "examples": [
+                        "Meta Ads retrieved successfully"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
-                      "example": 1
+                      "examples": [
+                        1
+                      ]
                     },
                     "ads_count": {
                       "type": "integer",
-                      "example": 1
+                      "examples": [
+                        1
+                      ]
                     },
                     "ads": {
                       "type": "array",
@@ -9316,144 +10524,146 @@
                       }
                     }
                   },
-                  "example": {
-                    "message": "Meta Ads retrieved successfully",
-                    "credits_consumed": 1,
-                    "ads_count": 1,
-                    "ads": [
-                      {
-                        "adid": "0",
-                        "adArchiveID": "618153827656899",
-                        "archiveTypes": [],
-                        "categories": [
-                          0
-                        ],
-                        "containsDigitallyCreatedMedia": false,
-                        "containsSensitiveContent": false,
-                        "collationCount": 1,
-                        "collationID": 1015196963820298,
-                        "currency": "",
-                        "endDate": 1741248000,
-                        "entityType": "person_profile",
-                        "fevInfo": null,
-                        "finServAdData": {
-                          "is_deemed_finserv": false,
-                          "is_limited_delivery": false
-                        },
-                        "gatedType": "eligible",
-                        "hasUserReported": false,
-                        "hiddenSafetyData": false,
-                        "hideDataStatus": "NONE",
-                        "impressionsWithIndex": {
-                          "impressionsText": null,
-                          "impressionsIndex": -1
-                        },
-                        "isAAAEligible": true,
-                        "isAdAccountActioned": false,
-                        "isActive": true,
-                        "isProfilePage": false,
-                        "pageID": "105549201674375",
-                        "pageInfo": null,
-                        "pageIsDeleted": false,
-                        "pageName": "Lykkedal Retreat",
-                        "politicalCountries": [],
-                        "reachEstimate": null,
-                        "regionalRegulationData": {
-                          "finserv": {
+                  "examples": [
+                    {
+                      "message": "Meta Ads retrieved successfully",
+                      "credits_consumed": 1,
+                      "ads_count": 1,
+                      "ads": [
+                        {
+                          "adid": "0",
+                          "adArchiveID": "618153827656899",
+                          "archiveTypes": [],
+                          "categories": [
+                            0
+                          ],
+                          "containsDigitallyCreatedMedia": false,
+                          "containsSensitiveContent": false,
+                          "collationCount": 1,
+                          "collationID": 1015196963820298,
+                          "currency": "",
+                          "endDate": 1741248000,
+                          "entityType": "person_profile",
+                          "fevInfo": null,
+                          "finServAdData": {
                             "is_deemed_finserv": false,
                             "is_limited_delivery": false
                           },
-                          "tw_anti_scam": {
-                            "is_limited_delivery": false
-                          }
-                        },
-                        "reportCount": null,
-                        "snapshot": {
-                          "ad_creative_id": 1159245568945589,
-                          "cards": [],
-                          "body_translations": {},
-                          "byline": null,
-                          "caption": "ezme.io",
-                          "cta_text": "Buy tickets",
-                          "dynamic_item_flags": {},
-                          "dynamic_versions": null,
-                          "edited_snapshots": [],
-                          "effective_authorization_category": "NONE",
-                          "event": {
-                            "event_promoted_type": "external_tickets",
-                            "event_start_timestamp": 1742130000,
-                            "event_end_timestamp": 1742137200,
-                            "event_location": "Dalvej 5, Helsinge",
-                            "event_timezone": "Europe/Copenhagen"
+                          "gatedType": "eligible",
+                          "hasUserReported": false,
+                          "hiddenSafetyData": false,
+                          "hideDataStatus": "NONE",
+                          "impressionsWithIndex": {
+                            "impressionsText": null,
+                            "impressionsIndex": -1
                           },
-                          "extra_images": [],
-                          "extra_links": [],
-                          "extra_texts": [],
-                          "extra_videos": [],
-                          "instagram_shopping_products": [],
-                          "display_format": "event",
-                          "title": "Yin Yoga & Yoga Nidra til LeadMagic",
-                          "link_description": "Dalvej 5, Helsinge",
-                          "link_url": "https://ezme.io/c/xHa/3KPb",
-                          "page_welcome_message": null,
-                          "images": [
-                            {
-                              "original_image_url": "https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/481787314_4001422706744378_5754827939445302437_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=oLiF-cU0WxgQ7kNvgEM6GgD&_nc_oc=AdgH2C1dxKtFX8-Nb0xC8YJj9RAGxYUVx4s72-vlBMvSF8NqRSDRTgLtQ49bxn4GKvU&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYFCcwS06k5-Zs4REiVNPyDBnDiH2m3ry6__l8b-xYVnNw&oe=67D010D7",
-                              "resized_image_url": "https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/482055202_1183219813458252_5286390622516633466_n.jpg?stp=dst-jpg_s600x600_tt6&_nc_cat=106&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=UpMVtSZb0FoQ7kNvgGYCYSO&_nc_oc=AdioNK9N0BC6jFliPpZBoCB7q8c6RxzPm1sjxYyWN8gW1fEzj5ort06-PEXPS9aRQtY&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYET5FXrho887m4dU5OxwmVKM8nNNYMDyPzbcrFDRHPNkQ&oe=67CFD900",
-                              "watermarked_resized_image_url": "",
-                              "image_crops": {}
-                            }
-                          ],
-                          "videos": [],
-                          "creation_time": 1741291804,
-                          "page_id": 105549201674375,
-                          "page_name": "Lykkedal Retreat",
-                          "page_profile_picture_url": "https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482021866_1335378004273354_6611332374691484765_n.jpg?stp=dst-jpg_s60x60_tt6&_nc_cat=107&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=9OkGTrz7rR0Q7kNvgG57RTD&_nc_oc=AdhR7nxSqcwLeXf4E6zMven92LUORzNF9f6UG5HdXPkNcCJwnCvuJsEFIkd2qEkf1mc&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYHvvv7TVyYBBZbUWdFtsMMF1Zw19HFrCguT8PizFkDG-w&oe=67CFF9CB",
-                          "page_categories": {
-                            "1215982301785137": "Meditation Center"
-                          },
-                          "page_entity_type": "person_profile",
-                          "page_is_profile_page": false,
-                          "instagram_actor_name": "🔆 ET LIV I BALANCE 🔆",
-                          "instagram_profile_pic_url": "https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482221977_1473904650233662_1812261223336634635_n.jpg?_nc_cat=102&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=pt8glJ939ioQ7kNvgEhv2uO&_nc_oc=Adi7fFY9dROfonTLhbM1HQhTr-sBDcj7xGQeKttehNVcjEKjKkBqWDm69xB9k8lQLk4&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYH7uq0g9Ag0DFiPvgZdXyt_1LXYO8ZrWuCq--rMrhWQfw&oe=67CFE12C",
-                          "instagram_url": "",
-                          "instagram_handle": "",
-                          "is_reshared": false,
-                          "version": 3,
-                          "body": {
-                            "context": {},
-                            "markup": {
-                              "__html": "🌿 Yin Yoga &amp; LeadMagic Meditation i jurten på Lykkedal Retreat 🌿<br /> <br /> Trænger du til en dyb pause, hvor krop og sind får lov at give slip og finde ro? ✨<br /> <br /> 🧘‍♀️ Yin Yoga er en blid, meditativ yogaform, der arbejder med kroppens bindevæv, led og energibaner gennem lange, rolige stræk. Stillingerne holdes i flere minutter, så kroppen får tid til at slippe spændinger og finde dybere afslapning. Alle kan være med – uanset erfaring.<br /> <br /> 🎶 LeadMagic Meditation fordyber din afslapning gennem dybe, vibrerende lyde, der beroliger nervesystemet og inviterer sindet til at give slip. Mange oplever en følelse af lethed, ro og fornyet energi efter en meditation.<br /> <br /> 📅 Dato: Søndag d. 16. marts<br /> ⏰ Tid: Kl. 14:00 - 16:00<br /> 📍 Sted: Lykkedal Retreat, Dalvej 5, Helsinge<br />       Pris: 275 kr.<br /> <br /> 🌿 Efter workshoppen byder vi på økologisk urtete og lækre snacks i vores hyggelige skovcafé. Her kan du nyde en stille stund og mærke effekten af din praksis. Tag en mindful gåtur i naturen og hils på dyrene – en smuk måde at afslutte dagen på.<br /> <br /> 🔔 Alle er velkomne – uanset erfaring! 🔔<br /> <br /> 💚 Tilmelding &amp; info:<br /> 📩 Send besked til Natassia på info&#064;lykkedalretreat.dk eller tlf. 2390 7473<br /> <br /> 🌾 Lykkedal Retreat – en perle i Nordsjællands natur 🌾<br /> Her finder du åbne marker med heste, høje træer og den smukke gamle Pibe Mølle. Workshoppen afholdes i den stemningsfulde jurt/rundsal, hvor du kan fordybe dig i ro og nærvær.<br /> <br /> ✨ Tidligere deltagere siger:<br /> 🌟 &quot;Lykkedal er et åndehul i naturen&quot;<br /> 🌟 &quot;Jeg kom hjem i mig selv&quot;<br /> 🌟 &quot;Jeg havde glemt, hvor meget jeg savner naturen&quot;<br /> <br /> 📩 Book din plads i dag – vi glæder os til at byde dig velkommen!<br /> <br /> #YinYoga #LeadMagicMeditation #LykkedalRetreat #IndreRo #NaturligBalance #Mindfulness #Selvforkælelse #TidTilDigSelv"
+                          "isAAAEligible": true,
+                          "isAdAccountActioned": false,
+                          "isActive": true,
+                          "isProfilePage": false,
+                          "pageID": "105549201674375",
+                          "pageInfo": null,
+                          "pageIsDeleted": false,
+                          "pageName": "Lykkedal Retreat",
+                          "politicalCountries": [],
+                          "reachEstimate": null,
+                          "regionalRegulationData": {
+                            "finserv": {
+                              "is_deemed_finserv": false,
+                              "is_limited_delivery": false
                             },
-                            "callerHash": "c339298372ed2a9ebf3ad02f136b05d2"
+                            "tw_anti_scam": {
+                              "is_limited_delivery": false
+                            }
                           },
-                          "brazil_tax_id": null,
-                          "branded_content": null,
-                          "current_page_name": "Lykkedal Retreat",
-                          "disclaimer_label": null,
-                          "page_like_count": 1198,
-                          "page_profile_uri": "https://facebook.com/LykkedalRetreat",
-                          "page_is_deleted": false,
-                          "root_reshared_post": null,
-                          "cta_type": "BUY_TICKETS",
-                          "additional_info": null,
-                          "ec_certificates": null,
-                          "country_iso_code": null,
-                          "instagram_branded_content": null
-                        },
-                        "spend": null,
-                        "startDate": 1741248000,
-                        "stateMediaRunLabel": null,
-                        "publisherPlatform": [
-                          "facebook",
-                          "instagram"
-                        ],
-                        "menuItems": [],
-                        "targetedOrReachedCountries": [],
-                        "totalActiveTime": 7915
-                      }
-                    ]
-                  }
+                          "reportCount": null,
+                          "snapshot": {
+                            "ad_creative_id": 1159245568945589,
+                            "cards": [],
+                            "body_translations": {},
+                            "byline": null,
+                            "caption": "ezme.io",
+                            "cta_text": "Buy tickets",
+                            "dynamic_item_flags": {},
+                            "dynamic_versions": null,
+                            "edited_snapshots": [],
+                            "effective_authorization_category": "NONE",
+                            "event": {
+                              "event_promoted_type": "external_tickets",
+                              "event_start_timestamp": 1742130000,
+                              "event_end_timestamp": 1742137200,
+                              "event_location": "Dalvej 5, Helsinge",
+                              "event_timezone": "Europe/Copenhagen"
+                            },
+                            "extra_images": [],
+                            "extra_links": [],
+                            "extra_texts": [],
+                            "extra_videos": [],
+                            "instagram_shopping_products": [],
+                            "display_format": "event",
+                            "title": "Yin Yoga & Yoga Nidra til LeadMagic",
+                            "link_description": "Dalvej 5, Helsinge",
+                            "link_url": "https://ezme.io/c/xHa/3KPb",
+                            "page_welcome_message": null,
+                            "images": [
+                              {
+                                "original_image_url": "https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/481787314_4001422706744378_5754827939445302437_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=oLiF-cU0WxgQ7kNvgEM6GgD&_nc_oc=AdgH2C1dxKtFX8-Nb0xC8YJj9RAGxYUVx4s72-vlBMvSF8NqRSDRTgLtQ49bxn4GKvU&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYFCcwS06k5-Zs4REiVNPyDBnDiH2m3ry6__l8b-xYVnNw&oe=67D010D7",
+                                "resized_image_url": "https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/482055202_1183219813458252_5286390622516633466_n.jpg?stp=dst-jpg_s600x600_tt6&_nc_cat=106&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=UpMVtSZb0FoQ7kNvgGYCYSO&_nc_oc=AdioNK9N0BC6jFliPpZBoCB7q8c6RxzPm1sjxYyWN8gW1fEzj5ort06-PEXPS9aRQtY&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYET5FXrho887m4dU5OxwmVKM8nNNYMDyPzbcrFDRHPNkQ&oe=67CFD900",
+                                "watermarked_resized_image_url": "",
+                                "image_crops": {}
+                              }
+                            ],
+                            "videos": [],
+                            "creation_time": 1741291804,
+                            "page_id": 105549201674375,
+                            "page_name": "Lykkedal Retreat",
+                            "page_profile_picture_url": "https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482021866_1335378004273354_6611332374691484765_n.jpg?stp=dst-jpg_s60x60_tt6&_nc_cat=107&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=9OkGTrz7rR0Q7kNvgG57RTD&_nc_oc=AdhR7nxSqcwLeXf4E6zMven92LUORzNF9f6UG5HdXPkNcCJwnCvuJsEFIkd2qEkf1mc&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYHvvv7TVyYBBZbUWdFtsMMF1Zw19HFrCguT8PizFkDG-w&oe=67CFF9CB",
+                            "page_categories": {
+                              "1215982301785137": "Meditation Center"
+                            },
+                            "page_entity_type": "person_profile",
+                            "page_is_profile_page": false,
+                            "instagram_actor_name": "🔆 ET LIV I BALANCE 🔆",
+                            "instagram_profile_pic_url": "https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482221977_1473904650233662_1812261223336634635_n.jpg?_nc_cat=102&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=pt8glJ939ioQ7kNvgEhv2uO&_nc_oc=Adi7fFY9dROfonTLhbM1HQhTr-sBDcj7xGQeKttehNVcjEKjKkBqWDm69xB9k8lQLk4&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYH7uq0g9Ag0DFiPvgZdXyt_1LXYO8ZrWuCq--rMrhWQfw&oe=67CFE12C",
+                            "instagram_url": "",
+                            "instagram_handle": "",
+                            "is_reshared": false,
+                            "version": 3,
+                            "body": {
+                              "context": {},
+                              "markup": {
+                                "__html": "🌿 Yin Yoga &amp; LeadMagic Meditation i jurten på Lykkedal Retreat 🌿<br /> <br /> Trænger du til en dyb pause, hvor krop og sind får lov at give slip og finde ro? ✨<br /> <br /> 🧘‍♀️ Yin Yoga er en blid, meditativ yogaform, der arbejder med kroppens bindevæv, led og energibaner gennem lange, rolige stræk. Stillingerne holdes i flere minutter, så kroppen får tid til at slippe spændinger og finde dybere afslapning. Alle kan være med – uanset erfaring.<br /> <br /> 🎶 LeadMagic Meditation fordyber din afslapning gennem dybe, vibrerende lyde, der beroliger nervesystemet og inviterer sindet til at give slip. Mange oplever en følelse af lethed, ro og fornyet energi efter en meditation.<br /> <br /> 📅 Dato: Søndag d. 16. marts<br /> ⏰ Tid: Kl. 14:00 - 16:00<br /> 📍 Sted: Lykkedal Retreat, Dalvej 5, Helsinge<br />       Pris: 275 kr.<br /> <br /> 🌿 Efter workshoppen byder vi på økologisk urtete og lækre snacks i vores hyggelige skovcafé. Her kan du nyde en stille stund og mærke effekten af din praksis. Tag en mindful gåtur i naturen og hils på dyrene – en smuk måde at afslutte dagen på.<br /> <br /> 🔔 Alle er velkomne – uanset erfaring! 🔔<br /> <br /> 💚 Tilmelding &amp; info:<br /> 📩 Send besked til Natassia på info&#064;lykkedalretreat.dk eller tlf. 2390 7473<br /> <br /> 🌾 Lykkedal Retreat – en perle i Nordsjællands natur 🌾<br /> Her finder du åbne marker med heste, høje træer og den smukke gamle Pibe Mølle. Workshoppen afholdes i den stemningsfulde jurt/rundsal, hvor du kan fordybe dig i ro og nærvær.<br /> <br /> ✨ Tidligere deltagere siger:<br /> 🌟 &quot;Lykkedal er et åndehul i naturen&quot;<br /> 🌟 &quot;Jeg kom hjem i mig selv&quot;<br /> 🌟 &quot;Jeg havde glemt, hvor meget jeg savner naturen&quot;<br /> <br /> 📩 Book din plads i dag – vi glæder os til at byde dig velkommen!<br /> <br /> #YinYoga #LeadMagicMeditation #LykkedalRetreat #IndreRo #NaturligBalance #Mindfulness #Selvforkælelse #TidTilDigSelv"
+                              },
+                              "callerHash": "c339298372ed2a9ebf3ad02f136b05d2"
+                            },
+                            "brazil_tax_id": null,
+                            "branded_content": null,
+                            "current_page_name": "Lykkedal Retreat",
+                            "disclaimer_label": null,
+                            "page_like_count": 1198,
+                            "page_profile_uri": "https://facebook.com/LykkedalRetreat",
+                            "page_is_deleted": false,
+                            "root_reshared_post": null,
+                            "cta_type": "BUY_TICKETS",
+                            "additional_info": null,
+                            "ec_certificates": null,
+                            "country_iso_code": null,
+                            "instagram_branded_content": null
+                          },
+                          "spend": null,
+                          "startDate": 1741248000,
+                          "stateMediaRunLabel": null,
+                          "publisherPlatform": [
+                            "facebook",
+                            "instagram"
+                          ],
+                          "menuItems": [],
+                          "targetedOrReachedCountries": [],
+                          "totalActiveTime": 7915
+                        }
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -9495,20 +10705,26 @@
                     "type": "string",
                     "description": "Company domain name",
                     "default": "gong.io",
-                    "example": "gong.io"
+                    "examples": [
+                      "gong.io"
+                    ]
                   },
                   "company_name": {
                     "type": "string",
                     "description": "Company name",
                     "default": "gong",
-                    "example": "gong"
+                    "examples": [
+                      "gong"
+                    ]
                   },
                   "limit": {
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 100,
                     "description": "Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the per-ad credits spent on the request; the 1 base credit per search still applies. Omit to return every ad found.",
-                    "example": 10
+                    "examples": [
+                      10
+                    ]
                   }
                 }
               }
@@ -9525,15 +10741,21 @@
                   "properties": {
                     "message": {
                       "type": "string",
-                      "example": "B2B ads found for the given company."
+                      "examples": [
+                        "B2B ads found for the given company."
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
-                      "example": 25
+                      "examples": [
+                        25
+                      ]
                     },
                     "ads_count": {
                       "type": "integer",
-                      "example": 24
+                      "examples": [
+                        24
+                      ]
                     },
                     "company": {
                       "type": "object",
@@ -9641,36 +10863,38 @@
                       }
                     }
                   },
-                  "example": {
-                    "message": "B2B ads found for the given company.",
-                    "credits_consumed": 25,
-                    "ads_count": 24,
-                    "company": {
-                      "name": "gong",
-                      "domain": "gong.io",
-                      "industry": "computer software",
-                      "company_size": "1001-5000",
-                      "linkedin_url": "/company/gong-io",
-                      "logo_url": "https://logo.leadmagic.io/gong.io",
-                      "city": "san francisco",
-                      "state": "california",
-                      "country": "united states"
-                    },
-                    "ads": [
-                      {
-                        "ad_id": "1436673673",
-                        "headline": null,
-                        "description": "See how revenue teams use Gong to win more deals.",
-                        "content": "See how revenue teams use Gong to win more deals.",
-                        "link": "1436673673",
-                        "ad_url": "/ad-library/detail/1436673673",
-                        "ad_type": "Document Ad",
-                        "creative_type": "SPONSORED_UPDATE_NATIVE_DOCUMENT",
-                        "advertiser": "Gong",
-                        "advertiser_linkedin_url": "/company/gong-io"
-                      }
-                    ]
-                  }
+                  "examples": [
+                    {
+                      "message": "B2B ads found for the given company.",
+                      "credits_consumed": 25,
+                      "ads_count": 24,
+                      "company": {
+                        "name": "gong",
+                        "domain": "gong.io",
+                        "industry": "computer software",
+                        "company_size": "1001-5000",
+                        "linkedin_url": "/company/gong-io",
+                        "logo_url": "https://logo.leadmagic.io/gong.io",
+                        "city": "san francisco",
+                        "state": "california",
+                        "country": "united states"
+                      },
+                      "ads": [
+                        {
+                          "ad_id": "1436673673",
+                          "headline": null,
+                          "description": "See how revenue teams use Gong to win more deals.",
+                          "content": "See how revenue teams use Gong to win more deals.",
+                          "link": "1436673673",
+                          "ad_url": "/ad-library/detail/1436673673",
+                          "ad_type": "Document Ad",
+                          "creative_type": "SPONSORED_UPDATE_NATIVE_DOCUMENT",
+                          "advertiser": "Gong",
+                          "advertiser_linkedin_url": "/company/gong-io"
+                        }
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -9711,7 +10935,9 @@
                   "ad_url": {
                     "type": "string",
                     "description": "B2B ad library URL, path (/ad-library/detail/{id}), or numeric ad ID",
-                    "example": "1436673673"
+                    "examples": [
+                      "1436673673"
+                    ]
                   }
                 },
                 "required": [
@@ -9731,11 +10957,15 @@
                   "properties": {
                     "message": {
                       "type": "string",
-                      "example": "Ad details retrieved successfully"
+                      "examples": [
+                        "Ad details retrieved successfully"
+                      ]
                     },
                     "credits_consumed": {
                       "type": "number",
-                      "example": 2
+                      "examples": [
+                        2
+                      ]
                     },
                     "company": {
                       "type": "object",
@@ -9863,25 +11093,27 @@
                       }
                     }
                   },
-                  "example": {
-                    "message": "Ad details retrieved successfully",
-                    "credits_consumed": 2,
-                    "company": {
-                      "name": "Gong",
-                      "linkedin_url": "/company/gong-io"
-                    },
-                    "ad_details": {
-                      "ad_id": "1436673673",
-                      "content": "See how revenue teams use Gong to win more deals.",
-                      "link": "1436673673",
-                      "ad_url": "/ad-library/detail/1436673673",
-                      "ad_type": "Document Ad",
-                      "creative_type": "SPONSORED_UPDATE_NATIVE_DOCUMENT",
-                      "advertiser": "Gong",
-                      "advertiser_linkedin_url": "/company/gong-io",
-                      "raw": {}
+                  "examples": [
+                    {
+                      "message": "Ad details retrieved successfully",
+                      "credits_consumed": 2,
+                      "company": {
+                        "name": "Gong",
+                        "linkedin_url": "/company/gong-io"
+                      },
+                      "ad_details": {
+                        "ad_id": "1436673673",
+                        "content": "See how revenue teams use Gong to win more deals.",
+                        "link": "1436673673",
+                        "ad_url": "/ad-library/detail/1436673673",
+                        "ad_type": "Document Ad",
+                        "creative_type": "SPONSORED_UPDATE_NATIVE_DOCUMENT",
+                        "advertiser": "Gong",
+                        "advertiser_linkedin_url": "/company/gong-io",
+                        "raw": {}
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -9922,19 +11154,23 @@
               "schema": {
                 "$ref": "#/components/schemas/BulkSubmissionRequest"
               },
-              "example": {
-                "product": "email_finder",
-                "rows": [
-                  {
-                    "profile_url": "https://example.com/in/jane-doe",
-                    "company_name": "LeadMagic"
+              "examples": {
+                "default": {
+                  "value": {
+                    "product": "email_finder",
+                    "rows": [
+                      {
+                        "profile_url": "https://example.com/in/jane-doe",
+                        "company_name": "LeadMagic"
+                      }
+                    ],
+                    "callback": {
+                      "url": "https://hooks.example.com/leadmagic/bulk",
+                      "events": [
+                        "completed"
+                      ]
+                    }
                   }
-                ],
-                "callback": {
-                  "url": "https://hooks.example.com/leadmagic/bulk",
-                  "events": [
-                    "completed"
-                  ]
                 }
               }
             }
@@ -10069,7 +11305,11 @@
               "type": "string",
               "format": "uuid"
             },
-            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            "examples": {
+              "default": {
+                "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              }
+            }
           }
         ],
         "responses": {
@@ -10080,45 +11320,49 @@
                 "schema": {
                   "$ref": "#/components/schemas/JobDetailResponse"
                 },
-                "example": {
-                  "job_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                  "status": "processing",
-                  "products": [
-                    "email_finder"
-                  ],
-                  "submission_product": "email_finder",
-                  "submission_endpoint": null,
-                  "execution_mode": null,
-                  "total_rows": 5000,
-                  "processed_items": 2125,
-                  "succeeded_items": 2080,
-                  "failed_items": 45,
-                  "skipped_items": 0,
-                  "total_credits_consumed": "2080.00",
-                  "total_duration_ms": null,
-                  "created_at": "2026-07-09T14:30:00.000Z",
-                  "started_at": "2026-07-09T14:30:05.000Z",
-                  "completed_at": null,
-                  "last_progress_at": "2026-07-09T14:35:12.000Z",
-                  "file_name": "q3-contacts.csv",
-                  "callback_url": "https://hooks.example.com/leadmagic/bulk",
-                  "callback_event": "completed",
-                  "priority": 0,
-                  "output_transform": null,
-                  "links": {
-                    "statusUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890?token=...",
-                    "streamUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stream?token=...",
-                    "wsUrl": "wss://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/ws?token=...",
-                    "resultsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/results?token=...",
-                    "rowsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rows?token=...",
-                    "errorsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/errors?token=...",
-                    "eventsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events?token=...",
-                    "eventsExportUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events/export?token=...",
-                    "logsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/logs?token=...",
-                    "downloadUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/download?token=...",
-                    "progressUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/progress?token=...",
-                    "token": "prt_abc123...",
-                    "exp": 1752259200
+                "examples": {
+                  "default": {
+                    "value": {
+                      "job_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "status": "processing",
+                      "products": [
+                        "email_finder"
+                      ],
+                      "submission_product": "email_finder",
+                      "submission_endpoint": null,
+                      "execution_mode": null,
+                      "total_rows": 5000,
+                      "processed_items": 2125,
+                      "succeeded_items": 2080,
+                      "failed_items": 45,
+                      "skipped_items": 0,
+                      "total_credits_consumed": "2080.00",
+                      "total_duration_ms": null,
+                      "created_at": "2026-07-09T14:30:00.000Z",
+                      "started_at": "2026-07-09T14:30:05.000Z",
+                      "completed_at": null,
+                      "last_progress_at": "2026-07-09T14:35:12.000Z",
+                      "file_name": "q3-contacts.csv",
+                      "callback_url": "https://hooks.example.com/leadmagic/bulk",
+                      "callback_event": "completed",
+                      "priority": 0,
+                      "output_transform": null,
+                      "links": {
+                        "statusUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890?token=...",
+                        "streamUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stream?token=...",
+                        "wsUrl": "wss://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/ws?token=...",
+                        "resultsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/results?token=...",
+                        "rowsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rows?token=...",
+                        "errorsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/errors?token=...",
+                        "eventsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events?token=...",
+                        "eventsExportUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events/export?token=...",
+                        "logsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/logs?token=...",
+                        "downloadUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/download?token=...",
+                        "progressUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/progress?token=...",
+                        "token": "prt_abc123...",
+                        "exp": 1752259200
+                      }
+                    }
                   }
                 }
               }
@@ -10157,7 +11401,11 @@
               "type": "string",
               "format": "uuid"
             },
-            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            "examples": {
+              "default": {
+                "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              }
+            }
           }
         ],
         "requestBody": {
@@ -10179,8 +11427,12 @@
                   }
                 }
               },
-              "example": {
-                "action": "reject"
+              "examples": {
+                "default": {
+                  "value": {
+                    "action": "reject"
+                  }
+                }
               }
             }
           }
@@ -10422,9 +11674,11 @@
                     "items": {
                       "type": "string"
                     },
-                    "example": [
-                      "plumber",
-                      "hvac contractor"
+                    "examples": [
+                      [
+                        "plumber",
+                        "hvac contractor"
+                      ]
                     ]
                   },
                   "cities": {
@@ -10433,9 +11687,11 @@
                     "items": {
                       "type": "string"
                     },
-                    "example": [
-                      "Austin",
-                      "Dallas"
+                    "examples": [
+                      [
+                        "Austin",
+                        "Dallas"
+                      ]
                     ]
                   },
                   "countryCodes": {
@@ -10444,15 +11700,19 @@
                     "items": {
                       "type": "string"
                     },
-                    "example": [
-                      "US",
-                      "US"
+                    "examples": [
+                      [
+                        "US",
+                        "US"
+                      ]
                     ]
                   },
                   "fileName": {
                     "type": "string",
                     "description": "Label for the resulting job, shown in the dashboard.",
-                    "example": "texas-trades"
+                    "examples": [
+                      "texas-trades"
+                    ]
                   },
                   "magicKey": {
                     "type": "string",
@@ -10521,12 +11781,16 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "status": "processing",
-                  "processed_items": 2125,
-                  "total_rows": 5000,
-                  "succeeded_items": 2080,
-                  "failed_items": 45
+                "examples": {
+                  "default": {
+                    "value": {
+                      "status": "processing",
+                      "processed_items": 2125,
+                      "total_rows": 5000,
+                      "succeeded_items": 2080,
+                      "failed_items": 45
+                    }
+                  }
                 }
               }
             }
@@ -10595,24 +11859,28 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "rows": [
-                    {
-                      "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-                      "row_index": 42,
-                      "status": "failed",
-                      "lm_input": {
-                        "email": "invalid-format"
-                      },
-                      "lm_output": null,
-                      "error_message": "Invalid email format: invalid-format",
-                      "http_status_code": 422,
-                      "response_time_ms": 45,
-                      "completed_at": "2026-07-09T14:30:06.000Z"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "rows": [
+                        {
+                          "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                          "row_index": 42,
+                          "status": "failed",
+                          "lm_input": {
+                            "email": "invalid-format"
+                          },
+                          "lm_output": null,
+                          "error_message": "Invalid email format: invalid-format",
+                          "http_status_code": 422,
+                          "response_time_ms": 45,
+                          "completed_at": "2026-07-09T14:30:06.000Z"
+                        }
+                      ],
+                      "limit": 100,
+                      "offset": 0
                     }
-                  ],
-                  "limit": 100,
-                  "offset": 0
+                  }
                 }
               }
             }
@@ -10660,26 +11928,30 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "events": [
-                    {
-                      "event_id": "e1f2g3h4-i5j6-7890-k1mn-opqrstuvwxyz",
-                      "job_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                      "event_type": "row.failed",
-                      "source": "queue-consumer",
-                      "level": "error",
-                      "message": "Row 42 failed: Invalid email format",
-                      "stage": "enrichment",
-                      "status": "processing",
-                      "details": {
-                        "row_index": 42,
-                        "error": "Invalid email format",
-                        "http_status_code": 422
-                      },
-                      "created_at": "2026-07-09T14:30:06.000Z"
+                "examples": {
+                  "default": {
+                    "value": {
+                      "events": [
+                        {
+                          "event_id": "e1f2g3h4-i5j6-7890-k1mn-opqrstuvwxyz",
+                          "job_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                          "event_type": "row.failed",
+                          "source": "queue-consumer",
+                          "level": "error",
+                          "message": "Row 42 failed: Invalid email format",
+                          "stage": "enrichment",
+                          "status": "processing",
+                          "details": {
+                            "row_index": 42,
+                            "error": "Invalid email format",
+                            "http_status_code": 422
+                          },
+                          "created_at": "2026-07-09T14:30:06.000Z"
+                        }
+                      ],
+                      "limit": 50
                     }
-                  ],
-                  "limit": 50
+                  }
                 }
               }
             }
@@ -10841,13 +12113,17 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                  "restarted": true,
-                  "newJobId": null,
-                  "mode": "failed_only",
-                  "started": false,
-                  "position": 1
+                "examples": {
+                  "default": {
+                    "value": {
+                      "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "restarted": true,
+                      "newJobId": null,
+                      "mode": "failed_only",
+                      "started": false,
+                      "position": 1
+                    }
+                  }
                 }
               }
             }
@@ -10909,9 +12185,13 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                  "priority": 100
+                "examples": {
+                  "default": {
+                    "value": {
+                      "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "priority": 100
+                    }
+                  }
                 }
               }
             }
@@ -11092,10 +12372,14 @@
                   "type": "object",
                   "additionalProperties": true
                 },
-                "example": {
-                  "batchId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                  "status": "accepted",
-                  "items_count": 2
+                "examples": {
+                  "default": {
+                    "value": {
+                      "batchId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "status": "accepted",
+                      "items_count": 2
+                    }
+                  }
                 }
               }
             }
@@ -11126,7 +12410,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+            "examples": {
+              "default": {
+                "value": "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+              }
+            }
           }
         ],
         "responses": {
@@ -11167,7 +12455,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "email-finder"
+            "examples": {
+              "default": {
+                "value": "email-finder"
+              }
+            }
           },
           {
             "name": "batchId",
@@ -11177,7 +12469,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+            "examples": {
+              "default": {
+                "value": "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+              }
+            }
           }
         ],
         "requestBody": {
@@ -11232,7 +12528,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "c1d2e3f4-a5b6-7890-cdef-123456789012"
+            "examples": {
+              "default": {
+                "value": "c1d2e3f4-a5b6-7890-cdef-123456789012"
+              }
+            }
           }
         ],
         "responses": {
@@ -11301,12 +12601,16 @@
                   "name": {
                     "type": "string",
                     "description": "Unique client identifier (slug). Lowercase, alphanumeric with hyphens.",
-                    "example": "acme-corp"
+                    "examples": [
+                      "acme-corp"
+                    ]
                   },
                   "display_name": {
                     "type": "string",
                     "description": "Human-readable display name.",
-                    "example": "Acme Corporation"
+                    "examples": [
+                      "Acme Corporation"
+                    ]
                   },
                   "contact_email": {
                     "type": "string",
@@ -11385,7 +12689,11 @@
               "type": "string",
               "format": "uuid"
             },
-            "example": "d1e2f3a4-b5c6-7890-def1-234567890123"
+            "examples": {
+              "default": {
+                "value": "d1e2f3a4-b5c6-7890-def1-234567890123"
+              }
+            }
           }
         ],
         "responses": {
@@ -11427,7 +12735,11 @@
               "type": "string",
               "format": "uuid"
             },
-            "example": "d1e2f3a4-b5c6-7890-def1-234567890123"
+            "examples": {
+              "default": {
+                "value": "d1e2f3a4-b5c6-7890-def1-234567890123"
+              }
+            }
           }
         ],
         "responses": {
@@ -11456,7 +12768,11 @@
               "type": "string",
               "format": "uuid"
             },
-            "example": "d1e2f3a4-b5c6-7890-def1-234567890123"
+            "examples": {
+              "default": {
+                "value": "d1e2f3a4-b5c6-7890-def1-234567890123"
+              }
+            }
           }
         ],
         "requestBody": {
@@ -11524,13 +12840,17 @@
                   "name": {
                     "type": "string",
                     "description": "Display name for the provider.",
-                    "example": "acme-enrichment"
+                    "examples": [
+                      "acme-enrichment"
+                    ]
                   },
                   "baseUrl": {
                     "type": "string",
                     "format": "uri",
                     "description": "HTTPS endpoint to call. Private IP addresses are rejected.",
-                    "example": "https://api.acme.com/enrich"
+                    "examples": [
+                      "https://api.acme.com/enrich"
+                    ]
                   },
                   "authType": {
                     "type": "string",
@@ -11544,7 +12864,9 @@
                   "authCredentialName": {
                     "type": "string",
                     "description": "Header or parameter name carrying the credential.",
-                    "example": "X-API-Key"
+                    "examples": [
+                      "X-API-Key"
+                    ]
                   },
                   "authCredentialValue": {
                     "type": "string",
@@ -11578,7 +12900,9 @@
                   "healthCheckExpectedStatus": {
                     "type": "integer",
                     "description": "HTTP status treated as healthy.",
-                    "example": 200
+                    "examples": [
+                      200
+                    ]
                   }
                 }
               }
@@ -11613,16 +12937,20 @@
               "schema": {
                 "$ref": "#/components/schemas/PreviewCostRequest"
               },
-              "example": {
-                "items": [
-                  {
-                    "product": "email_finder",
-                    "input": {
-                      "profile_url": "https://example.com/in/jane-doe"
-                    }
+              "examples": {
+                "default": {
+                  "value": {
+                    "items": [
+                      {
+                        "product": "email_finder",
+                        "input": {
+                          "profile_url": "https://example.com/in/jane-doe"
+                        }
+                      }
+                    ],
+                    "budget_user_id": "user_abc123"
                   }
-                ],
-                "budget_user_id": "user_abc123"
+                }
               }
             }
           }
@@ -11698,13 +13026,17 @@
                   }
                 }
               },
-              "example": {
-                "scope": "user",
-                "scope_value": "user_abc123",
-                "max_credits": 10000,
-                "period": "monthly",
-                "alert_threshold_pct": 0.8,
-                "alert_email": "ops@example.com"
+              "examples": {
+                "default": {
+                  "value": {
+                    "scope": "user",
+                    "scope_value": "user_abc123",
+                    "max_credits": 10000,
+                    "period": "monthly",
+                    "alert_threshold_pct": 0.8,
+                    "alert_email": "ops@example.com"
+                  }
+                }
               }
             }
           }
@@ -11803,7 +13135,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "bg_4a7d2e9c1f60"
+            "examples": {
+              "default": {
+                "value": "bg_4a7d2e9c1f60"
+              }
+            }
           }
         ],
         "requestBody": {
@@ -11865,7 +13201,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "bg_4a7d2e9c1f60"
+            "examples": {
+              "default": {
+                "value": "bg_4a7d2e9c1f60"
+              }
+            }
           }
         ],
         "responses": {
@@ -11911,11 +13251,15 @@
                   }
                 }
               },
-              "example": {
-                "list_id": "bounced-2026-q3",
-                "emails": [
-                  "bounced1@example.com"
-                ]
+              "examples": {
+                "default": {
+                  "value": {
+                    "list_id": "bounced-2026-q3",
+                    "emails": [
+                      "bounced1@example.com"
+                    ]
+                  }
+                }
               }
             }
           }
@@ -11983,7 +13327,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "sl_9f2c1d7e4b8a"
+            "examples": {
+              "default": {
+                "value": "sl_9f2c1d7e4b8a"
+              }
+            }
           },
           {
             "name": "limit",
@@ -12035,7 +13383,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "sl_9f2c1d7e4b8a"
+            "examples": {
+              "default": {
+                "value": "sl_9f2c1d7e4b8a"
+              }
+            }
           }
         ],
         "responses": {
@@ -12065,7 +13417,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "sl_9f2c1d7e4b8a"
+            "examples": {
+              "default": {
+                "value": "sl_9f2c1d7e4b8a"
+              }
+            }
           }
         ],
         "requestBody": {
@@ -12117,7 +13473,11 @@
             "schema": {
               "type": "string"
             },
-            "example": "sl_9f2c1d7e4b8a"
+            "examples": {
+              "default": {
+                "value": "sl_9f2c1d7e4b8a"
+              }
+            }
           }
         ],
         "requestBody": {

--- a/leadmagic-openapi-3.1.json
+++ b/leadmagic-openapi-3.1.json
@@ -1,2469 +1,12158 @@
 {
-	"openapi": "3.1.0",
-	"jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
-	"info": {
-		"title": "LeadMagic API",
-		"version": "1.5.0",
-		"description": "A clean, consistent, and well-documented API to access LeadMagic's services, including email finding, validation, company and professional profile enrichment, and advertisement searching.\n\n**Important**: Current public docs are not fully uniform on field naming. Some endpoints use snake_case while others show mixed or camelCase response fields.\n",
-		"contact": {
-			"name": "LeadMagic API Support",
-			"url": "https://leadmagic.io",
-			"email": "support@leadmagic.io"
-		},
-		"license": {
-			"name": "MIT",
-			"url": "https://opensource.org/licenses/MIT"
-		},
-		"summary": "Complete API for LeadMagic data enrichment services"
-	},
-	"servers": [
-		{
-			"url": "https://api.leadmagic.io",
-			"description": "Production API Server"
-		}
-	],
-	"components": {
-		"securitySchemes": {
-			"apiKey": {
-				"type": "apiKey",
-				"in": "header",
-				"name": "X-API-Key",
-				"description": "API key for authentication. Get your API key from your LeadMagic dashboard."
-			}
-		},
-		"schemas": {
-			"Location": {
-				"type": "object",
-				"description": "Geographic location information",
-				"properties": {
-					"name": {
-						"type": "string",
-						"examples": ["boston, massachusetts, united states"]
-					},
-					"locality": {
-						"type": "string",
-						"examples": ["boston"]
-					},
-					"region": {
-						"type": "string",
-						"examples": ["massachusetts"]
-					},
-					"metro": {
-						"type": "string",
-						"examples": ["boston, massachusetts"]
-					},
-					"country": {
-						"type": "string",
-						"examples": ["united states"]
-					},
-					"continent": {
-						"type": "string",
-						"examples": ["north america"]
-					},
-					"street_address": {
-						"type": "string",
-						"examples": ["1 Seaport Lane"]
-					},
-					"address_line_2": {
-						"type": ["string", "null"]
-					},
-					"postal_code": {
-						"type": "string",
-						"examples": ["02210"]
-					},
-					"geo": {
-						"type": "string",
-						"examples": ["42.35,-71.06"]
-					}
-				}
-			},
-			"DetailedCompany": {
-				"type": "object",
-				"description": "Detailed company information from company search",
-				"properties": {
-					"company_name": {
-						"type": "string",
-						"examples": ["LeadMagic"]
-					},
-					"company_id": {
-						"type": "integer",
-						"examples": [75153174]
-					},
-					"locations": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"country": {
-									"type": "string",
-									"examples": ["US"]
-								},
-								"city": {
-									"type": "string",
-									"examples": ["Boston"]
-								},
-								"geographic_area": {
-									"type": "string",
-									"examples": ["Massachusetts"]
-								},
-								"postal_code": {
-									"type": "string",
-									"examples": ["02210"]
-								},
-								"line1": {
-									"type": "string",
-									"examples": ["1 Seaport Ln"]
-								},
-								"line2": {
-									"type": ["string", "null"]
-								},
-								"description": {
-									"type": "string",
-									"examples": ["Headquarters"]
-								},
-								"headquarter": {
-									"type": "boolean"
-								},
-								"localized_name": {
-									"type": "string",
-									"examples": ["Boston"]
-								},
-								"latitude": {
-									"type": "number",
-									"examples": [42.36041]
-								},
-								"longitude": {
-									"type": "number",
-									"examples": [-71.05798]
-								}
-							}
-						}
-					},
-					"employee_count": {
-						"type": "integer",
-						"examples": [9]
-					},
-					"specialities": {
-						"type": "array",
-						"items": {
-							"type": "string"
-						},
-						"examples": [["Sales", "Marketing", "ABM", "RevOps"]]
-					},
-					"employee_count_range": {
-						"type": "object",
-						"properties": {
-							"start": {
-								"type": "integer",
-								"examples": [11]
-							},
-							"end": {
-								"type": "integer",
-								"examples": [50]
-							}
-						}
-					},
-					"tagline": {
-						"type": "string",
-						"examples": [
-							"LeadMagic tells you who is interested in your products or services. Engage them and build more pipeline, win more deals"
-						]
-					},
-					"follower_count": {
-						"type": "integer",
-						"examples": [6096]
-					},
-					"industry": {
-						"type": "string",
-						"examples": ["Internet"]
-					},
-					"description": {
-						"type": "string",
-						"examples": [
-							"LeadMagic tells you exactly what businesses are on your website and helps you enrich your contact and company data."
-						]
-					},
-					"website_url": {
-						"type": "string",
-						"examples": ["https://leadmagic.io"]
-					},
-					"founded_on": {
-						"type": "object",
-						"properties": {
-							"month": {
-								"type": ["integer", "null"]
-							},
-							"year": {
-								"type": "integer",
-								"examples": [2022]
-							},
-							"day": {
-								"type": ["integer", "null"]
-							}
-						}
-					},
-					"universal_name": {
-						"type": "string",
-						"examples": ["leadmagichq"]
-					},
-					"hashtag": {
-						"type": "string",
-						"examples": ["#abm"]
-					},
-					"industry_v2_taxonomy": {
-						"type": "string",
-						"examples": ["Internet Publishing"]
-					},
-					"url": {
-						"type": "string",
-						"examples": ["https://profiles.example.com/company/leadmagichq/"]
-					},
-					"credits_consumed": {
-						"type": "integer",
-						"examples": [1]
-					}
-				}
-			},
-			"PersonProfile": {
-				"type": "object",
-				"description": "Personal profile information",
-				"properties": {
-					"profile_url": {
-						"type": "string",
-						"examples": ["https://profiles.example.com/williamhgates/"]
-					},
-					"first_name": {
-						"type": "string",
-						"examples": ["Bill"]
-					},
-					"last_name": {
-						"type": "string",
-						"examples": ["Gates"]
-					},
-					"full_name": {
-						"type": "string",
-						"examples": ["Bill Gates"]
-					},
-					"public_identifier": {
-						"type": "string",
-						"examples": ["williamhgates"]
-					},
-					"headline": {
-						"type": "string",
-						"examples": [
-							"Chair, Gates Foundation and Founder, Breakthrough Energy"
-						]
-					},
-					"company_name": {
-						"type": "string",
-						"examples": ["Gates Foundation"]
-					},
-					"company_size": {
-						"type": "string",
-						"examples": ["1001-5000"]
-					},
-					"company_industry": {
-						"type": "string",
-						"examples": ["investment management"]
-					},
-					"company_linkedin_url": {
-						"type": "string",
-						"examples": [
-							"profiles.example.com/company/bill-and-melinda-gates-foundation"
-						]
-					},
-					"company_website": {
-						"type": "string",
-						"examples": ["gatesfoundation.org"]
-					},
-					"total_tenure_months": {
-						"type": "string",
-						"examples": ["305"]
-					},
-					"total_tenure_days": {
-						"type": "string",
-						"examples": ["9150"]
-					},
-					"total_tenure_years": {
-						"type": "string",
-						"examples": ["25.42"]
-					},
-					"connections": {
-						"type": "integer",
-						"examples": [8]
-					},
-					"followers": {
-						"type": "integer",
-						"examples": [37841613]
-					},
-					"country": {
-						"type": "string",
-						"examples": ["United States"]
-					},
-					"location": {
-						"type": "string",
-						"examples": ["Seattle, Washington, United States"]
-					},
-					"about": {
-						"type": "string",
-						"examples": [
-							"Chair of the Gates Foundation. Founder of Breakthrough Energy. Co-founder of Microsoft. Voracious reader. Avid traveler. Active blogger."
-						]
-					},
-					"experiences": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"company_id": {
-									"type": "string",
-									"examples": ["8736"]
-								},
-								"title": {
-									"type": "string",
-									"examples": ["Co-chair"]
-								},
-								"subtitle": {
-									"type": "string",
-									"examples": ["Gates Foundation"]
-								},
-								"caption": {
-									"type": "string",
-									"examples": ["2000 - Present \u00b7 25 yrs 5 mos"]
-								}
-							}
-						}
-					},
-					"educations": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"title": {
-									"type": "string",
-									"examples": ["Harvard University"]
-								},
-								"caption": {
-									"type": "string",
-									"examples": ["1973 - 1975"]
-								}
-							}
-						}
-					}
-				}
-			},
-			"GoogleAd": {
-				"type": "object",
-				"description": "Google advertisement information",
-				"properties": {
-					"advertiser_id": {
-						"type": "string",
-						"examples": ["AR14106062795078369281"]
-					},
-					"creative_id": {
-						"type": "string",
-						"examples": ["CR14003695067076755457"]
-					},
-					"advertiser_name": {
-						"type": "string",
-						"examples": ["Gong.io Inc"]
-					},
-					"format": {
-						"type": "string",
-						"examples": ["Text"]
-					},
-					"start": {
-						"type": "string",
-						"format": "date",
-						"examples": ["2025-03-06"]
-					},
-					"last_seen": {
-						"type": "string",
-						"format": "date",
-						"examples": ["2025-06-27"]
-					},
-					"original_url": {
-						"type": "string",
-						"examples": [
-							"https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR14003695067076755457?region=anywhere"
-						]
-					},
-					"variants": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"content": {
-									"type": "string",
-									"description": "HTML content or JavaScript URL for the ad"
-								},
-								"height": {
-									"type": ["integer", "null"]
-								},
-								"width": {
-									"type": ["integer", "null"]
-								}
-							}
-						}
-					}
-				}
-			},
-			"JobResult": {
-				"type": "object",
-				"description": "Job search result",
-				"properties": {
-					"company": {
-						"type": "object",
-						"properties": {
-							"name": {
-								"type": "string",
-								"examples": ["Microsoft"]
-							},
-							"website_url": {
-								"type": "string",
-								"examples": ["https://www.microsoft.com/"]
-							},
-							"linkedin_url": {
-								"type": "string",
-								"examples": ["https://profiles.example.com/company/microsoft/"]
-							},
-							"twitter_handle": {
-								"type": "string",
-								"examples": ["Microsoft"]
-							},
-							"github_url": {
-								"type": "string",
-								"examples": ["https://github.com/microsoft"]
-							},
-							"is_agency": {
-								"type": "boolean",
-								"examples": [false]
-							}
-						}
-					},
-					"title": {
-						"type": "string",
-						"examples": ["Technical Program Manager - Developer (AI)"]
-					},
-					"location": {
-						"type": "string",
-						"examples": ["Redmond, Washington, United States"]
-					},
-					"types": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "integer",
-									"examples": [1]
-								},
-								"name": {
-									"type": "string",
-									"examples": ["Full Time"]
-								}
-							}
-						}
-					},
-					"cities": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"geonameid": {
-									"type": "integer",
-									"examples": [5808079]
-								},
-								"asciiname": {
-									"type": "string",
-									"examples": ["Redmond"]
-								},
-								"name": {
-									"type": "string",
-									"examples": ["Redmond"]
-								},
-								"country": {
-									"type": "object",
-									"properties": {
-										"id": {
-											"type": "integer",
-											"examples": [238]
-										},
-										"code": {
-											"type": "string",
-											"examples": ["US"]
-										},
-										"name": {
-											"type": "string",
-											"examples": ["United States"]
-										}
-									}
-								}
-							}
-						}
-					},
-					"has_remote": {
-						"type": "boolean",
-						"examples": [false]
-					},
-					"published": {
-						"type": "string",
-						"format": "date-time",
-						"examples": ["2025-06-25T20:36:00Z"]
-					},
-					"expired": {
-						"type": ["string", "null"],
-						"format": "date-time"
-					},
-					"application_url": {
-						"type": "string",
-						"examples": [
-							"https://jobs.careers.microsoft.com/global/en/job/1833754/"
-						]
-					},
-					"language": {
-						"type": "string",
-						"examples": ["en"]
-					},
-					"salary_min": {
-						"type": "string",
-						"examples": ["100600"]
-					},
-					"salary_max": {
-						"type": "string",
-						"examples": ["215400"]
-					},
-					"salary_currency": {
-						"type": "string",
-						"examples": ["USD"]
-					},
-					"experience_level": {
-						"type": "string",
-						"examples": ["Mid Level"]
-					},
-					"description": {
-						"type": "string",
-						"description": "Full job description text"
-					}
-				}
-			},
-			"Error": {
-				"type": "object",
-				"properties": {
-					"error": {
-						"type": "string",
-						"examples": ["Bad Request"]
-					},
-					"message": {
-						"type": "string",
-						"examples": ["API key is missing or invalid."]
-					}
-				}
-			}
-		}
-	},
-	"security": [
-		{
-			"apiKey": []
-		}
-	],
-	"paths": {
-		"/credits": {
-			"post": {
-				"summary": "Check Credits",
-				"description": "Check the number of available credits for the authenticated user.",
-				"operationId": "getCredits",
-				"tags": ["Credits"],
-				"requestBody": {
-					"required": false,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful credits retrieval.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"credits": {
-											"type": "number",
-											"description": "Available credits balance",
-											"examples": [7333.8]
-										},
-										"is_frozen": {
-											"type": "boolean",
-											"description": "Whether the account's credits are currently frozen.",
-											"examples": [false]
-										},
-										"credits_frozen": {
-											"type": "number",
-											"description": "Portion of credits currently frozen.",
-											"examples": [0]
-										},
-										"credits_liquid": {
-											"type": "number",
-											"description": "Portion of credits currently available for use.",
-											"examples": [7333.8]
-										},
-										"credit_freeze_message": {
-											"type": ["string", "null"],
-											"description": "Optional message describing the freeze state.",
-											"examples": [null]
-										},
-										"credit_freeze_plan_hint": {
-											"type": ["string", "null"],
-											"description": "Optional plan or upgrade hint related to a credit freeze.",
-											"examples": [null]
-										}
-									},
-									"required": ["credits"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/email-validate": {
-			"post": {
-				"summary": "Email Validation",
-				"description": "Validate an email address for deliverability and retrieve associated company information.",
-				"operationId": "validateEmail",
-				"tags": ["Email"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["email"],
-								"properties": {
-									"email": {
-										"type": "string",
-										"description": "Email address to validate.",
-										"examples": ["jesse@leadmagic.io"]
-									},
-									"first_name": {
-										"type": "string",
-										"description": "First name of the person (optional).",
-										"examples": ["Jesse"]
-									},
-									"last_name": {
-										"type": "string",
-										"description": "Last name of the person (optional).",
-										"examples": ["Ouellette"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful validation.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"email": {
-											"type": "string",
-											"examples": ["jesse@leadmagic.io"]
-										},
-										"email_status": {
-											"type": "string",
-											"enum": [
-												"valid",
-												"valid_catch_all",
-												"invalid",
-												"unknown",
-												"catch_all"
-											],
-											"examples": ["valid"]
-										},
-										"credits_consumed": {
-											"type": "number",
-											"examples": [0.05]
-										},
-										"message": {
-											"type": "string",
-											"examples": ["Email is valid."]
-										},
-										"is_domain_catch_all": {
-											"type": "boolean",
-											"examples": [false]
-										},
-										"mx_record": {
-											"type": "string",
-											"examples": ["aspmx.l.google.com"]
-										},
-										"mx_provider": {
-											"type": "string",
-											"examples": ["Google Workspace"]
-										},
-										"mx_security_gateway": {
-											"type": "boolean",
-											"examples": [false]
-										},
-										"company_name": {
-											"type": "string",
-											"examples": ["Leadmagic"]
-										},
-										"company_industry": {
-											"type": "string",
-											"examples": ["Internet"]
-										},
-										"company_size": {
-											"type": "string",
-											"examples": ["11-50"]
-										},
-										"company_founded": {
-											"type": "integer",
-											"examples": [2022]
-										},
-										"company_type": {
-											"type": "string",
-											"examples": ["private"]
-										},
-										"company_linkedin_url": {
-											"type": "string",
-											"examples": ["profiles.example.com/company/leadmagichq"]
-										},
-										"company_linkedin_id": {
-											"type": "string",
-											"examples": ["75153174"]
-										},
-										"company_facebook_url": {
-											"type": ["string", "null"]
-										},
-										"company_twitter_url": {
-											"type": ["string", "null"]
-										},
-										"company_location": {
-											"$ref": "#/components/schemas/Location"
-										}
-									},
-									"required": ["email", "email_status", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/email-finder": {
-			"post": {
-				"summary": "Email Finder",
-				"description": "Finds a verified email address based on a person's name and company.",
-				"operationId": "findEmail",
-				"tags": ["Email"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["first_name", "last_name"],
-								"properties": {
-									"first_name": {
-										"type": "string",
-										"description": "The person's first name.",
-										"examples": ["Bill"]
-									},
-									"last_name": {
-										"type": "string",
-										"description": "The person's last name.",
-										"examples": ["Gates"]
-									},
-									"domain": {
-										"type": "string",
-										"description": "The company's domain name.",
-										"examples": ["microsoft.com"]
-									},
-									"company_name": {
-										"type": "string",
-										"description": "The company's name (used if domain is unknown).",
-										"examples": ["Microsoft"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful email discovery.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"email": {
-											"type": "string",
-											"examples": ["billg@microsoft.com"]
-										},
-										"status": {
-											"type": "string",
-											"enum": ["valid", "valid_catch_all", "not_found"],
-											"examples": ["valid"]
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [1]
-										},
-										"message": {
-											"type": "string",
-											"examples": ["Valid email found."]
-										},
-										"first_name": {
-											"type": "string",
-											"examples": ["Bill"]
-										},
-										"last_name": {
-											"type": "string",
-											"examples": ["Gates"]
-										},
-										"domain": {
-											"type": "string",
-											"examples": ["microsoft.com"]
-										},
-										"is_domain_catch_all": {
-											"type": "boolean",
-											"examples": [false]
-										},
-										"mx_record": {
-											"type": "string",
-											"examples": ["microsoft-com.mail.protection.outlook.com"]
-										},
-										"mx_provider": {
-											"type": "string",
-											"examples": ["Microsoft 365"]
-										},
-										"mx_security_gateway": {
-											"type": "boolean",
-											"examples": [false]
-										},
-										"company_name": {
-											"type": "string",
-											"examples": ["Microsoft"]
-										},
-										"company_industry": {
-											"type": "string",
-											"examples": ["Computer Software"]
-										},
-										"company_size": {
-											"type": "string",
-											"examples": ["10001+"]
-										},
-										"company_founded": {
-											"type": "integer",
-											"examples": [1975]
-										},
-										"company_type": {
-											"type": "string",
-											"examples": ["public"]
-										},
-										"company_linkedin_url": {
-											"type": "string",
-											"examples": ["profiles.example.com/company/microsoft"]
-										},
-										"company_linkedin_id": {
-											"type": "string",
-											"examples": ["1035"]
-										},
-										"company_location": {
-											"$ref": "#/components/schemas/Location"
-										}
-									},
-									"required": ["email", "status", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/profile-search": {
-			"post": {
-				"summary": "Profile Search",
-				"description": "Provide a B2B profile URL (for example, a professional social profile) to get full profile details. \nRate limit: 300 requests/minute.\n",
-				"operationId": "searchProfile",
-				"tags": ["Profiles"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["profile_url"],
-								"properties": {
-									"profile_url": {
-										"type": "string",
-										"description": "Full URL of the B2B profile.",
-										"examples": ["https://profiles.example.com/williamhgates/"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful retrieval of profile information.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"credits_consumed": {
-											"type": "number",
-											"examples": [1]
-										}
-									},
-									"required": ["credits_consumed"],
-									"allOf": [
-										{
-											"$ref": "#/components/schemas/PersonProfile"
-										}
-									]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"429": {
-						"description": "Rate limit exceeded.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/company-search": {
-			"post": {
-				"summary": "Company Search",
-				"description": "Search for company details using its domain, name, or profile URL.",
-				"operationId": "searchCompany",
-				"tags": ["Companies"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"description": "Provide at least one of the following to find company details.",
-								"properties": {
-									"company_domain": {
-										"type": "string",
-										"examples": ["leadmagic.io"]
-									},
-									"company_name": {
-										"type": "string",
-										"examples": ["Leadmagic"]
-									},
-									"profile_url": {
-										"type": "string",
-										"examples": [
-											"https://profiles.example.com/company/leadmagichq"
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful retrieval of company details.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [1]
-										}
-									},
-									"required": ["credits_consumed"],
-									"allOf": [
-										{
-											"$ref": "#/components/schemas/DetailedCompany"
-										}
-									]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/jobs-finder": {
-			"post": {
-				"summary": "Jobs Finder",
-				"description": "Searches for job postings based on various criteria.",
-				"operationId": "findJobs",
-				"tags": ["Jobs"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"company_name": {
-										"type": "string",
-										"description": "Filter by company name.",
-										"examples": ["Microsoft"]
-									},
-									"company_website": {
-										"type": "string",
-										"description": "Filter by company website.",
-										"examples": ["microsoft.com"]
-									},
-									"job_title": {
-										"type": "string",
-										"description": "Filter by job title.",
-										"examples": ["Developer"]
-									},
-									"location": {
-										"type": "string",
-										"description": "Filter by job location.",
-										"examples": ["New York"]
-									},
-									"experience_level": {
-										"type": "string",
-										"description": "Required experience level.",
-										"enum": ["entry", "mid", "senior", "executive"],
-										"examples": ["senior"]
-									},
-									"job_description": {
-										"type": "string",
-										"description": "Keywords from the job description.",
-										"examples": ["python \"software engineer\""]
-									},
-									"country_id": {
-										"type": "string",
-										"description": "Filter jobs by country ID.",
-										"examples": ["US"]
-									},
-									"page": {
-										"type": "integer",
-										"default": 1,
-										"minimum": 1,
-										"examples": [1]
-									},
-									"per_page": {
-										"type": "integer",
-										"default": 20,
-										"minimum": 1,
-										"maximum": 50,
-										"description": "Number of results per page. Maximum of 50.",
-										"examples": [5]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful job search.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"total_count": {
-											"type": "integer",
-											"examples": [105]
-										},
-										"page": {
-											"type": "integer",
-											"examples": [1]
-										},
-										"per_page": {
-											"type": "integer",
-											"examples": [5]
-										},
-										"total_pages": {
-											"type": "integer",
-											"examples": [21]
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [5]
-										},
-										"results": {
-											"type": "array",
-											"items": {
-												"$ref": "#/components/schemas/JobResult"
-											}
-										}
-									},
-									"required": [
-										"total_count",
-										"page",
-										"per_page",
-										"total_pages",
-										"credits_consumed",
-										"results"
-									]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/google/searchads": {
-			"post": {
-				"summary": "Google Ads Search",
-				"description": "Search for Google Ads based on a company's domain or name.",
-				"operationId": "searchGoogleAds",
-				"tags": ["Advertisements"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"description": "Provide a company name or domain to search for ads.",
-								"properties": {
-									"company_domain": {
-										"type": "string",
-										"examples": ["gong.io"]
-									},
-									"company_name": {
-										"type": "string",
-										"examples": ["gong"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful retrieval of Google Ads.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"credits_consumed": {
-											"type": "number",
-											"examples": [8]
-										},
-										"ads": {
-											"type": "array",
-											"items": {
-												"$ref": "#/components/schemas/GoogleAd"
-											}
-										}
-									},
-									"required": ["credits_consumed", "ads"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/meta/searchads": {
-			"post": {
-				"summary": "Meta (Facebook/Instagram) Ads Search",
-				"description": "Search for Meta Ads based on a company's domain or name.",
-				"operationId": "searchMetaAds",
-				"tags": ["Advertisements"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"description": "Provide a company name or domain to search for ads.",
-								"properties": {
-									"company_domain": {
-										"type": "string",
-										"examples": ["gong.io"]
-									},
-									"company_name": {
-										"type": "string",
-										"examples": ["gong"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful retrieval of Meta Ads.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"credits_consumed": {
-											"type": "number",
-											"examples": [2.6]
-										},
-										"ads": {
-											"type": "array",
-											"items": {
-												"type": "object",
-												"properties": {
-													"ad_archive_id": {
-														"type": "string",
-														"examples": ["618153827656899"]
-													},
-													"page_id": {
-														"type": "string",
-														"examples": ["105549201674375"]
-													},
-													"page_name": {
-														"type": "string",
-														"examples": ["Lykkedal Retreat"]
-													},
-													"is_active": {
-														"type": "boolean"
-													},
-													"publisher_platform": {
-														"type": "array",
-														"items": {
-															"type": "string"
-														},
-														"examples": [["facebook", "instagram"]]
-													},
-													"snapshot": {
-														"type": "object",
-														"properties": {
-															"body": {
-																"type": "object",
-																"properties": {
-																	"markup": {
-																		"type": "string"
-																	}
-																}
-															},
-															"title": {
-																"type": "string"
-															},
-															"cta_text": {
-																"type": "string"
-															},
-															"images": {
-																"type": "array",
-																"items": {
-																	"type": "object",
-																	"properties": {
-																		"original_image_url": {
-																			"type": "string",
-																			"format": "uri"
-																		}
-																	}
-																}
-															},
-															"videos": {
-																"type": "array",
-																"items": {
-																	"type": "object",
-																	"properties": {
-																		"video_hd_url": {
-																			"type": "string",
-																			"format": "uri"
-																		}
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									},
-									"required": ["credits_consumed", "ads"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/mobile-finder": {
-			"post": {
-				"summary": "Mobile Finder",
-				"description": "Find mobile phone numbers using profile URL, work email, or personal email.",
-				"operationId": "findMobile",
-				"tags": ["Mobile"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"description": "Provide at least one of the following parameters.",
-								"properties": {
-									"profile_url": {
-										"type": "string",
-										"examples": ["https://profiles.example.com/williamhgates/"]
-									},
-									"work_email": {
-										"type": "string",
-										"examples": ["jesse@leadmagic.io"]
-									},
-									"personal_email": {
-										"type": "string",
-										"examples": ["jesse.ouellette@gmail.com"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Mobile search response.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"message": {
-											"type": "string",
-											"examples": ["mobile not found", "Mobile found"]
-										},
-										"credits_consumed": {
-											"type": "number",
-											"examples": [0, 1]
-										},
-										"mobile_number": {
-											"type": ["string", "null"],
-											"examples": ["+1234567890"]
-										}
-									},
-									"required": ["message", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/b2b-profile": {
-			"post": {
-				"summary": "Email Address to B2B Profile",
-				"description": "Find B2B profile URL using work email address.",
-				"operationId": "emailToProfile",
-				"tags": ["Profiles"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["work_email"],
-								"properties": {
-									"work_email": {
-										"type": "string",
-										"examples": ["jesse@leadmagic.io"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Profile URL found.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"profile_url": {
-											"type": "string",
-											"examples": ["https://profiles.example.com/jesseouehwx"]
-										},
-										"message": {
-											"type": "string",
-											"examples": ["Profile URL found"]
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [10]
-										}
-									},
-									"required": ["message", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/role-finder": {
-			"post": {
-				"summary": "Role Finder",
-				"description": "Find specific roles/positions within a company.",
-				"operationId": "findRole",
-				"tags": ["People"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["job_title"],
-								"properties": {
-									"job_title": {
-										"type": "string",
-										"examples": ["Developer"]
-									},
-									"company_name": {
-										"type": "string",
-										"examples": ["Microsoft"]
-									},
-									"company_domain": {
-										"type": "string",
-										"examples": ["microsoft.com"]
-									},
-									"company_profile_url": {
-										"type": "string",
-										"examples": [
-											"https://profiles.example.com/company/microsoft"
-										]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Role search response.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"message": {
-											"type": "string",
-											"examples": ["Role not found.", "Role found."]
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [0, 1]
-										},
-										"company_name": {
-											"type": "string",
-											"examples": ["Microsoft"]
-										},
-										"company_website": {
-											"type": "string",
-											"examples": ["microsoft.com"]
-										}
-									},
-									"required": ["message", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/employee-finder": {
-			"post": {
-				"summary": "Employee Finder",
-				"description": "Find employees of a specific company.",
-				"operationId": "findEmployees",
-				"tags": ["People"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["company_name"],
-								"properties": {
-									"company_name": {
-										"type": "string",
-										"examples": ["Microsoft"]
-									},
-									"page": {
-										"type": "integer",
-										"default": 1,
-										"minimum": 1,
-										"examples": [1]
-									},
-									"per_page": {
-										"type": "integer",
-										"default": 20,
-										"minimum": 1,
-										"maximum": 50,
-										"examples": [5]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Employee search results.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"message": {
-											"type": "string",
-											"examples": ["Data found for the given company."]
-										},
-										"total_count": {
-											"type": "integer",
-											"examples": [5000]
-										},
-										"returned_count": {
-											"type": "integer",
-											"examples": [20]
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [1]
-										},
-										"data": {
-											"type": "array",
-											"items": {
-												"type": "object",
-												"properties": {
-													"first_name": {
-														"type": "string",
-														"examples": ["John"]
-													},
-													"last_name": {
-														"type": "string",
-														"examples": ["Doe"]
-													},
-													"title": {
-														"type": "string",
-														"examples": ["Senior Software Engineer"]
-													},
-													"website": {
-														"type": "string",
-														"examples": ["http://www.microsoft.com"]
-													},
-													"company_name": {
-														"type": "string",
-														"examples": ["Microsoft"]
-													}
-												}
-											}
-										}
-									},
-									"required": ["message", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/company-funding": {
-			"post": {
-				"summary": "Company Funding",
-				"description": "Get comprehensive funding information, financials, competitors, and company insights.",
-				"operationId": "getCompanyFunding",
-				"tags": ["Companies"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"properties": {
-									"company_domain": {
-										"type": "string",
-										"examples": ["microsoft.com"]
-									},
-									"company_name": {
-										"type": "string",
-										"examples": ["Microsoft"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Comprehensive company funding and business information.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"basicInfo": {
-											"type": "object",
-											"properties": {
-												"companyName": {
-													"type": "string",
-													"examples": ["Microsoft Corp."]
-												},
-												"description": {
-													"type": "string"
-												},
-												"shortName": {
-													"type": "string",
-													"examples": ["Microsoft"]
-												},
-												"founded": {
-													"type": "string",
-													"examples": ["1975"]
-												},
-												"primaryDomain": {
-													"type": "string",
-													"examples": ["microsoft.com"]
-												},
-												"phone": {
-													"type": "string",
-													"examples": ["1-124-415-8000"]
-												},
-												"status": {
-													"type": "string",
-													"examples": ["NEW"]
-												},
-												"followers": {
-													"type": "integer",
-													"examples": [181691]
-												},
-												"ownership": {
-													"type": "string",
-													"examples": ["Public"]
-												}
-											}
-										},
-										"financialInfo": {
-											"type": "object",
-											"properties": {
-												"revenue": {
-													"type": "integer",
-													"examples": [270010000000]
-												},
-												"formattedRevenue": {
-													"type": "string",
-													"examples": ["270B"]
-												},
-												"totalFunding": {
-													"type": "integer",
-													"examples": [61000000]
-												},
-												"formattedFunding": {
-													"type": "string",
-													"examples": ["61M"]
-												}
-											}
-										},
-										"companySize": {
-											"type": "object",
-											"properties": {
-												"employees": {
-													"type": "integer",
-													"examples": [221000]
-												},
-												"employeeRange": {
-													"type": "string",
-													"examples": ["100,000 - 9,999,999"]
-												}
-											}
-										},
-										"topCompetitors": {
-											"type": "array",
-											"items": {
-												"type": "object",
-												"properties": {
-													"name": {
-														"type": "string",
-														"examples": ["IBM"]
-													},
-													"revenue": {
-														"type": "string",
-														"examples": [""]
-													},
-													"employees": {
-														"type": "string",
-														"examples": ["311,300"]
-													},
-													"website": {
-														"type": "string",
-														"examples": ["https://www.ibm.com"]
-													}
-												}
-											}
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [4]
-										}
-									},
-									"required": ["credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/job-country": {
-			"get": {
-				"summary": "Get Job Countries",
-				"description": "Retrieve list of available countries for job filtering.",
-				"operationId": "getJobCountries",
-				"tags": ["Jobs"],
-				"responses": {
-					"200": {
-						"description": "List of available countries.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"id": {
-												"type": "string",
-												"examples": ["US", "CA", "UK"]
-											},
-											"name": {
-												"type": "string",
-												"examples": [
-													"United States",
-													"Canada",
-													"United Kingdom"
-												]
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/job-types": {
-			"get": {
-				"summary": "Get Job Types",
-				"description": "Retrieve list of available job types for filtering.",
-				"operationId": "getJobTypes",
-				"tags": ["Jobs"],
-				"responses": {
-					"200": {
-						"description": "List of available job types.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"id": {
-												"type": "integer",
-												"examples": [1, 2, 3]
-											},
-											"name": {
-												"type": "string",
-												"examples": ["Full Time", "Part Time", "Contract"]
-											}
-										}
-									}
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/personal-email-finder": {
-			"post": {
-				"summary": "Personal Email Finder",
-				"description": "Find personal email addresses from B2B profile URLs.",
-				"operationId": "findPersonalEmail",
-				"tags": ["Email"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["profile_url"],
-								"properties": {
-									"profile_url": {
-										"type": "string",
-										"description": "B2B profile URL (for example, a professional social profile)",
-										"examples": ["https://profiles.example.com/williamhgates/"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Personal email search response.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"personal_email": {
-											"type": ["string", "null"],
-											"examples": ["bill.gates@gmail.com"]
-										},
-										"status": {
-											"type": "string",
-											"enum": ["found", "not_found"],
-											"examples": ["found"]
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [1]
-										},
-										"message": {
-											"type": "string",
-											"examples": [
-												"Personal email found",
-												"Personal email not found"
-											]
-										}
-									},
-									"required": ["status", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/b2b-social-email": {
-			"post": {
-				"summary": "B2B Social to Email",
-				"description": "Find work email addresses from B2B profile URLs.",
-				"operationId": "socialToWorkEmail",
-				"tags": ["Email"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["profile_url"],
-								"properties": {
-									"profile_url": {
-										"type": "string",
-										"description": "B2B profile URL (for example, a professional social profile)",
-										"examples": ["https://profiles.example.com/williamhgates/"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Work email search response.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"work_email": {
-											"type": ["string", "null"],
-											"examples": ["bill.gates@microsoft.com"]
-										},
-										"status": {
-											"type": "string",
-											"enum": ["found", "not_found"],
-											"examples": ["found"]
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [1]
-										},
-										"message": {
-											"type": "string",
-											"examples": ["Work email found", "Work email not found"]
-										}
-									},
-									"required": ["status", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/b2b/searchads": {
-			"post": {
-				"summary": "B2B Ads Search",
-				"description": "Search for B2B Ads based on a company's domain or name.",
-				"operationId": "searchB2BAds",
-				"tags": ["Advertisements"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"description": "Provide a company name or domain to search for ads.",
-								"properties": {
-									"company_domain": {
-										"type": "string",
-										"examples": ["microsoft.com"]
-									},
-									"company_name": {
-										"type": "string",
-										"examples": ["Microsoft"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Successful retrieval of B2B Ads.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"credits_consumed": {
-											"type": "number",
-											"examples": [5]
-										},
-										"ads": {
-											"type": "array",
-											"items": {
-												"type": "object",
-												"properties": {
-													"ad_id": {
-														"type": "string",
-														"examples": ["12345"]
-													},
-													"company_name": {
-														"type": "string",
-														"examples": ["Microsoft"]
-													},
-													"ad_title": {
-														"type": "string",
-														"examples": ["Microsoft Azure Cloud Services"]
-													},
-													"ad_description": {
-														"type": "string"
-													},
-													"ad_url": {
-														"type": "string",
-														"format": "uri"
-													}
-												}
-											}
-										}
-									},
-									"required": ["credits_consumed", "ads"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"/b2b/ad-details": {
-			"post": {
-				"summary": "B2B Ad Details",
-				"description": "Get detailed information about a specific B2B ad.",
-				"operationId": "getB2BAdDetails",
-				"tags": ["Advertisements"],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"type": "object",
-								"required": ["ad_id"],
-								"properties": {
-									"ad_id": {
-										"type": "string",
-										"description": "B2B ad ID",
-										"examples": ["12345"]
-									}
-								}
-							}
-						}
-					}
-				},
-				"responses": {
-					"200": {
-						"description": "Detailed B2B ad information.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "object",
-									"properties": {
-										"ad_id": {
-											"type": "string",
-											"examples": ["12345"]
-										},
-										"company_name": {
-											"type": "string",
-											"examples": ["Microsoft"]
-										},
-										"ad_title": {
-											"type": "string",
-											"examples": ["Microsoft Azure Cloud Services"]
-										},
-										"ad_description": {
-											"type": "string"
-										},
-										"ad_url": {
-											"type": "string",
-											"format": "uri"
-										},
-										"campaign_info": {
-											"type": "object",
-											"properties": {
-												"campaign_name": {
-													"type": "string"
-												},
-												"start_date": {
-													"type": "string",
-													"format": "date"
-												},
-												"end_date": {
-													"type": ["string", "null"],
-													"format": "date"
-												}
-											}
-										},
-										"credits_consumed": {
-											"type": "integer",
-											"examples": [2]
-										}
-									},
-									"required": ["ad_id", "credits_consumed"]
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					},
-					"401": {
-						"description": "Unauthorized - Invalid API key.",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Error"
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"tags": [
-		{
-			"name": "Advertisements",
-			"description": "Advertisement intelligence"
-		},
-		{
-			"name": "Companies",
-			"description": "Company information and enrichment"
-		},
-		{
-			"name": "Credits",
-			"description": "Credit management operations"
-		},
-		{
-			"name": "Email",
-			"description": "Email finding and validation"
-		},
-		{
-			"name": "Jobs",
-			"description": "Job posting search"
-		},
-		{
-			"name": "Mobile",
-			"description": "Mobile number finding"
-		},
-		{
-			"name": "People",
-			"description": "People enrichment and search"
-		},
-		{
-			"name": "Profiles",
-			"description": "Professional profile enrichment"
-		}
-	]
+  "openapi": "3.1.0",
+  "info": {
+    "title": "LeadMagic API",
+    "version": "1.4.35",
+    "description": "# LeadMagic API Documentation\n\nThe LeadMagic API provides comprehensive B2B data enrichment services including email validation, email finding, profile search, company intelligence, and more.\n\n## Quick Start\n\n1. Get your API key from the [LeadMagic Dashboard](https://app.leadmagic.io)\n2. Add the `X-API-Key` header to all requests\n3. Start enriching your data!\n\n## Base URL\n\nAll API requests should be made to: `https://api.leadmagic.io`\n\n## Rate Limits\n\nEach endpoint has specific rate limits (requests per minute). Exceeding limits returns a `429 Too Many Requests` response.\n\n## Fair Use\n\nAll API use is subject to LeadMagic [Fair Use](https://leadmagic.io/legal/terms#fair-use). For Email Finder and similar enrichment endpoints, a sustained find rate below **10%** may result in throttling, reduced limits, suspension, or termination — including when you still have prepaid credits. Email Finder and Email Validation may have different published rate limits and plan tiers. LeadMagic reserves the right to modify Fair Use thresholds, rate limits, product tiering, and enforcement policies as described in our Terms.\n\n## Credits and rollover\n\nAPI calls consume credits based on the endpoint used. On eligible **monthly** plans (Essential and above), unused subscription credits may roll over, but your workspace may never hold more than **two months** of your plan's included monthly allocation (2× monthly credits). Credits above that cap expire at each billing reset. **Basic**, **annual billing**, and **custom (negotiated) deals** do not roll over unless your written agreement explicitly includes rollover. See [Terms — Credit Expiration and Rollover](https://leadmagic.io/legal/terms#subscription) and check your balance with `/v1/credits`.\n\n## Support\n\nContact us at support@leadmagic.io for assistance.\n",
+    "contact": {
+      "name": "LeadMagic Support",
+      "email": "support@leadmagic.io",
+      "url": "https://leadmagic.io"
+    },
+    "termsOfService": "https://leadmagic.io/legal/terms"
+  },
+  "servers": [
+    {
+      "url": "https://api.leadmagic.io",
+      "description": "Production API Server"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "Your LeadMagic API key. Header name is case-insensitive (X-API-Key, X-API-KEY, x-api-key all work)."
+      }
+    },
+    "parameters": {
+      "BulkJobId": {
+        "name": "jobId",
+        "in": "path",
+        "required": true,
+        "description": "UUID identifier of the bulk job.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+      }
+    },
+    "headers": {
+      "RateLimitLimit": {
+        "description": "Effective organization request ceiling for the current minute.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "RateLimitRemaining": {
+        "description": "Requests remaining in the effective organization minute window.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "RateLimitReset": {
+        "description": "Unix epoch second when the current minute window resets.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "SearchRpsLimit": {
+        "description": "Effective organization sustained Search RPS ceiling.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "SearchRpsRemaining": {
+        "description": "Tokens remaining in the current sustained Search RPS window.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "SearchRpsReset": {
+        "description": "Unix epoch second when the sustained Search RPS window refills.",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    },
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "description": "RFC 9457 Problem Details error response",
+        "required": [
+          "success",
+          "errors"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false,
+            "description": "Always false for error responses"
+          },
+          "errors": {
+            "type": "array",
+            "description": "Array of error details (typically one, but can be multiple)",
+            "items": {
+              "$ref": "#/components/schemas/ErrorDetail"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          }
+        }
+      },
+      "ErrorDetail": {
+        "type": "object",
+        "description": "RFC 9457 compliant error detail",
+        "required": [
+          "type",
+          "title",
+          "status"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri",
+            "description": "RFC 9457 - URI reference identifying the error type",
+            "example": "https://api.leadmagic.io/errors/validation_error"
+          },
+          "title": {
+            "type": "string",
+            "description": "RFC 9457 - Short human-readable summary",
+            "example": "Request validation failed. Check your input parameters."
+          },
+          "status": {
+            "type": "integer",
+            "description": "RFC 9457 - HTTP status code",
+            "example": 400
+          },
+          "detail": {
+            "type": "string",
+            "description": "RFC 9457 - Human-readable explanation specific to this occurrence",
+            "example": "The email field is required but was not provided."
+          },
+          "instance": {
+            "type": "string",
+            "format": "uri-reference",
+            "description": "RFC 9457 - URI reference for this specific occurrence",
+            "example": "/v1/people/email-validation#req_abc123"
+          },
+          "code": {
+            "type": "string",
+            "description": "Machine-readable error code for programmatic handling",
+            "example": "validation_error"
+          },
+          "param": {
+            "type": "array",
+            "description": "Parameters that caused the error",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "email"
+            ]
+          },
+          "action": {
+            "type": "string",
+            "description": "Suggested action to resolve the error",
+            "example": "Provide a valid email address in the 'email' field."
+          },
+          "docs": {
+            "type": "string",
+            "format": "uri",
+            "description": "Link to relevant documentation",
+            "example": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+          },
+          "context": {
+            "type": "object",
+            "description": "Additional context specific to this error type",
+            "additionalProperties": true
+          }
+        }
+      },
+      "ResponseMeta": {
+        "type": "object",
+        "description": "Metadata included in all responses",
+        "properties": {
+          "request_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for this request (use for debugging/support)",
+            "example": "ea6e3248-f4d2-437d-bca3-20881b529129"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when the response was generated",
+            "example": "2024-02-01T12:00:00.000Z"
+          },
+          "environment": {
+            "type": "string",
+            "description": "API environment (production, staging)",
+            "example": "production"
+          }
+        }
+      },
+      "ValidationError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/validation_error",
+              "title": "Request validation failed. Check your input parameters.",
+              "status": 400,
+              "code": "validation_error",
+              "param": [
+                "email"
+              ],
+              "detail": "Email format is invalid. Expected format: user@domain.com",
+              "action": "Provide a valid email address in the 'email' field.",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "MissingFieldError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/missing_required_field",
+              "title": "Missing required field: email. Add this field to your request.",
+              "status": 400,
+              "code": "missing_required_field",
+              "param": [
+                "email"
+              ],
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "InvalidJsonError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/invalid_json",
+              "title": "Invalid JSON in request body. Check your JSON syntax.",
+              "status": 400,
+              "code": "invalid_json",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "InvalidParameterError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/invalid_parameter",
+              "title": "Invalid parameter: experience_level. Valid options: entry, mid, senior, executive.",
+              "status": 400,
+              "code": "invalid_parameter",
+              "param": [
+                "experience_level"
+              ],
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "MissingAuthenticationError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/missing_authentication",
+              "title": "Authentication required. Provide a valid API key in the X-API-Key header (case-insensitive).",
+              "status": 401,
+              "code": "missing_authentication",
+              "docs": "https://leadmagic.io/docs/v1/authentication"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "InvalidApiKeyError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/invalid_api_key",
+              "title": "Invalid API key. The key does not exist or is incorrect.",
+              "status": 401,
+              "code": "invalid_api_key",
+              "docs": "https://leadmagic.io/docs/v1/authentication"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "InsufficientPermissionsError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/insufficient_permissions",
+              "title": "Access denied to this resource. Upgrade your plan or contact support.",
+              "status": 403,
+              "code": "insufficient_permissions",
+              "docs": "https://leadmagic.io/docs/v1/authentication"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "InsufficientCreditsError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/insufficient_credits",
+              "title": "Insufficient credits: need 5, have 2.50. Add credits to continue.",
+              "status": 402,
+              "code": "insufficient_credits",
+              "detail": "This request requires 5 credit(s) but your account only has 2.50 credits remaining.",
+              "action": "Add credits to your account at https://app.leadmagic.io/settings/billing or contact support@leadmagic.io for enterprise plans.",
+              "docs": "https://leadmagic.io/docs/v1/credits",
+              "context": {
+                "credits_required": 5,
+                "credits_available": 2.5,
+                "credits_needed": 2.5
+              }
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "ResourceNotFoundError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/resource_not_found",
+              "title": "Resource not found.",
+              "status": 404,
+              "code": "resource_not_found",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "ProfileNotFoundError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/profile_not_found",
+              "title": "Profile not found or not accessible",
+              "status": 404,
+              "code": "profile_not_found",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "RateLimitExceededError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/rate_limit_exceeded",
+              "title": "Rate limit exceeded: 600 requests per 1 minute. Wait and try again.",
+              "status": 429,
+              "code": "rate_limit_exceeded",
+              "detail": "You have exceeded the maximum allowed request rate. Please wait before making additional requests.",
+              "action": "Wait 42 seconds before retrying. Consider implementing exponential backoff.",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#rate-limits",
+              "context": {
+                "limit": 600,
+                "window": "1 minute",
+                "remaining": 0,
+                "reset_at": 1706745642,
+                "retry_after_seconds": 42
+              }
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "InternalServerError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/INTERNAL_ERROR",
+              "title": "Something went wrong on our end. Our team has been notified and is investigating.",
+              "status": 500,
+              "code": "INTERNAL_ERROR",
+              "detail": "This is a temporary server error. The issue has been automatically reported to our team.",
+              "action": "Wait 30 seconds and retry your request. If the problem persists, contact support@leadmagic.io",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "ExternalServiceError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/external_service_error",
+              "title": "Error communicating with external service. Please try again.",
+              "status": 502,
+              "code": "external_service_error",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "ServiceUnavailableError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/service_unavailable",
+              "title": "Service temporarily unavailable. Please try again later.",
+              "status": 503,
+              "code": "service_unavailable",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "ConflictError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          }
+        ],
+        "example": {
+          "success": false,
+          "errors": [
+            {
+              "type": "https://api.leadmagic.io/errors/conflict",
+              "title": "Resource conflict detected.",
+              "status": 409,
+              "code": "conflict",
+              "docs": "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+            }
+          ],
+          "meta": {
+            "request_id": "ea6e3248-f4d2-437d-bca3-20881b529129",
+            "timestamp": "2024-02-01T12:00:00.000Z"
+          }
+        }
+      },
+      "EmailValidationMessages": {
+        "type": "string",
+        "description": "Possible success messages for email validation",
+        "enum": [
+          "Email is valid.",
+          "Email is invalid.",
+          "Unable to determine email validity."
+        ]
+      },
+      "EmailFinderMessages": {
+        "type": "string",
+        "description": "Possible success messages for email finder",
+        "enum": [
+          "Valid email found.",
+          "No email found for this person at this company."
+        ]
+      },
+      "MobileFinderMessages": {
+        "type": "string",
+        "description": "Possible success messages for mobile finder",
+        "enum": [
+          "Mobile number found.",
+          "No mobile number found for this contact."
+        ]
+      },
+      "ProfileSearchMessages": {
+        "type": "string",
+        "description": "Possible success messages for profile search",
+        "enum": [
+          "Profile found.",
+          "Profile not found or not accessible."
+        ]
+      },
+      "CompanySearchMessages": {
+        "type": "string",
+        "description": "Possible success messages for company search",
+        "enum": [
+          "Company found.",
+          "Company not found"
+        ]
+      },
+      "RoleFinderMessages": {
+        "type": "string",
+        "description": "Possible success messages for role finder",
+        "enum": [
+          "Role found.",
+          "No matching role found at this company."
+        ]
+      },
+      "EmployeeFinderMessages": {
+        "type": "string",
+        "description": "Possible success messages for employee finder",
+        "enum": [
+          "Employees found.",
+          "No employees found for this company."
+        ]
+      },
+      "JobChangeDetectorMessages": {
+        "type": "string",
+        "description": "Possible success messages for job change detector",
+        "enum": [
+          "No job change detected. Still employed at expected company.",
+          "Job change detected. Person has moved to a new company.",
+          "Never worked at the expected company."
+        ]
+      },
+      "CompetitorsSearchMessages": {
+        "type": "string",
+        "description": "Possible success messages for competitors search",
+        "enum": [
+          "Competitors found.",
+          "No competitors found for this company."
+        ]
+      },
+      "CompanyFundingMessages": {
+        "type": "string",
+        "description": "Possible success messages for company funding",
+        "enum": [
+          "Funding data found.",
+          "Company funding data not found"
+        ]
+      },
+      "TechnographicsMessages": {
+        "type": "string",
+        "description": "Possible success messages for technographics",
+        "enum": [
+          "Technologies found.",
+          "No technology data found for this domain."
+        ]
+      },
+      "AdsSearchMessages": {
+        "type": "string",
+        "description": "Possible success messages for ads search endpoints",
+        "enum": [
+          "Ads found.",
+          "No ads found for this company."
+        ]
+      },
+      "PersonalEmailFinderMessages": {
+        "type": "string",
+        "description": "Possible success messages for personal email finder",
+        "enum": [
+          "Personal email found.",
+          "No personal email found for this contact."
+        ]
+      },
+      "B2BProfileToEmailMessages": {
+        "type": "string",
+        "description": "Possible success messages for B2B profile to email",
+        "enum": [
+          "Email found for this profile.",
+          "No email found for this profile."
+        ]
+      },
+      "EmailToB2BProfileMessages": {
+        "type": "string",
+        "description": "Possible success messages for email to B2B profile",
+        "enum": [
+          "Profile URL found.",
+          "No profile found for this email."
+        ]
+      },
+      "RateLimitHeaders": {
+        "type": "object",
+        "description": "Rate limit headers returned with every response",
+        "properties": {
+          "RateLimit-Limit": {
+            "type": "integer",
+            "description": "IETF Standard - Maximum requests per minute",
+            "example": 600
+          },
+          "RateLimit-Remaining": {
+            "type": "integer",
+            "description": "IETF Standard - Requests remaining this minute",
+            "example": 587
+          },
+          "RateLimit-Reset": {
+            "type": "integer",
+            "description": "IETF Standard - Seconds until limit resets",
+            "example": 42
+          },
+          "X-RateLimit-Limit": {
+            "type": "integer",
+            "description": "Legacy - Maximum requests per minute",
+            "example": 600
+          },
+          "X-RateLimit-Remaining": {
+            "type": "integer",
+            "description": "Legacy - Requests remaining this minute",
+            "example": 587
+          },
+          "X-RateLimit-Reset": {
+            "type": "integer",
+            "description": "Legacy - Unix timestamp when limit resets",
+            "example": 1706745600
+          },
+          "X-RateLimit-Limit-Daily": {
+            "type": "integer",
+            "description": "Daily request limit",
+            "example": 500000
+          },
+          "X-RateLimit-Remaining-Daily": {
+            "type": "integer",
+            "description": "Requests remaining today",
+            "example": 485000
+          },
+          "X-RateLimit-Reset-Daily": {
+            "type": "integer",
+            "description": "Unix timestamp when daily limit resets",
+            "example": 1706832000
+          },
+          "X-Credits-Remaining": {
+            "type": "number",
+            "description": "Wallet credits remaining after this request",
+            "example": 15432.5
+          },
+          "X-Credits-Cost": {
+            "type": "number",
+            "description": "Credits reserved for this route before finalization (may exceed credits actually charged)",
+            "example": 1
+          },
+          "X-Credits-Consumed": {
+            "type": "number",
+            "description": "Credits actually charged after finalization (matches body credits_consumed)",
+            "example": 1
+          },
+          "X-Credits-Total": {
+            "type": "number",
+            "description": "Wallet credit balance at authorization",
+            "example": 15433.5
+          },
+          "X-Credits-Max-Cost": {
+            "type": "number",
+            "description": "Maximum credits that could be charged for this request",
+            "example": 1
+          },
+          "X-Request-Id": {
+            "type": "string",
+            "description": "Correlation id for support troubleshooting"
+          },
+          "X-RateLimit-Soft-Mode": {
+            "type": "string",
+            "description": "Whether soft mode is enabled (warn but don't block)",
+            "example": "true"
+          },
+          "X-RateLimit-Daily-Usage-Percent": {
+            "type": "integer",
+            "description": "Daily usage as percentage",
+            "example": 15
+          },
+          "X-RateLimit-RPM-Usage-Percent": {
+            "type": "integer",
+            "description": "Current minute usage as percentage",
+            "example": 5
+          },
+          "Retry-After": {
+            "type": "integer",
+            "description": "Seconds to wait before retrying (only on 429 responses)",
+            "example": 42
+          }
+        }
+      },
+      "BulkSubmissionRequest": {
+        "type": "object",
+        "description": "Request body for submitting a bulk enrichment job via POST /bulk/submit. Provide exactly one of rows, csv, fileUrl, or scrape.",
+        "required": [
+          "product"
+        ],
+        "properties": {
+          "product": {
+            "type": "string",
+            "description": "The enrichment product to run on each row (e.g. email_finder, email_validation, mobile_finder, profile_search, company_search).",
+            "example": "email_finder"
+          },
+          "rows": {
+            "type": "array",
+            "description": "JSON array of row objects for /bulk/json (or /bulk/submit auto-detect). Each row is an object whose keys match the input fields the selected product expects.",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "csv": {
+            "type": "string",
+            "description": "Inline CSV string for /bulk/csv (or /bulk/submit)."
+          },
+          "fileUrl": {
+            "type": "string",
+            "description": "Public HTTPS URL to a remote file (CSV, JSON, JSONL). SSRF-validated server-side.",
+            "format": "uri"
+          },
+          "format": {
+            "type": "string",
+            "description": "File format for fileUrl submissions.",
+            "enum": [
+              "csv",
+              "json",
+              "jsonl"
+            ]
+          },
+          "scrape": {
+            "type": "object",
+            "description": "Browser-rendering config for /bulk/scrape (or /bulk/submit).",
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "scrape",
+                  "crawl",
+                  "content",
+                  "markdown",
+                  "links",
+                  "json",
+                  "snapshot"
+                ]
+              },
+              "extractPrompt": {
+                "type": "string"
+              },
+              "render": {
+                "type": "boolean"
+              },
+              "maxPages": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 50
+              },
+              "maxDepth": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10
+              }
+            }
+          },
+          "inputMapping": {
+            "type": "object",
+            "description": "Optional column mapping from CSV/JSON columns to product input fields.",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "column": {
+                  "type": "string"
+                },
+                "value": {}
+              }
+            }
+          },
+          "callback": {
+            "type": "object",
+            "description": "Webhook configuration.",
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "HTTPS URL to receive a POST on completion/failure. SSRF-validated."
+              },
+              "events": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "completed",
+                    "failed",
+                    "canceled",
+                    "any",
+                    "job.completed",
+                    "job.failed",
+                    "job.canceled"
+                  ]
+                },
+                "default": [
+                  "completed"
+                ]
+              },
+              "inlineResults": {
+                "type": "boolean"
+              },
+              "secret": {
+                "type": "string"
+              },
+              "metadata": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "description": "Optional idempotency key for safe retries."
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "presetId": {
+            "type": "string"
+          },
+          "outputTransform": {
+            "type": "object",
+            "properties": {
+              "model": {
+                "type": "string",
+                "example": "llama-3.1-8b-instruct"
+              },
+              "prompt": {
+                "type": "string"
+              },
+              "jsonSchema": {}
+            }
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": -1000,
+            "maximum": 1000
+          },
+          "fileName": {
+            "type": "string"
+          }
+        }
+      },
+      "BulkSubmissionResponse": {
+        "type": "object",
+        "description": "Response for a successful bulk job submission. HTTP 202 Accepted.",
+        "required": [
+          "jobId",
+          "product",
+          "totalRows",
+          "status",
+          "queue"
+        ],
+        "properties": {
+          "jobId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID identifier for the bulk job.",
+            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          },
+          "product": {
+            "type": "string",
+            "description": "The enrichment product this job is running."
+          },
+          "endpoint": {
+            "type": "string",
+            "nullable": true
+          },
+          "totalRows": {
+            "type": "integer",
+            "description": "Total number of rows in the submission."
+          },
+          "status": {
+            "type": "string",
+            "description": "Always 'uploaded' for a freshly submitted job.",
+            "example": "uploaded"
+          },
+          "queue": {
+            "type": "object",
+            "properties": {
+              "position": {
+                "type": "integer"
+              },
+              "started": {
+                "type": "boolean"
+              },
+              "queuedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "statusUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "streamUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "wsUrl": {
+            "type": "string"
+          },
+          "resultsUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "rowsUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "errorsUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "eventsUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "eventsExportUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "logsUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "downloadUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "progressUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "token": {
+            "type": "string",
+            "description": "Progress token for follow-up reads without the API key."
+          },
+          "exp": {
+            "type": "integer",
+            "description": "Unix timestamp when the progress token expires."
+          }
+        }
+      },
+      "JobSummary": {
+        "type": "object",
+        "required": [
+          "job_id",
+          "status",
+          "total_rows",
+          "processed_items",
+          "succeeded_items",
+          "failed_items",
+          "created_at"
+        ],
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "products": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "submission_product": {
+            "type": "string",
+            "nullable": true
+          },
+          "submission_endpoint": {
+            "type": "string",
+            "nullable": true
+          },
+          "total_rows": {
+            "type": "integer"
+          },
+          "processed_items": {
+            "type": "integer"
+          },
+          "succeeded_items": {
+            "type": "integer"
+          },
+          "failed_items": {
+            "type": "integer"
+          },
+          "total_credits_consumed": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "last_progress_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "file_name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "JobsListResponse": {
+        "type": "object",
+        "required": [
+          "jobs",
+          "limit",
+          "offset"
+        ],
+        "properties": {
+          "jobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JobSummary"
+            }
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        }
+      },
+      "JobSnapshot": {
+        "type": "object",
+        "required": [
+          "job_id",
+          "status",
+          "total_rows",
+          "processed_items",
+          "succeeded_items",
+          "failed_items",
+          "skipped_items",
+          "created_at"
+        ],
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "products": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "submission_product": {
+            "type": "string",
+            "nullable": true
+          },
+          "submission_endpoint": {
+            "type": "string",
+            "nullable": true
+          },
+          "execution_mode": {
+            "type": "string",
+            "nullable": true
+          },
+          "total_rows": {
+            "type": "integer"
+          },
+          "processed_items": {
+            "type": "integer"
+          },
+          "succeeded_items": {
+            "type": "integer"
+          },
+          "failed_items": {
+            "type": "integer"
+          },
+          "skipped_items": {
+            "type": "integer"
+          },
+          "total_credits_consumed": {
+            "type": "string",
+            "nullable": true
+          },
+          "total_duration_ms": {
+            "type": "integer",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "last_progress_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "file_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "callback_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "callback_event": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "nullable": true
+          },
+          "output_transform": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Optional output transform applied to result rows."
+          }
+        }
+      },
+      "JobDetailResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/JobSnapshot"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "links": {
+                "type": "object",
+                "properties": {
+                  "statusUrl": {
+                    "type": "string"
+                  },
+                  "streamUrl": {
+                    "type": "string"
+                  },
+                  "wsUrl": {
+                    "type": "string"
+                  },
+                  "resultsUrl": {
+                    "type": "string"
+                  },
+                  "rowsUrl": {
+                    "type": "string"
+                  },
+                  "errorsUrl": {
+                    "type": "string"
+                  },
+                  "eventsUrl": {
+                    "type": "string"
+                  },
+                  "eventsExportUrl": {
+                    "type": "string"
+                  },
+                  "logsUrl": {
+                    "type": "string"
+                  },
+                  "downloadUrl": {
+                    "type": "string"
+                  },
+                  "progressUrl": {
+                    "type": "string"
+                  },
+                  "token": {
+                    "type": "string"
+                  },
+                  "exp": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ReviewResponse": {
+        "type": "object",
+        "required": [
+          "jobId",
+          "status"
+        ],
+        "properties": {
+          "jobId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "running",
+              "canceled"
+            ]
+          }
+        }
+      },
+      "JobRow": {
+        "type": "object",
+        "required": [
+          "id",
+          "row_index",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "row_index": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "lm_input": {
+            "type": "object",
+            "nullable": true
+          },
+          "lm_output": {
+            "type": "object",
+            "nullable": true
+          },
+          "credits_consumed": {
+            "type": "string",
+            "nullable": true
+          },
+          "error_message": {
+            "type": "string",
+            "nullable": true
+          },
+          "http_status_code": {
+            "type": "integer",
+            "nullable": true
+          },
+          "response_time_ms": {
+            "type": "integer",
+            "nullable": true
+          },
+          "completed_at": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "JobRowsResponse": {
+        "type": "object",
+        "required": [
+          "rows",
+          "limit",
+          "offset"
+        ],
+        "properties": {
+          "rows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JobRow"
+            }
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        }
+      },
+      "PreviewCostRequest": {
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 10000,
+            "items": {
+              "type": "object",
+              "properties": {
+                "product": {
+                  "type": "string",
+                  "description": "Required for mixed-product mode. Omitted for per-product mode."
+                },
+                "input": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "client_id": {
+                  "type": "string"
+                },
+                "client_name": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "budget_user_id": {
+            "type": "string",
+            "description": "User ID to check against configured Credit Budgets."
+          },
+          "client_id": {
+            "type": "string"
+          },
+          "client_name": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "PreviewCostResponse": {
+        "type": "object",
+        "required": [
+          "totalItems",
+          "totalCredits",
+          "estimatedCostUsd",
+          "perProduct",
+          "willExceedBudget"
+        ],
+        "properties": {
+          "totalItems": {
+            "type": "integer"
+          },
+          "creditsPerItem": {
+            "type": "number",
+            "nullable": true
+          },
+          "totalCredits": {
+            "type": "number"
+          },
+          "estimatedCostUsd": {
+            "type": "number"
+          },
+          "perProduct": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "product": {
+                  "type": "string"
+                },
+                "items": {
+                  "type": "integer"
+                },
+                "creditsPerItem": {
+                  "type": "number"
+                },
+                "credits": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "clientCreditRemaining": {
+            "type": "string",
+            "nullable": true
+          },
+          "willExceedBudget": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Budget": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "scope_value": {
+            "type": "string"
+          },
+          "max_credits": {
+            "type": "number"
+          },
+          "period": {
+            "type": "string"
+          },
+          "alert_threshold_pct": {
+            "type": "number"
+          },
+          "alert_email": {
+            "type": "string"
+          }
+        }
+      },
+      "BudgetStatus": {
+        "type": "object",
+        "properties": {
+          "scope": {
+            "type": "string"
+          },
+          "scopeValue": {
+            "type": "string"
+          },
+          "maxCredits": {
+            "type": "number"
+          },
+          "remainingCredits": {
+            "type": "number"
+          },
+          "isExceeded": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SuppressionList": {
+        "type": "object",
+        "properties": {
+          "list_id": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad Request - The request was malformed or contains invalid parameters.\n\n**Common causes:**\n- Missing required fields\n- Invalid field format (e.g., malformed email)\n- Invalid JSON syntax\n- Invalid parameter values\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized - Authentication failed.\n\n**Common causes:**\n- Missing X-API-Key header\n- Invalid or expired API key\n- Malformed API key\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/MissingAuthenticationError"
+                },
+                {
+                  "$ref": "#/components/schemas/InvalidApiKeyError"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Forbidden - You don't have permission to access this resource.\n\n**Common causes:**\n- API key doesn't have access to this endpoint\n- Plan limitations\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/InsufficientPermissionsError"
+            }
+          }
+        }
+      },
+      "PaymentRequired": {
+        "description": "Payment Required - Insufficient credits for this request.\n\n**Action required:** Add credits to your account at https://app.leadmagic.io/settings/billing\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/InsufficientCreditsError"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Not Found - The requested resource could not be found.\n\n**Common causes:**\n- Profile doesn't exist or is not accessible\n- Company not found in our database\n- Invalid URL or identifier\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ResourceNotFoundError"
+                },
+                {
+                  "$ref": "#/components/schemas/ProfileNotFoundError"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "Conflict - The request conflicts with the current state of the resource.\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ConflictError"
+            }
+          }
+        }
+      },
+      "RateLimitExceeded": {
+        "description": "Too Many Requests - Rate limit exceeded.\n\n**Action required:** Check the `Retry-After` header for when to retry.\n\n**Headers returned:**\n- `Retry-After`: Seconds until you can retry\n- `RateLimit-Limit`: Your limit per minute\n- `RateLimit-Remaining`: Remaining requests this minute\n- `RateLimit-Reset`: Seconds until limit resets\n",
+        "headers": {
+          "Retry-After": {
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Seconds to wait before retrying"
+          },
+          "RateLimit-Limit": {
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Maximum requests per minute"
+          },
+          "RateLimit-Remaining": {
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Remaining requests this minute"
+          },
+          "RateLimit-Reset": {
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Seconds until limit resets"
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/RateLimitExceededError"
+            }
+          }
+        }
+      },
+      "InternalServerError": {
+        "description": "Internal Server Error - Something went wrong on our end.\n\n**Action required:** Wait 30 seconds and retry. If the problem persists, contact support@leadmagic.io\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/InternalServerError"
+            }
+          }
+        }
+      },
+      "BadGateway": {
+        "description": "Bad Gateway - Error communicating with an upstream service.\n\n**Action required:** Retry after a brief delay.\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ExternalServiceError"
+            }
+          }
+        }
+      },
+      "ServiceUnavailable": {
+        "description": "Service Unavailable - The service is temporarily unavailable.\n\n**Action required:** Retry after a brief delay.\n",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/ServiceUnavailableError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Credits",
+      "description": "Manage and check your credit balance"
+    },
+    {
+      "name": "Analytics",
+      "description": "Monitor your API usage with comprehensive analytics endpoints (FREE - no credits consumed)"
+    },
+    {
+      "name": "People Enrichment",
+      "description": "Find and validate contact information for individuals"
+    },
+    {
+      "name": "Company Data",
+      "description": "Discover company information and intelligence"
+    },
+    {
+      "name": "Jobs Data",
+      "description": "Search job listings and detect career changes"
+    },
+    {
+      "name": "Ads Data",
+      "description": "Search advertising data across platforms"
+    },
+    {
+      "name": "Bulk Jobs",
+      "description": "Submit and manage bulk enrichment jobs for processing CSV files at scale"
+    },
+    {
+      "name": "Batch",
+      "description": "Campaign-oriented batch enrichment with budgets, clients, suppression lists, and webhooks"
+    },
+    {
+      "name": "Cost Control",
+      "description": "Preview costs, manage credit budgets, and maintain suppression lists to control spend"
+    }
+  ],
+  "paths": {
+    "/v1/credits": {
+      "get": {
+        "summary": "Check Credits",
+        "description": "Check your current credit balance.",
+        "operationId": "check-credits",
+        "tags": [
+          "Credits"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful credits retrieval",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credits": {
+                      "type": "number",
+                      "example": 2200
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/analytics/dashboard": {
+      "get": {
+        "summary": "Dashboard Overview",
+        "description": "Get a real-time snapshot of your account including credits, rate limits, and usage statistics.",
+        "operationId": "analytics-dashboard",
+        "tags": [
+          "Analytics"
+        ],
+        "responses": {
+          "200": {
+            "description": "Dashboard data retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "user_abc123"
+                        },
+                        "email": {
+                          "type": "string",
+                          "example": "developer@leadmagic.io"
+                        }
+                      }
+                    },
+                    "credits": {
+                      "type": "object",
+                      "properties": {
+                        "current": {
+                          "type": "number",
+                          "example": 15432.5
+                        },
+                        "formatted": {
+                          "type": "string",
+                          "example": "$154.33"
+                        }
+                      }
+                    },
+                    "rate_limit": {
+                      "type": "object",
+                      "properties": {
+                        "minute": {
+                          "type": "object",
+                          "properties": {
+                            "limit": {
+                              "type": "integer",
+                              "example": 600
+                            },
+                            "used": {
+                              "type": "integer",
+                              "example": 45
+                            },
+                            "remaining": {
+                              "type": "integer",
+                              "example": 555
+                            },
+                            "utilization": {
+                              "type": "number",
+                              "example": 15
+                            }
+                          }
+                        },
+                        "daily": {
+                          "type": "object",
+                          "properties": {
+                            "limit": {
+                              "type": "integer",
+                              "example": 500000
+                            },
+                            "used": {
+                              "type": "integer",
+                              "example": 12500
+                            },
+                            "remaining": {
+                              "type": "integer",
+                              "example": 487500
+                            },
+                            "utilization": {
+                              "type": "number",
+                              "example": 2.5
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "concurrency": {
+                      "type": "object",
+                      "properties": {
+                        "current": {
+                          "type": "integer",
+                          "example": 0
+                        },
+                        "peak": {
+                          "type": "integer",
+                          "example": 23
+                        },
+                        "active_reservations": {
+                          "type": "integer",
+                          "example": 0
+                        }
+                      }
+                    },
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "today": {
+                          "type": "object",
+                          "properties": {
+                            "requests": {
+                              "type": "integer",
+                              "example": 1250
+                            },
+                            "credits": {
+                              "type": "number",
+                              "example": 875.5
+                            },
+                            "chargeable_requests": {
+                              "type": "integer",
+                              "example": 1100
+                            },
+                            "chargeable_rate": {
+                              "type": "number",
+                              "example": 88
+                            },
+                            "unique_products": {
+                              "type": "integer",
+                              "example": 5
+                            }
+                          }
+                        },
+                        "this_week": {
+                          "type": "object",
+                          "properties": {
+                            "requests": {
+                              "type": "integer",
+                              "example": 8500
+                            },
+                            "credits": {
+                              "type": "number",
+                              "example": 5200.25
+                            },
+                            "chargeable_requests": {
+                              "type": "integer",
+                              "example": 7200
+                            },
+                            "chargeable_rate": {
+                              "type": "number",
+                              "example": 84.7
+                            },
+                            "unique_products": {
+                              "type": "integer",
+                              "example": 8
+                            }
+                          }
+                        },
+                        "this_month": {
+                          "type": "object",
+                          "properties": {
+                            "requests": {
+                              "type": "integer",
+                              "example": 45000
+                            },
+                            "credits": {
+                              "type": "number",
+                              "example": 28500
+                            },
+                            "chargeable_requests": {
+                              "type": "integer",
+                              "example": 38000
+                            },
+                            "chargeable_rate": {
+                              "type": "number",
+                              "example": 84.4
+                            },
+                            "unique_products": {
+                              "type": "integer",
+                              "example": 12
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/analytics/usage": {
+      "get": {
+        "summary": "Usage Summary",
+        "description": "Get daily usage summary with requests, credits consumed, and chargeable rates.",
+        "operationId": "analytics-usage",
+        "tags": [
+          "Analytics"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Number of days to include (1-90)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90,
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Usage summary retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "period": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": "string",
+                          "format": "date",
+                          "example": "2024-01-02"
+                        },
+                        "end": {
+                          "type": "string",
+                          "format": "date",
+                          "example": "2024-02-01"
+                        },
+                        "days": {
+                          "type": "integer",
+                          "example": 30
+                        }
+                      }
+                    },
+                    "summary": {
+                      "type": "object",
+                      "properties": {
+                        "total_requests": {
+                          "type": "integer",
+                          "example": 45000
+                        },
+                        "chargeable_requests": {
+                          "type": "integer",
+                          "example": 38000
+                        },
+                        "total_credits": {
+                          "type": "number",
+                          "example": 28500
+                        },
+                        "avg_credits_per_request": {
+                          "type": "number",
+                          "example": 0.63
+                        },
+                        "chargeable_rate": {
+                          "type": "number",
+                          "example": 84.4
+                        },
+                        "unique_products": {
+                          "type": "integer",
+                          "example": 12
+                        }
+                      }
+                    },
+                    "daily": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date",
+                            "example": "2024-02-01"
+                          },
+                          "total_requests": {
+                            "type": "integer",
+                            "example": 1250
+                          },
+                          "chargeable_requests": {
+                            "type": "integer",
+                            "example": 1100
+                          },
+                          "total_credits": {
+                            "type": "number",
+                            "example": 875.5
+                          },
+                          "unique_products_used": {
+                            "type": "integer",
+                            "example": 5
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/analytics/products": {
+      "get": {
+        "summary": "Products Breakdown",
+        "description": "Get per-product usage with requests, credits, and success rates.",
+        "operationId": "analytics-products",
+        "tags": [
+          "Analytics"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Number of days to include (1-90)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90,
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Products breakdown retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "period": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "end": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "days": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "products": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "total_requests": {
+                            "type": "integer",
+                            "example": 20000
+                          },
+                          "total_credits": {
+                            "type": "number",
+                            "example": 1000
+                          },
+                          "successful_requests": {
+                            "type": "integer",
+                            "example": 19500
+                          },
+                          "failed_requests": {
+                            "type": "integer",
+                            "example": 500
+                          },
+                          "success_rate": {
+                            "type": "number",
+                            "example": 97.5
+                          },
+                          "avg_credits_per_request": {
+                            "type": "number",
+                            "example": 0.25
+                          }
+                        }
+                      }
+                    },
+                    "daily": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/analytics/credits": {
+      "get": {
+        "summary": "Credit History",
+        "description": "Get credit consumption history with daily breakdown.",
+        "operationId": "analytics-credits",
+        "tags": [
+          "Analytics"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Number of days to include (1-90)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90,
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Credit history retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "period": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "end": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "days": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "summary": {
+                      "type": "object",
+                      "properties": {
+                        "total_credits": {
+                          "type": "number",
+                          "example": 28500
+                        },
+                        "total_requests": {
+                          "type": "integer",
+                          "example": 45000
+                        },
+                        "chargeable_requests": {
+                          "type": "integer",
+                          "example": 38000
+                        },
+                        "avg_credits_per_request": {
+                          "type": "number",
+                          "example": 0.63
+                        },
+                        "chargeable_rate": {
+                          "type": "number",
+                          "example": 84.4
+                        }
+                      }
+                    },
+                    "daily": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date"
+                          },
+                          "total_credits": {
+                            "type": "number"
+                          },
+                          "total_requests": {
+                            "type": "integer"
+                          },
+                          "chargeable_requests": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/analytics/summary": {
+      "get": {
+        "summary": "All-Time Summary",
+        "description": "Get lifetime statistics for your account.",
+        "operationId": "analytics-summary",
+        "tags": [
+          "Analytics"
+        ],
+        "parameters": [
+          {
+            "name": "start_date",
+            "in": "query",
+            "description": "Start date (YYYY-MM-DD)",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "description": "End date (YYYY-MM-DD)",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Summary statistics retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total_api_requests": {
+                      "type": "integer",
+                      "example": 1250000
+                    },
+                    "total_credits_consumed": {
+                      "type": "number",
+                      "example": 425000.5
+                    },
+                    "unique_products_used": {
+                      "type": "integer",
+                      "example": 15
+                    },
+                    "successful_requests": {
+                      "type": "integer",
+                      "example": 1150000
+                    },
+                    "failed_requests": {
+                      "type": "integer",
+                      "example": 100000
+                    },
+                    "success_rate": {
+                      "type": "number",
+                      "example": 92
+                    },
+                    "avg_response_time_ms": {
+                      "type": "number",
+                      "example": 245
+                    },
+                    "first_request": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "example": "2023-06-15T10:30:00.000Z"
+                    },
+                    "last_request": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "example": "2024-02-01T14:22:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/analytics/daily": {
+      "get": {
+        "summary": "Daily Metrics",
+        "description": "Get detailed daily metrics with performance data.",
+        "operationId": "analytics-daily",
+        "tags": [
+          "Analytics"
+        ],
+        "parameters": [
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Number of days to include (1-90)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90,
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Daily metrics retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "period": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "end": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "days": {
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                            "format": "date"
+                          },
+                          "total_requests": {
+                            "type": "integer"
+                          },
+                          "successful_requests": {
+                            "type": "integer"
+                          },
+                          "failed_requests": {
+                            "type": "integer"
+                          },
+                          "total_credits": {
+                            "type": "number"
+                          },
+                          "p50_latency_ms": {
+                            "type": "number"
+                          },
+                          "p95_latency_ms": {
+                            "type": "number"
+                          },
+                          "p99_latency_ms": {
+                            "type": "number"
+                          },
+                          "error_rate": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/analytics/day/{date}": {
+      "get": {
+        "summary": "Day Breakdown",
+        "description": "Get per-product breakdown for a specific day.",
+        "operationId": "analytics-day",
+        "tags": [
+          "Analytics"
+        ],
+        "parameters": [
+          {
+            "name": "date",
+            "in": "path",
+            "required": true,
+            "description": "Date in YYYY-MM-DD format",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Day breakdown retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "date": {
+                      "type": "string",
+                      "format": "date",
+                      "example": "2024-02-01"
+                    },
+                    "summary": {
+                      "type": "object",
+                      "properties": {
+                        "total_credits": {
+                          "type": "number",
+                          "example": 875.5
+                        },
+                        "total_requests": {
+                          "type": "integer",
+                          "example": 1250
+                        },
+                        "products_count": {
+                          "type": "integer",
+                          "example": 8
+                        }
+                      }
+                    },
+                    "products": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "product_id": {
+                            "type": "string",
+                            "example": "email_validation"
+                          },
+                          "requests": {
+                            "type": "integer",
+                            "example": 500
+                          },
+                          "credits": {
+                            "type": "number",
+                            "example": 25
+                          },
+                          "credits_percentage": {
+                            "type": "number",
+                            "example": 2.86
+                          },
+                          "avg_credits_per_request": {
+                            "type": "number",
+                            "example": 0.25
+                          },
+                          "max_credits": {
+                            "type": "number",
+                            "example": 0.25
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/people/email-validation": {
+      "post": {
+        "summary": "Email Validation",
+        "description": "Validate an email address for deliverability and get company enrichment data.",
+        "operationId": "email-validation",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email address to validate",
+                    "example": "alex.rivera@example.com"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "example": "alex.rivera@example.com"
+                    },
+                    "email_status": {
+                      "type": "string",
+                      "example": "valid"
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "example": 0.25
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Email is valid."
+                    },
+                    "mx_record": {
+                      "type": "string",
+                      "example": "mx1.example.com"
+                    },
+                    "mx_provider": {
+                      "type": "string",
+                      "example": "Example Mail"
+                    },
+                    "mx_gateway": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Security gateway vendor name",
+                      "example": null
+                    },
+                    "mx_gateway_type": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Security gateway type",
+                      "example": null
+                    },
+                    "mx_security_gateway": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "company_name": {
+                      "type": "string",
+                      "example": "Leadmagic"
+                    },
+                    "company_industry": {
+                      "type": "string",
+                      "example": "Internet"
+                    },
+                    "company_size": {
+                      "type": "string",
+                      "example": "11-50"
+                    },
+                    "company_founded": {
+                      "type": "integer",
+                      "example": 2022
+                    },
+                    "company_type": {
+                      "type": "string",
+                      "example": "Private"
+                    },
+                    "company_location": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "example": "Boston, Massachusetts, United States"
+                        },
+                        "locality": {
+                          "type": "string",
+                          "example": "Boston"
+                        },
+                        "region": {
+                          "type": "string",
+                          "example": "Massachusetts"
+                        },
+                        "metro": {
+                          "type": "string",
+                          "example": "Boston"
+                        },
+                        "country": {
+                          "type": "string",
+                          "example": "United States"
+                        },
+                        "continent": {
+                          "type": "string",
+                          "example": "North America"
+                        },
+                        "street_address": {
+                          "type": "string",
+                          "example": "1 Seaport Lane"
+                        },
+                        "address_line_2": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": null
+                        },
+                        "postal_code": {
+                          "type": "string",
+                          "example": "02210"
+                        },
+                        "geo": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": null
+                        }
+                      }
+                    },
+                    "company_linkedin_url": {
+                      "type": "string",
+                      "description": "Legacy field name for the B2B company profile.",
+                      "example": "example.com/company/acme"
+                    },
+                    "company_linkedin_id": {
+                      "type": "string",
+                      "example": "75153174"
+                    },
+                    "company_facebook_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": null
+                    },
+                    "company_twitter_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": null
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/email-finder": {
+      "post": {
+        "summary": "Email Finder",
+        "description": "Find a person's work email address using their name and company information.",
+        "operationId": "email-finder",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "first_name": {
+                    "type": "string",
+                    "description": "First name of the person (optional if full_name provided)",
+                    "default": "Alex"
+                  },
+                  "last_name": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Last name of the person (optional)",
+                    "default": "Rivera"
+                  },
+                  "full_name": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Full name of the person (alternative to first_name + last_name)",
+                    "default": "Alex Rivera"
+                  },
+                  "domain": {
+                    "type": "string",
+                    "description": "Company domain name (required if company_name not provided)",
+                    "default": "leadmagic.io"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Company name (required if domain not provided)",
+                    "default": "LeadMagic"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with email details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string",
+                      "example": "alex.rivera@example.com"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "valid"
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Valid email found."
+                    },
+                    "first_name": {
+                      "type": "string",
+                      "example": "Alex"
+                    },
+                    "last_name": {
+                      "type": "string",
+                      "example": "Rivera"
+                    },
+                    "domain": {
+                      "type": "string",
+                      "example": "leadmagic.io"
+                    },
+                    "mx_record": {
+                      "type": "string",
+                      "example": "alt3.mx1.example.com"
+                    },
+                    "mx_provider": {
+                      "type": "string",
+                      "example": "Example Mail"
+                    },
+                    "mx_security_gateway": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "has_mx": {
+                      "type": "boolean",
+                      "description": "Whether the domain has MX records",
+                      "example": true
+                    },
+                    "mx_records_full": {
+                      "type": "array",
+                      "description": "Complete list of MX records with priorities",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "priority": {
+                            "type": "integer",
+                            "example": 10
+                          },
+                          "exchange": {
+                            "type": "string",
+                            "example": "mx1.example.com"
+                          }
+                        }
+                      }
+                    },
+                    "company_name": {
+                      "type": "string",
+                      "example": "Leadmagic"
+                    },
+                    "company_industry": {
+                      "type": "string",
+                      "example": ""
+                    },
+                    "company_size": {
+                      "type": "string",
+                      "example": "11-50"
+                    },
+                    "company_founded": {
+                      "type": "integer",
+                      "example": 2022
+                    },
+                    "company_location": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "example": "boston, massachusetts, united states"
+                        },
+                        "locality": {
+                          "type": "string",
+                          "example": "boston"
+                        },
+                        "region": {
+                          "type": "string",
+                          "example": "massachusetts"
+                        },
+                        "metro": {
+                          "type": "string",
+                          "example": "boston, massachusetts"
+                        },
+                        "country": {
+                          "type": "string",
+                          "example": "united states"
+                        },
+                        "continent": {
+                          "type": "string",
+                          "example": "north america"
+                        },
+                        "street_address": {
+                          "type": "string",
+                          "example": "1 seaport lane"
+                        },
+                        "address_line_2": {
+                          "type": "string"
+                        },
+                        "postal_code": {
+                          "type": "string",
+                          "example": "02210"
+                        },
+                        "geo": {
+                          "type": "string",
+                          "example": "42.35,-71.06"
+                        }
+                      }
+                    },
+                    "company_profile_url": {
+                      "type": "string",
+                      "example": "leadmagichq"
+                    },
+                    "company_profile_id": {
+                      "type": "string",
+                      "example": "75153174"
+                    },
+                    "company_facebook_url": {
+                      "type": "string",
+                      "example": ""
+                    },
+                    "company_twitter_url": {
+                      "type": "string",
+                      "example": ""
+                    },
+                    "company_type": {
+                      "type": "string",
+                      "example": "private"
+                    },
+                    "employment_verified": {
+                      "type": "boolean",
+                      "nullable": true,
+                      "description": "Whether the employment at the domain was verified",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/personal-email-finder": {
+      "post": {
+        "summary": "Personal Email Finder",
+        "description": "Provide a B2B Profile URL and get back the personal emails of the person.",
+        "operationId": "personal-email-finder",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile_url": {
+                    "type": "string",
+                    "description": "Professional profile URL or identifier",
+                    "default": "alex-rivera"
+                  }
+                },
+                "required": [
+                  "profile_url"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with personal email details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profile_url": {
+                      "type": "string",
+                      "example": "alex-rivera"
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Personal Email Found."
+                    },
+                    "name": {
+                      "type": "string",
+                      "example": "Alex Rivera"
+                    },
+                    "first_personal_email": {
+                      "type": "string",
+                      "example": "alex-riveral@gmail.com"
+                    },
+                    "personal_emails": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": [
+                        "alex-riveral@gmail.com"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/b2b-profile-email": {
+      "post": {
+        "summary": "B2B Person Profile to Email",
+        "description": "Provide a B2B person profile and get back the work email of the person.",
+        "operationId": "b2b-profile-email",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile_url": {
+                    "type": "string",
+                    "description": "B2B person profile URL or slug",
+                    "default": "alex-rivera"
+                  }
+                },
+                "required": [
+                  "profile_url"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with profile and email details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profile_url": {
+                      "type": "string",
+                      "example": "alex-rivera"
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 5
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Email Found."
+                    },
+                    "email": {
+                      "type": "string",
+                      "example": "alex.rivera@example.com"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/profile-search": {
+      "post": {
+        "summary": "B2B Person Profile",
+        "description": "Retrieve comprehensive B2B person profile information including work history, education, certifications, and more.",
+        "operationId": "profile-search",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile_url": {
+                    "type": "string",
+                    "description": "B2B person profile URL or slug",
+                    "example": "alex-rivera"
+                  }
+                },
+                "required": [
+                  "profile_url"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with profile information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profile_url": {
+                      "type": "string",
+                      "example": "alex-rivera"
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "first_name": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "Alex"
+                    },
+                    "last_name": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "Rivera"
+                    },
+                    "full_name": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "Alex Rivera"
+                    },
+                    "professional_title": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "Growth & AI Expert | Founder LeadMagic"
+                    },
+                    "bio": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "SaaS Founder"
+                    },
+                    "company_name": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "LeadMagic"
+                    },
+                    "company_industry": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "Internet"
+                    },
+                    "company_website": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "leadmagic.io"
+                    },
+                    "total_tenure_months": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "205"
+                    },
+                    "total_tenure_days": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "6240"
+                    },
+                    "total_tenure_years": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "17"
+                    },
+                    "followers_range": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "45K-50K",
+                      "description": "Follower count range for privacy (e.g. \"45K-50K\", \"1M+\")"
+                    },
+                    "personal_website": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "example": "https://leadmagic.io"
+                        },
+                        "link": {
+                          "type": "string",
+                          "example": "https://leadmagic.io"
+                        }
+                      }
+                    },
+                    "country": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "United States"
+                    },
+                    "location": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "Greater Boston"
+                    },
+                    "work_experience": {
+                      "type": "array",
+                      "nullable": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "position_title": {
+                            "type": "string",
+                            "example": "Founder"
+                          },
+                          "company_name": {
+                            "type": "string",
+                            "example": "LeadMagic"
+                          },
+                          "employment_period": {
+                            "type": "string",
+                            "example": "Sep 2022 - Present · 3 yrs 2 mos"
+                          },
+                          "company_website": {
+                            "type": "string",
+                            "nullable": true,
+                            "example": "leadmagic.io",
+                            "description": "Only included when domain is available"
+                          },
+                          "company_logo_url": {
+                            "type": "string",
+                            "nullable": true,
+                            "example": "https://logo.leadmagic.io/leadmagic.io",
+                            "description": "Only included when domain is available"
+                          }
+                        }
+                      }
+                    },
+                    "education": {
+                      "type": "array",
+                      "nullable": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "institution_name": {
+                            "type": "string",
+                            "example": "University of Maine"
+                          },
+                          "degree": {
+                            "type": "string",
+                            "example": "University of Maine"
+                          },
+                          "attendance_period": {
+                            "type": "string",
+                            "example": ""
+                          }
+                        }
+                      }
+                    },
+                    "certifications": {
+                      "type": "array",
+                      "nullable": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "certification_name": {
+                            "type": "string",
+                            "example": "Revenue Architect"
+                          },
+                          "issuing_organization": {
+                            "type": "string",
+                            "example": "Winning by Design"
+                          },
+                          "issue_date": {
+                            "type": "string",
+                            "example": "Issued Nov 2020"
+                          }
+                        }
+                      }
+                    },
+                    "honors": {
+                      "type": "array",
+                      "nullable": true,
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "example": "Hortonworks - MVP NorthEast - Region - 2016"
+                          },
+                          "description": {
+                            "type": "string",
+                            "example": "Issued by Hortonworks · Jan 2016"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/b2b-profile": {
+      "post": {
+        "summary": "Email Address to B2B Person Profile",
+        "description": "Use this endpoint to find a B2B person profile based on the provided email.",
+        "operationId": "email-to-b2b-profile",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "work_email": {
+                    "type": "string",
+                    "description": "Provide the Work Email of the person",
+                    "default": "alex.rivera@example.com"
+                  },
+                  "personal_email": {
+                    "type": "string",
+                    "description": "Provide the Personal Email of the person",
+                    "default": "alex-riveral@gmail.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with B2B profile details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profile_url": {
+                      "type": "string",
+                      "example": "jouellette"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Profile URL found"
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 10
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/mobile-finder": {
+      "post": {
+        "summary": "Mobile Finder",
+        "description": "Find a person's mobile phone number using their profile URL or email address.",
+        "operationId": "mobile-finder",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile_url": {
+                    "type": "string",
+                    "description": "Provide their Social Media URL",
+                    "default": "alex-rivera"
+                  },
+                  "work_email": {
+                    "type": "string",
+                    "description": "Provide the Work Email of the person",
+                    "default": "alex.rivera@example.com"
+                  },
+                  "personal_email": {
+                    "type": "string",
+                    "description": "Provide the Personal Email of the person",
+                    "default": "alex-riveral@gmail.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with mobile details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profile_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "example": "alex-rivera"
+                    },
+                    "email": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Email address used in lookup (if provided)",
+                      "example": "alex.rivera@example.com"
+                    },
+                    "mobile_number": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Mobile phone number if found",
+                      "example": "12077523358"
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "example": 5
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Status message about the result",
+                      "example": "Mobile number found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/job-change-detector": {
+      "post": {
+        "summary": "Job Change Detector",
+        "description": "Monitor employee transitions and detect when someone has changed jobs.",
+        "operationId": "job-change-detector",
+        "tags": [
+          "Jobs Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile_url": {
+                    "type": "string",
+                    "description": "Professional profile URL or identifier",
+                    "example": "alex-rivera"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Expected company name (either company_name or company_domain is required)",
+                    "example": "Example Robotics"
+                  },
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Expected company domain (either company_name or company_domain is required)",
+                    "example": "smartlead.ai"
+                  }
+                },
+                "required": [
+                  "profile_url"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful job change detection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "job_change_detected": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "NO_CHANGE",
+                        "JOB_CHANGE_DETECTED",
+                        "NEVER_WORKED_THERE"
+                      ],
+                      "example": "NEVER_WORKED_THERE"
+                    },
+                    "summary": {
+                      "type": "string",
+                      "example": "Alex Rivera has never worked at Example Robotics according to their comprehensive employment history. They are currently working at Leadmagic as Founder for 3 years. Their complete employment history shows experience at Leadmagic, Atlas Guild, Northstar Labs, and 7 other companies. The expected company does not appear in any current or past positions, confirming they have never been employed there."
+                    },
+                    "employee_name": {
+                      "type": "string",
+                      "example": "Alex Rivera"
+                    },
+                    "expected_company": {
+                      "type": "string",
+                      "example": "Example Robotics"
+                    },
+                    "current_company": {
+                      "type": "string",
+                      "example": "Leadmagic"
+                    },
+                    "current_position": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "example": "Founder"
+                        },
+                        "company": {
+                          "type": "string",
+                          "example": "Leadmagic"
+                        },
+                        "start_date": {
+                          "type": "string",
+                          "example": "Sep 2022"
+                        },
+                        "days_at_job": {
+                          "type": "integer",
+                          "example": 1111
+                        },
+                        "tenure_formatted": {
+                          "type": "string",
+                          "example": "3 years"
+                        },
+                        "is_current_position": {
+                          "type": "boolean",
+                          "example": true
+                        }
+                      }
+                    },
+                    "tenure_stats": {
+                      "type": "object",
+                      "properties": {
+                        "average_tenure_months": {
+                          "type": "integer",
+                          "example": 26
+                        },
+                        "average_tenure_formatted": {
+                          "type": "string",
+                          "example": "2 years 2 months"
+                        },
+                        "total_positions": {
+                          "type": "integer",
+                          "example": 10
+                        },
+                        "longest_tenure_months": {
+                          "type": "integer",
+                          "example": 73
+                        },
+                        "longest_tenure_formatted": {
+                          "type": "string",
+                          "example": "6 years 1 month"
+                        },
+                        "shortest_tenure_months": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "shortest_tenure_formatted": {
+                          "type": "string",
+                          "example": "1 month"
+                        }
+                      }
+                    },
+                    "work_history": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "example": "Founder"
+                          },
+                          "company": {
+                            "type": "string",
+                            "example": "LeadMagic"
+                          },
+                          "duration": {
+                            "type": "string",
+                            "example": "Sep 2022 - Present"
+                          },
+                          "is_present": {
+                            "type": "boolean",
+                            "example": true
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "title": "Founder",
+                          "company": "Leadmagic",
+                          "duration": "Sep 2022 - Present",
+                          "is_present": true
+                        },
+                        {
+                          "title": "Executive Member",
+                          "company": "Atlas Guild",
+                          "duration": "Aug 2019 - Present",
+                          "is_present": true
+                        },
+                        {
+                          "title": "Advisor",
+                          "company": "Northstar Labs",
+                          "duration": "Feb 2023 - Jan 2024",
+                          "is_present": false
+                        },
+                        {
+                          "title": "Advisor",
+                          "company": "Sales Community",
+                          "duration": "May 2020 - Dec 2023",
+                          "is_present": false
+                        },
+                        {
+                          "title": "Advisor",
+                          "company": "Astronomer",
+                          "duration": "Jul 2020 - Sep 2023",
+                          "is_present": false
+                        }
+                      ]
+                    },
+                    "profile_found": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "profile_url": {
+                      "type": "string",
+                      "example": "alex-rivera"
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 2
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/companies/company-search": {
+      "post": {
+        "summary": "Company Search",
+        "description": "Search for companies and retrieve comprehensive company intelligence including funding, employees, industry, and more.",
+        "operationId": "company-search",
+        "tags": [
+          "Company Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile_url": {
+                    "type": "string",
+                    "description": "Business company profile URL or identifier",
+                    "default": "leadmagichq"
+                  },
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Provide Company Domain",
+                    "default": "leadmagic.io"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Provide Company Name",
+                    "default": "Leadmagic"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with company details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Status message",
+                      "example": "Company found"
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "description": "Number of credits consumed for this request",
+                      "example": 1
+                    },
+                    "companyName": {
+                      "type": "string",
+                      "example": "LeadMagic"
+                    },
+                    "companyId": {
+                      "type": "integer",
+                      "example": 75153174
+                    },
+                    "locations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "country": {
+                            "type": "string",
+                            "example": "US"
+                          },
+                          "city": {
+                            "type": "string",
+                            "example": "Boston"
+                          },
+                          "geographicArea": {
+                            "type": "string",
+                            "example": "Massachusetts"
+                          },
+                          "postalCode": {
+                            "type": "string",
+                            "example": "02210"
+                          },
+                          "line1": {
+                            "type": "string",
+                            "example": "1 Seaport Ln"
+                          },
+                          "line2": {
+                            "type": "string",
+                            "nullable": true,
+                            "example": null
+                          },
+                          "description": {
+                            "type": "string",
+                            "example": "Headquarters"
+                          },
+                          "headquarter": {
+                            "type": "boolean",
+                            "example": true
+                          },
+                          "localizedName": {
+                            "type": "string",
+                            "example": "Boston"
+                          },
+                          "latitude": {
+                            "type": "number",
+                            "example": 42.36041
+                          },
+                          "longitude": {
+                            "type": "number",
+                            "example": -71.05798
+                          }
+                        }
+                      }
+                    },
+                    "employeeCount": {
+                      "type": "integer",
+                      "example": 9
+                    },
+                    "specialities": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": [
+                        "Sales",
+                        "Marketing",
+                        "ABM",
+                        "RevOps"
+                      ]
+                    },
+                    "employeeCountRange": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": "integer",
+                          "example": 11
+                        },
+                        "end": {
+                          "type": "integer",
+                          "example": 50
+                        }
+                      }
+                    },
+                    "tagline": {
+                      "type": "string",
+                      "example": "Example Robotics provides enterprise software solutions for B2B companies. Their platform helps teams streamline operations and drive growth."
+                    },
+                    "followerCount": {
+                      "type": "integer",
+                      "example": 4663
+                    },
+                    "industry": {
+                      "type": "string",
+                      "example": "Internet"
+                    },
+                    "description": {
+                      "type": "string",
+                      "example": "LeadMagic tells you exactly what businesses are on your website and helps you enrich your contact and company data."
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "example": "https://leadmagic.io"
+                    },
+                    "headquarter": {
+                      "type": "object",
+                      "properties": {
+                        "country": {
+                          "type": "string",
+                          "example": "US"
+                        },
+                        "city": {
+                          "type": "string",
+                          "example": "Boston"
+                        },
+                        "geographicArea": {
+                          "type": "string",
+                          "example": "Massachusetts"
+                        },
+                        "postalCode": {
+                          "type": "string",
+                          "example": "02210"
+                        },
+                        "line1": {
+                          "type": "string",
+                          "example": "1 Seaport Ln"
+                        },
+                        "line2": {
+                          "type": "string",
+                          "nullable": true,
+                          "example": null
+                        },
+                        "description": {
+                          "type": "string",
+                          "example": "Headquarters"
+                        }
+                      }
+                    },
+                    "foundedOn": {
+                      "type": "object",
+                      "properties": {
+                        "month": {
+                          "type": "integer",
+                          "nullable": true,
+                          "example": null
+                        },
+                        "year": {
+                          "type": "integer",
+                          "example": 2022
+                        },
+                        "day": {
+                          "type": "integer",
+                          "nullable": true,
+                          "example": null
+                        }
+                      }
+                    },
+                    "universalName": {
+                      "type": "string",
+                      "example": "leadmagichq"
+                    },
+                    "hashtag": {
+                      "type": "string",
+                      "example": "#abm"
+                    },
+                    "url": {
+                      "type": "string",
+                      "example": "leadmagichq"
+                    },
+                    "logo_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Company logo URL from logo.leadmagic.io (generated from company domain)",
+                      "example": "https://logo.leadmagic.io/leadmagic.io"
+                    },
+                    "founded_year": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Year the company was founded",
+                      "example": "2009"
+                    },
+                    "ownership_status": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Ownership type (Public, Private, or Acquired)",
+                      "example": "Private"
+                    },
+                    "revenue": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "Estimated annual revenue",
+                      "example": 5100000000
+                    },
+                    "revenue_formatted": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Human-readable revenue format",
+                      "example": "5.1B"
+                    },
+                    "employee_range": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Employee count range",
+                      "example": "5,000 - 10,000"
+                    },
+                    "total_funding": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Total funding raised",
+                      "example": "9.8B"
+                    },
+                    "funding_rounds": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Number of funding rounds completed",
+                      "example": 5
+                    },
+                    "last_funding_round": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Type of most recent funding round",
+                      "example": "Equity"
+                    },
+                    "last_funding_amount": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "Amount raised in most recent funding round",
+                      "example": 694159778
+                    },
+                    "last_funding_date": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Date of most recent funding round",
+                      "example": "Apr 2024"
+                    },
+                    "competitors": {
+                      "type": "array",
+                      "nullable": true,
+                      "description": "List of competitor company names",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": [
+                        "Rapyd",
+                        "Square",
+                        "PayPal",
+                        "Clover",
+                        "Payment Depot"
+                      ]
+                    },
+                    "acquisitions_count": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Number of acquisitions made by the company",
+                      "example": 3
+                    },
+                    "twitter_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Twitter/X profile URL",
+                      "example": "https://twitter.com/leadmagichq"
+                    },
+                    "b2b_profile_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "B2B company profile URL",
+                      "example": "leadmagichq"
+                    },
+                    "facebook_url": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Facebook page URL",
+                      "example": ""
+                    },
+                    "stock_ticker": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Stock ticker symbol (if publicly traded)",
+                      "example": "STRP"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/companies/company-funding": {
+      "post": {
+        "summary": "Company Funding",
+        "description": "Provide the Company Domain or Company Name and get back the complete funding details of the company.",
+        "operationId": "company-funding",
+        "tags": [
+          "Company Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_name": {
+                    "type": "string",
+                    "description": "Provide Company Name",
+                    "default": "leadmagic"
+                  },
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Provide Company Domain",
+                    "default": "leadmagic.io"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with company funding details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "basicInfo": {
+                      "type": "object",
+                      "properties": {
+                        "companyName": {
+                          "type": "string",
+                          "example": "LeadMagic Inc"
+                        },
+                        "description": {
+                          "type": "string",
+                          "example": "Example Robotics provides enterprise software solutions for B2B companies."
+                        },
+                        "shortName": {
+                          "type": "string",
+                          "example": "LeadMagic"
+                        },
+                        "founded": {
+                          "type": "string",
+                          "example": "2015"
+                        },
+                        "headquarters": {
+                          "type": "object",
+                          "properties": {
+                            "city": {
+                              "type": "string",
+                              "example": "Palo Alto"
+                            },
+                            "state": {
+                              "type": "string",
+                              "example": "California"
+                            },
+                            "country": {
+                              "type": "string",
+                              "example": "USA"
+                            },
+                            "fullAddress": {
+                              "type": "string",
+                              "example": "Palo Alto, California, USA"
+                            }
+                          }
+                        },
+                        "primaryDomain": {
+                          "type": "string",
+                          "example": "leadmagic.io"
+                        },
+                        "phone": {
+                          "type": "string",
+                          "example": "1-650-276-3068"
+                        },
+                        "status": {
+                          "type": "string",
+                          "example": "NEW"
+                        },
+                        "followers": {
+                          "type": "integer",
+                          "example": 2422
+                        },
+                        "ownership": {
+                          "type": "string",
+                          "example": "Private"
+                        }
+                      }
+                    },
+                    "financialInfo": {
+                      "type": "object",
+                      "properties": {
+                        "revenue": {
+                          "type": "integer",
+                          "example": 178000000
+                        },
+                        "formattedRevenue": {
+                          "type": "string",
+                          "example": "178M"
+                        },
+                        "totalFunding": {
+                          "type": "integer",
+                          "example": 584000000
+                        },
+                        "formattedFunding": {
+                          "type": "string",
+                          "example": "584M"
+                        },
+                        "lastFundingRound": {
+                          "type": "object",
+                          "properties": {
+                            "round": {
+                              "type": "string",
+                              "example": "Series E"
+                            },
+                            "date": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2021-05-01T00:00:00.000Z"
+                            },
+                            "amount": {
+                              "type": "integer",
+                              "example": 250000000
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "fundingHistory": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "round": {
+                            "type": "string",
+                            "example": "Series E"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2021-05-01T00:00:00.000Z"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "example": "$250,000,000"
+                          },
+                          "investors": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "example": [
+                              "Franklin Templeton",
+                              "Coatue",
+                              "Sequoia",
+                              "Thrive Capital",
+                              "Tiger Global"
+                            ]
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "round": "Series E",
+                          "date": "2021-05-01T00:00:00.000Z",
+                          "amount": "$250,000,000",
+                          "investors": [
+                            "Franklin Templeton",
+                            "Coatue",
+                            "Sequoia",
+                            "Thrive Capital",
+                            "Tiger Global"
+                          ]
+                        },
+                        {
+                          "round": "Series D",
+                          "date": "2020-08-01T00:00:00.000Z",
+                          "amount": "$200,000,000",
+                          "investors": [
+                            "Coatue",
+                            "Index Ventures",
+                            "Thrive Capital",
+                            "Battery Ventures",
+                            "NextWorld Capital",
+                            "Norwest Venture Partners",
+                            "Sequoia Capital",
+                            "Wing Venture Capital"
+                          ]
+                        },
+                        {
+                          "round": "Series C",
+                          "date": "2019-12-01T00:00:00.000Z",
+                          "amount": "$65,000,000",
+                          "investors": [
+                            "Sequoia Capital",
+                            "Battery Ventures",
+                            "Norwest Venture Partners",
+                            "Wing Venture Capital",
+                            "NextWorld Capital",
+                            "Cisco Investments"
+                          ]
+                        }
+                      ]
+                    },
+                    "companySize": {
+                      "type": "object",
+                      "properties": {
+                        "employees": {
+                          "type": "integer",
+                          "example": 1100
+                        },
+                        "employeeRange": {
+                          "type": "string",
+                          "example": "1,000 - 5,000"
+                        },
+                        "employeeGrowth": {
+                          "type": "string",
+                          "example": "N/A"
+                        }
+                      }
+                    },
+                    "leadership": {
+                      "type": "object",
+                      "properties": {
+                        "ceo": {
+                          "type": "object",
+                          "properties": {
+                            "firstName": {
+                              "type": "string",
+                              "example": "Amit"
+                            },
+                            "lastName": {
+                              "type": "string",
+                              "example": "Bendov"
+                            },
+                            "designation": {
+                              "type": "string",
+                              "example": "Co-Founder & CEO"
+                            },
+                            "b2b_profile": {
+                              "type": "string",
+                              "example": "amitbendov"
+                            },
+                            "twitter": {
+                              "type": "string",
+                              "example": "https://twitter.com/banditmove"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "industryAndSectors": {
+                      "type": "object",
+                      "properties": {
+                        "industrySectors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            "Sales Enablement Software",
+                            "Business Intelligence (BI)"
+                          ]
+                        },
+                        "industries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "example": [
+                            "Software, Internet & Computer Services"
+                          ]
+                        },
+                        "technologyStack": {
+                          "type": "string",
+                          "example": "N/A"
+                        }
+                      }
+                    },
+                    "topCompetitors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "example": "Chorus"
+                          },
+                          "revenue": {
+                            "type": "string",
+                            "example": "$21"
+                          },
+                          "employees": {
+                            "type": "string",
+                            "example": "200"
+                          },
+                          "totalFunding": {
+                            "type": "string",
+                            "example": "$1,003"
+                          },
+                          "headquarters": {
+                            "type": "object",
+                            "properties": {
+                              "city": {
+                                "type": "string",
+                                "example": "San Francisco"
+                              },
+                              "state": {
+                                "type": "string",
+                                "example": "US-CA"
+                              },
+                              "country": {
+                                "type": "string",
+                                "example": "USA"
+                              },
+                              "fullAddress": {
+                                "type": "string",
+                                "example": "San Francisco, US-CA, USA"
+                              }
+                            }
+                          },
+                          "founded": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2015-01-01T00:00:00.000Z"
+                          },
+                          "ownership": {
+                            "type": "string",
+                            "example": "Private"
+                          },
+                          "website": {
+                            "type": "string",
+                            "example": "https://www.chorus.ai"
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "name": "BoostUp",
+                          "revenue": "$6",
+                          "employees": "85",
+                          "totalFunding": "$425",
+                          "headquarters": {
+                            "city": "Santa Clara",
+                            "state": "US-CA",
+                            "country": "USA",
+                            "fullAddress": "Santa Clara, US-CA, USA"
+                          },
+                          "founded": "2018-01-01T00:00:00.000Z",
+                          "ownership": "Private",
+                          "website": "https://www.boostup.ai"
+                        },
+                        {
+                          "name": "ExecVision",
+                          "revenue": "$43",
+                          "employees": "31",
+                          "totalFunding": "$81",
+                          "headquarters": {
+                            "city": "Arlington",
+                            "state": "US-VA",
+                            "country": "USA",
+                            "fullAddress": "Arlington, US-VA, USA"
+                          },
+                          "founded": "2015-01-01T00:00:00.000Z",
+                          "ownership": "Private",
+                          "website": "https://www.execvision.io"
+                        },
+                        {
+                          "name": "Seismic",
+                          "revenue": "$375",
+                          "employees": "1,000",
+                          "totalFunding": "$940",
+                          "headquarters": {
+                            "city": "San Diego",
+                            "state": "US-CA",
+                            "country": "USA",
+                            "fullAddress": "San Diego, US-CA, USA"
+                          },
+                          "founded": "2010-01-01T00:00:00.000Z",
+                          "ownership": "Private",
+                          "website": "https://seismic.com"
+                        }
+                      ]
+                    },
+                    "acquisitions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "companyName": {
+                            "type": "string",
+                            "example": "Vayo"
+                          },
+                          "acquisitionDate": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2020-09-01T00:00:00.000Z"
+                          },
+                          "description": {
+                            "type": "string",
+                            "example": "Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business"
+                          },
+                          "source": {
+                            "type": "string",
+                            "example": "https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo"
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "companyName": "Vayo",
+                          "acquisitionDate": "2020-09-01T00:00:00.000Z",
+                          "description": "Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business",
+                          "source": "https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo"
+                        },
+                        {
+                          "companyName": "ONDiGO",
+                          "acquisitionDate": "2018-04-01T00:00:00.000Z",
+                          "description": "ONDiGO is a CRM platform that offers customer retention and management services to professionals and micro-businesses.",
+                          "source": "https://www.prnewswire.com/news-releases/leadmagic-acquires-ondigo-to-extend-its-conversation-intelligence-platform-300630168.html"
+                        }
+                      ]
+                    },
+                    "socialMedia": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "platform": {
+                            "type": "string",
+                            "example": "twitter"
+                          },
+                          "url": {
+                            "type": "string",
+                            "example": "https://twitter.com/leadmagic"
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "platform": "twitter",
+                          "url": "https://twitter.com/leadmagic"
+                        },
+                        {
+                          "platform": "facebook",
+                          "url": "https://www.facebook.com/To.LeadMagicHQ"
+                        },
+                        {
+                          "platform": "b2b_profile",
+                          "url": "leadmagichq"
+                        }
+                      ]
+                    },
+                    "news": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "example": "Example Robotics: Example Robotics Launches New Enterprise Platform"
+                          },
+                          "source": {
+                            "type": "string",
+                            "example": "Martech Cube"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2024-08-07T08:40:00.000Z"
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "title": "Example Robotics: Example Robotics Launches New Enterprise Platform",
+                          "source": "TechCrunch",
+                          "date": "2024-08-07T08:40:00.000Z"
+                        },
+                        {
+                          "title": "Example Robotics: Example Robotics Partners with Example CRM",
+                          "source": "Business Wire",
+                          "date": "2024-06-26T22:15:00.000Z"
+                        },
+                        {
+                          "title": "Example Robotics Named Best SaaS Solution in 2024 Industry Awards",
+                          "source": "Forbes",
+                          "date": "2024-06-26T00:00:00.000Z"
+                        }
+                      ]
+                    },
+                    "pressReleases": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string",
+                            "example": "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
+                          },
+                          "source": {
+                            "type": "string",
+                            "example": "PR Newswire"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2024-10-17T22:21:00.000Z"
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "title": "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics",
+                          "source": "PR Newswire",
+                          "date": "2024-10-17T22:21:00.000Z"
+                        },
+                        {
+                          "title": "Press Release: Example Robotics Named a Winner in The Cloud Awards",
+                          "source": "PR Newswire",
+                          "date": "2024-10-09T18:28:00.000Z"
+                        },
+                        {
+                          "title": "Press Release: Example Robotics Recognized as Industry Leader by Example Research",
+                          "source": "Business Wire",
+                          "date": "2024-09-04T18:50:00.000Z"
+                        }
+                      ]
+                    },
+                    "keyHighlights": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "example": "partnership"
+                          },
+                          "text": {
+                            "type": "string",
+                            "example": "Example Robotics Announces Strategic Partnership with Example Robotics"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date-time",
+                            "example": "2024-10-17T22:21:00.000Z"
+                          },
+                          "src": {
+                            "type": "string",
+                            "example": "https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html"
+                          },
+                          "source": {
+                            "type": "string",
+                            "example": "PR Newswire"
+                          }
+                        }
+                      },
+                      "example": [
+                        {
+                          "type": "partnership",
+                          "text": "Example Robotics Announces Strategic Partnership with Example Robotics",
+                          "date": "2024-10-17T22:21:00.000Z",
+                          "src": "https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html",
+                          "source": "PR Newswire"
+                        },
+                        {
+                          "type": "award",
+                          "text": "Example Robotics Named a Winner in The Cloud Awards",
+                          "date": "2024-10-09T18:28:00.000Z",
+                          "src": "https://www.prnewswire.com/news-releases/acme-corp-cloud-awards-302271452.html",
+                          "source": "PR Newswire"
+                        }
+                      ]
+                    },
+                    "summarySection": {
+                      "type": "string",
+                      "example": "Example Robotics provides enterprise software solutions for B2B companies. Example Robotics was founded in 2018. Example Robotics's headquarters is located in San Francisco, California, USA."
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 4
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/companies/competitors-search": {
+      "post": {
+        "summary": "Competitors Search",
+        "description": "Find competitors of a company by analyzing market position and industry data.",
+        "operationId": "competitors-search",
+        "tags": [
+          "Company Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Company website domain",
+                    "example": "leadmagic.io"
+                  },
+                  "company_url": {
+                    "type": "string",
+                    "description": "Company profile URL or identifier (optional)",
+                    "example": "leadmagichq"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Company name",
+                    "example": "LeadMagic"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with competitors details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "competitors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "example": "LeadMagic"
+                          },
+                          "shortDescription": {
+                            "type": "string",
+                            "example": "LeadMagic is a company that develops a conversation intelligence platform for B2B sales teams. "
+                          },
+                          "founded_year": {
+                            "type": "string",
+                            "example": "2015"
+                          },
+                          "companyType": {
+                            "type": "string",
+                            "example": "private"
+                          },
+                          "hq": {
+                            "type": "string",
+                            "example": "San Francisco, US"
+                          },
+                          "employeesCount": {
+                            "type": "integer",
+                            "example": 1504
+                          },
+                          "valuation": {
+                            "type": "integer",
+                            "example": 7250000000
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "example": "Technology"
+                                },
+                                "slug": {
+                                  "type": "string",
+                                  "example": "technology"
+                                },
+                                "primary": {
+                                  "type": "boolean",
+                                  "example": true
+                                }
+                              }
+                            }
+                          },
+                          "twitter_followers": {
+                            "type": "integer",
+                            "example": 7611
+                          },
+                          "growth": {
+                            "type": "integer",
+                            "example": 1
+                          },
+                          "non_hq_locations": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "example": [
+                              "Dublin, IE",
+                              "Ramat Gan, IL",
+                              "Atlanta, US",
+                              "Chicago, US"
+                            ]
+                          },
+                          "more_locations": {
+                            "type": "boolean",
+                            "example": false
+                          },
+                          "financial_metrics": {
+                            "type": "object",
+                            "properties": {
+                              "currency_code": {
+                                "type": "string",
+                                "example": "USD"
+                              },
+                              "period": {
+                                "type": "string",
+                                "example": "Y, 2020"
+                              },
+                              "revenue": {
+                                "type": "integer",
+                                "example": 37500000
+                              },
+                              "cost_of_goods_sold": {
+                                "type": "integer",
+                                "nullable": true,
+                                "example": null
+                              },
+                              "gross_profit": {
+                                "type": "integer",
+                                "nullable": true,
+                                "example": null
+                              },
+                              "net_income": {
+                                "type": "integer",
+                                "nullable": true,
+                                "example": null
+                              }
+                            }
+                          },
+                          "operating_metrics": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "period": {
+                                  "type": "string",
+                                  "example": "Dec, 2019"
+                                },
+                                "value": {
+                                  "type": "string",
+                                  "example": "700.0"
+                                },
+                                "definition": {
+                                  "type": "string",
+                                  "example": "Enterprise Customers"
+                                },
+                                "operating_metric_group": {
+                                  "type": "string",
+                                  "example": "Customers"
+                                },
+                                "currency_code": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "example": null
+                                }
+                              }
+                            }
+                          },
+                          "funding_metrics": {
+                            "type": "object",
+                            "properties": {
+                              "date": {
+                                "type": "string",
+                                "example": "about 3 years"
+                              },
+                              "latest": {
+                                "type": "integer",
+                                "example": 250000000
+                              },
+                              "currency_code": {
+                                "type": "string",
+                                "example": "USD"
+                              },
+                              "total": {
+                                "type": "integer",
+                                "example": 581000000
+                              }
+                            }
+                          },
+                          "twitterEngagement": {
+                            "type": "object",
+                            "properties": {
+                              "handle": {
+                                "type": "string",
+                                "example": "leadmagichq"
+                              },
+                              "analytics": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "collectedAt": {
+                                      "type": "string",
+                                      "example": "2023-07-12T00:00:00"
+                                    },
+                                    "tweets": {
+                                      "type": "integer",
+                                      "example": 6384
+                                    },
+                                    "following": {
+                                      "type": "integer",
+                                      "example": 1854
+                                    },
+                                    "followers": {
+                                      "type": "integer",
+                                      "example": 7611
+                                    },
+                                    "tweetsForPeriod": {
+                                      "type": "integer",
+                                      "example": 0
+                                    },
+                                    "avgTweetsPerDay": {
+                                      "type": "number",
+                                      "example": 0
+                                    },
+                                    "avgRetweetsPerTweet": {
+                                      "type": "number",
+                                      "example": 0
+                                    },
+                                    "avgLikesPerTweet": {
+                                      "type": "number",
+                                      "example": 0
+                                    },
+                                    "tweetsPercentageEngagementForPeriod": {
+                                      "type": "number",
+                                      "example": 0
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/companies/technographics": {
+      "post": {
+        "summary": "Company Technographics",
+        "description": "Get detailed technology stack information for any company by providing their domain.",
+        "operationId": "technographics",
+        "tags": [
+          "Company Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "company_domain"
+                ],
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "description": "The domain of the company to analyze",
+                    "example": "leadmagic.io"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with technology stack information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Technology stack information retrieved successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "description": "Array of technologies found. Omitted or empty when no data is available.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the technology",
+                            "example": "Google Analytics"
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Description of the technology",
+                            "example": "Google Analytics is a web analytics service offered by Google that tracks and reports website traffic."
+                          },
+                          "categories": {
+                            "type": "array",
+                            "description": "Categories this technology belongs to",
+                            "items": {
+                              "type": "string"
+                            },
+                            "example": [
+                              "Analytics",
+                              "Marketing"
+                            ]
+                          },
+                          "sub_technologies": {
+                            "type": "array",
+                            "description": "Sub-technologies or related tools",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Name of the sub-technology",
+                                  "example": "Google Analytics 4"
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "description": "Description of the sub-technology",
+                                  "example": "The latest version of Google Analytics with enhanced privacy features"
+                                },
+                                "categories": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "description": "Categories for the sub-technology",
+                                  "example": [
+                                    "Analytics",
+                                    "Privacy-focused"
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/role-finder": {
+      "post": {
+        "summary": "Role Finder",
+        "description": "Provide the company name or domain and the required job title, and retrieve the corresponding person.",
+        "operationId": "role-finder",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_name": {
+                    "type": "string",
+                    "description": "Business Profile URL (with url or public_identifier)",
+                    "default": "leadmagic"
+                  },
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Company domain",
+                    "default": "leadmagic.io"
+                  },
+                  "job_title": {
+                    "type": "string",
+                    "description": "Enter the job title you want to find in the company.",
+                    "default": "ceo"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with role details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "example": "Alex Rivera"
+                    },
+                    "profile_url": {
+                      "type": "string",
+                      "example": "alex-rivera"
+                    },
+                    "first_name": {
+                      "type": "string",
+                      "example": "Alex"
+                    },
+                    "last_name": {
+                      "type": "string",
+                      "example": "Rivera"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Role found."
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "company_name": {
+                      "type": "string",
+                      "example": "Leadmagic"
+                    },
+                    "company_website": {
+                      "type": "string",
+                      "example": "leadmagic.io"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/people/employee-finder": {
+      "post": {
+        "summary": "Employee Finder",
+        "description": "Find employees at a company. Returns a list of employees with their profiles, titles, and locations. Costs 0.05 credits per employee returned — free when no employees are found.",
+        "operationId": "employee-finder",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Company website domain (preferred — more accurate than company_name)",
+                    "default": "leadmagic.io"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Company name. Use if domain is not available.",
+                    "default": "leadmagic"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of employees to return",
+                    "default": 10
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with employee list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "employees": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "first_name": {
+                            "type": "string",
+                            "example": "Alex"
+                          },
+                          "last_name": {
+                            "type": "string",
+                            "example": "Rivera"
+                          },
+                          "full_name": {
+                            "type": "string",
+                            "example": "Alex Rivera"
+                          },
+                          "profile_url": {
+                            "type": "string",
+                            "example": "example.com/in/alex-rivera"
+                          },
+                          "job_title": {
+                            "type": "string",
+                            "example": "VP of Sales"
+                          },
+                          "location": {
+                            "type": "string",
+                            "example": "San Francisco, CA"
+                          }
+                        }
+                      }
+                    },
+                    "total_count": {
+                      "type": "integer",
+                      "description": "Total employees found (may exceed returned count when limit is set)",
+                      "example": 150
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "description": "Credits used (0.05 per employee returned)",
+                      "example": 0.5
+                    },
+                    "message": {
+                      "$ref": "#/components/schemas/EmployeeFinderMessages"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v3/people/search": {
+      "post": {
+        "summary": "People Search",
+        "description": "Canonical V3 people lookup with all company, title, role, people, channel, and contact-detail filters.",
+        "operationId": "people-search",
+        "tags": [
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "example": "leadmagic.io"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "example": "LeadMagic"
+                  },
+                  "linkedin_url": {
+                    "type": "string",
+                    "description": "B2B company profile URL or slug.",
+                    "example": "https://www.example.com/company/acme/"
+                  },
+                  "company_filters": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Criteria-based company set. Supports the full Company Search filter family."
+                  },
+                  "people_filters": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "People-level filters for names, title/function/level, geography, profile URLs, headline/about-me/industry, languages, seniority, connection count, and channel availability. Canonical keys use the contact_* prefix (e.g. contact_linkedin_about_me); bare aliases such as about_me, headline, industry, job_function, and city are accepted. contact_job_function accepts short chips (Sales, Marketing, Finance, …) or full standard labels (Sales & Business Development, …); matching is exact after chip→label expansion and response rows always return the standard label. Multiple values in one array are OR'd; different people_filters keys in one request are AND'd. Keys the search cannot honor are echoed in interpreted_search.ignored_people_filters rather than silently dropped.\n"
+                  },
+                  "title": {
+                    "type": "string",
+                    "example": "VP Sales"
+                  },
+                  "job_title": {
+                    "type": "string",
+                    "example": "Head of Revenue"
+                  },
+                  "titles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12
+                  },
+                  "roles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12
+                  },
+                  "query": {
+                    "type": "string",
+                    "description": "Free-text people/title query."
+                  },
+                  "required_email": {
+                    "type": "boolean",
+                    "description": "Only return people with email availability."
+                  },
+                  "required_mobile": {
+                    "type": "boolean",
+                    "description": "Only return people with mobile availability."
+                  },
+                  "channels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "email",
+                        "phone"
+                      ]
+                    },
+                    "description": "Legacy alias for contactability requirements."
+                  },
+                  "channel_match": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "all"
+                    ],
+                    "default": "any"
+                  },
+                  "include_company": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "include_domain_intel": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "include_contact_details": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Opt in to paid raw email/mobile fields (alias — full_search). Bills 1 extra credit per returned email and 5 per returned mobile; base results are 1 credit per returned person. Search RPS / unmetered people-search plans cannot unlock email or mobile (403); unlocks require a credit-metered plan.\n"
+                  },
+                  "include_email": {
+                    "type": "boolean",
+                    "description": "When contact details are on, return and bill raw emails (+1 credit each). If neither include_email nor include_mobile is set, both default to true. If either flag is set, the omitted flag defaults to false (include_email=true alone is email-only).\n"
+                  },
+                  "include_mobile": {
+                    "type": "boolean",
+                    "description": "When contact details are on, return and bill raw mobiles (+5 credits each). Same default rules as include_email.\n"
+                  },
+                  "confirm_credit_charge": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Accepted for backwards compatibility; does not bypass RPS/unmetered unlock restrictions."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "default": 25,
+                    "minimum": 1,
+                    "maximum": 10000,
+                    "description": "Offset requests allow up to 10000 rows; cursor-based pages are capped at 50."
+                  },
+                  "cursor": {
+                    "type": "string",
+                    "description": "Opaque signed next_cursor from the previous page. Send unchanged with the same filters, a limit no greater than 50, and offset 0."
+                  },
+                  "offset": {
+                    "type": "integer",
+                    "default": 0,
+                    "minimum": 0,
+                    "deprecated": true,
+                    "description": "Legacy offset pagination; prefer cursor. Unstable ordering, uncached. Restart at offset 0 to obtain a cursor.\n"
+                  }
+                }
+              },
+              "example": {
+                "company_filters": {
+                  "company_domains": [
+                    "leadmagic.io"
+                  ],
+                  "crm_tech": [
+                    "Salesforce"
+                  ]
+                },
+                "people_filters": {
+                  "contact_job_level": [
+                    "VP",
+                    "Director"
+                  ],
+                  "contact_job_function": [
+                    "Sales"
+                  ],
+                  "is_sales": true,
+                  "min_contactability_score": 40
+                },
+                "titles": [
+                  "VP Sales",
+                  "Head of Revenue"
+                ],
+                "required_email": true,
+                "limit": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "People search results",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-RateLimit-RPS-Limit": {
+                "$ref": "#/components/headers/SearchRpsLimit"
+              },
+              "X-RateLimit-RPS-Remaining": {
+                "$ref": "#/components/headers/SearchRpsRemaining"
+              },
+              "X-RateLimit-RPS-Reset": {
+                "$ref": "#/components/headers/SearchRpsReset"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "credits_consumed": {
+                      "type": "number"
+                    },
+                    "credit_preview": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "people": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                          "contact_linkedin_url": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_linkedin_username": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_first_name": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_last_name": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_full_name": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_email": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_email_domain": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_mobile_phone": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_direct_phone": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_linkedin_headline": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_linkedin_industry": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_linkedin_about_me": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_city": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_state": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_state_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_country": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_country_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_region": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_continent": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_title": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_function": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Standard department label for the person's current role (e.g. Sales & Business Development). Filter requests may use short chips such as Sales; responses always return this standard label.\n"
+                          },
+                          "contact_job_level": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_start_date": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_count": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "contact_persona": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_city": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_country": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_country_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_region": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_continent": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_state": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_job_state_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_company_name": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "company_domain": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_education": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_skills": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_certifications": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_languages": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "contact_websites": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "seniority_score": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "has_email": {
+                            "type": "boolean"
+                          },
+                          "has_mobile_phone": {
+                            "type": "boolean"
+                          },
+                          "has_phone": {
+                            "type": "boolean"
+                          },
+                          "is_cio": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "is_it_leader": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "is_security": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "is_revops": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "is_recruiting": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "is_engineering": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "is_sales": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "is_marketing": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "is_operations": {
+                            "type": "boolean",
+                            "nullable": true
+                          },
+                          "contactability_score": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "profile_completeness_score": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "job_observation_count": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "distinct_company_count": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "followers": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "company": {
+                            "type": "object",
+                            "nullable": true,
+                            "additionalProperties": true
+                          },
+                          "domain_intel": {
+                            "type": "object",
+                            "nullable": true,
+                            "additionalProperties": true
+                          },
+                          "unlock": {
+                            "type": "object",
+                            "nullable": true,
+                            "additionalProperties": true
+                          }
+                        }
+                      }
+                    },
+                    "companies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    },
+                    "returned_count": {
+                      "type": "integer"
+                    },
+                    "limit_applied": {
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "type": "integer"
+                    },
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "next_cursor": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Opaque signed token for the next page, or null on the last page. Send back as cursor with offset 0. Cursor pagination is stable and cached."
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "pagination": {
+                          "type": "string",
+                          "enum": [
+                            "snapshot",
+                            "cursor",
+                            "offset"
+                          ],
+                          "description": "snapshot/cursor for cursor/first-page responses; offset for legacy offset responses."
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "message": "People found",
+                  "credits_consumed": 0,
+                  "count": 120,
+                  "returned_count": 25,
+                  "limit_applied": 25,
+                  "offset": 25,
+                  "has_more": true,
+                  "next_cursor": null,
+                  "metadata": {
+                    "query_name": "people_search_v3",
+                    "query_path": "full_search",
+                    "pagination": "offset"
+                  },
+                  "people": [
+                    {
+                      "contact_linkedin_url": "https://example.com/in/jane-doe",
+                      "contact_linkedin_username": "jesseoue",
+                      "contact_first_name": "Jesse",
+                      "contact_last_name": "Ouellette",
+                      "contact_full_name": "Jesse Ouellette",
+                      "contact_email": "jesse@leadmagic.io",
+                      "contact_email_domain": "leadmagic.io",
+                      "contact_mobile_phone": "+12073561898",
+                      "contact_direct_phone": null,
+                      "contact_linkedin_headline": "Growth & AI Expert | Founder LeadMagic",
+                      "contact_linkedin_about_me": "SaaS Founder",
+                      "contact_city": "Boston",
+                      "contact_state": "Massachusetts",
+                      "contact_state_code": "MA",
+                      "contact_country": "United States",
+                      "contact_country_code": "US",
+                      "contact_region": "NORAM",
+                      "contact_continent": "North America",
+                      "contact_job_title": "Founder",
+                      "contact_job_function": "General Business & Management",
+                      "contact_job_level": "C-Team",
+                      "contact_job_description": "LeadMagic is the Best B2B Email & Mobile Finder",
+                      "contact_job_start_date": "2022-09-01",
+                      "contact_job_count": 15,
+                      "contact_persona": "Founder/Co-Founder",
+                      "contact_company_name": "Leadmagic",
+                      "company_domain": "leadmagic.io",
+                      "seniority_score": 5,
+                      "has_email": true,
+                      "has_mobile_phone": true,
+                      "has_phone": false,
+                      "followers": 500,
+                      "company": {
+                        "company_domain": "leadmagic.io",
+                        "company_name": "Leadmagic",
+                        "company_website": "https://www.leadmagic.io",
+                        "company_industry_linkedin": "Internet Publishing",
+                        "employee_range": "11 to 50",
+                        "employee_min": 11,
+                        "employee_max": 50,
+                        "linkedin_employee_count": 10,
+                        "revenue_range": "$1M to <$10M",
+                        "revenue_min": "4000000",
+                        "revenue_max": "4000000",
+                        "hq_country": "United States",
+                        "hq_country_code": "US",
+                        "hq_city": "Boston",
+                        "hq_state": "Massachusetts",
+                        "founded_year": 2022,
+                        "linkedin_followers": 8804,
+                        "growth_rate": 14,
+                        "linkedin_url": "https://www.example.com/company/acme",
+                        "company_headline": "The data provider other data providers use. Emails, mobiles, and company data that don't bounce."
+                      },
+                      "domain_intel": {
+                        "company_domain": "leadmagic.io",
+                        "company_name": "Leadmagic",
+                        "company_website": "https://www.leadmagic.io",
+                        "company_domain_tld": "leadmagic.io",
+                        "company_website_active": true,
+                        "primary_email_domain": "leadmagic.io",
+                        "email_pattern": "first",
+                        "email_pattern_example": "soufiane@leadmagic.io",
+                        "email_pattern_confidence": 100,
+                        "email_pattern_confidence_tier": "low",
+                        "total_email_count": 4,
+                        "valid_email_count": 4,
+                        "total_contacts": 10
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          }
+        }
+      }
+    },
+    "/v3/companies/search": {
+      "post": {
+        "summary": "Company Search",
+        "description": "Canonical V3 company lookup with all company filters.",
+        "operationId": "company-search-v3",
+        "tags": [
+          "Company Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Direct one-company lookup input. Returns one rich company row plus legacy-friendly aliases when no broad filters or explicit limit are supplied.",
+                    "example": "leadmagic.io"
+                  },
+                  "domain": {
+                    "type": "string",
+                    "description": "Alias for company_domain."
+                  },
+                  "website": {
+                    "type": "string",
+                    "description": "Company website URL or domain."
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Company name lookup input."
+                  },
+                  "profile_url": {
+                    "type": "string",
+                    "description": "Company profile URL."
+                  },
+                  "linkedin_url": {
+                    "type": "string",
+                    "description": "Company profile URL."
+                  },
+                  "company_filters": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Full company filter object."
+                  },
+                  "query": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 10
+                  },
+                  "cursor": {
+                    "type": "string",
+                    "description": "Opaque next_cursor from the previous page. Send unchanged with the same filters and limit."
+                  },
+                  "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "deprecated": true,
+                    "description": "Legacy offset pagination; prefer cursor. Unstable ordering, uncached. Restart at offset 0 to obtain a cursor.\n"
+                  }
+                }
+              },
+              "example": {
+                "limit": 10,
+                "company_filters": {
+                  "company_domains": [
+                    "leadmagic.io"
+                  ],
+                  "country_codes": [
+                    "US"
+                  ],
+                  "location_country_codes": [
+                    "US"
+                  ],
+                  "crm_tech": [
+                    "Salesforce"
+                  ],
+                  "has_funding": true,
+                  "website_active": true
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Company search results",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-RateLimit-RPS-Limit": {
+                "$ref": "#/components/headers/SearchRpsLimit"
+              },
+              "X-RateLimit-RPS-Remaining": {
+                "$ref": "#/components/headers/SearchRpsRemaining"
+              },
+              "X-RateLimit-RPS-Reset": {
+                "$ref": "#/components/headers/SearchRpsReset"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "credits_consumed": {
+                      "type": "number"
+                    },
+                    "companies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                          "company_domain": {
+                            "type": "string"
+                          },
+                          "company_name": {
+                            "type": "string"
+                          },
+                          "company_website": {
+                            "type": "string"
+                          },
+                          "company_industry_linkedin": {
+                            "type": "string"
+                          },
+                          "employee_range": {
+                            "type": "string"
+                          },
+                          "employee_min": {
+                            "type": "integer"
+                          },
+                          "employee_max": {
+                            "type": "integer"
+                          },
+                          "linkedin_employee_count": {
+                            "type": "integer"
+                          },
+                          "revenue_range": {
+                            "type": "string"
+                          },
+                          "revenue_min": {
+                            "type": "string"
+                          },
+                          "revenue_max": {
+                            "type": "string"
+                          },
+                          "hq_country": {
+                            "type": "string"
+                          },
+                          "hq_country_code": {
+                            "type": "string"
+                          },
+                          "hq_city": {
+                            "type": "string"
+                          },
+                          "hq_state": {
+                            "type": "string"
+                          },
+                          "hq_street": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "hq_postcode": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "hq_region": {
+                            "type": "string"
+                          },
+                          "hq_continent": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "location_city": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "location_country_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "location_region": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "location_state_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "founded_year": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "specialties": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "total_funding": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "funding_investor_count": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "last_funding_type": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "last_funding_date": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "last_funding_amount": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "lead_investors": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Not returned in standard company search responses."
+                          },
+                          "linkedin_followers": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "growth_rate": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "linkedin_url": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "linkedin_claimed": {
+                            "type": "boolean"
+                          },
+                          "company_headline": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "company_about": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "company_phone": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "company_entity_type": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "company_legal_type": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "has_tech_stack": {
+                            "type": "boolean"
+                          },
+                          "profile_completeness_score": {
+                            "type": "integer",
+                            "nullable": true
+                          },
+                          "total_contacts": {
+                            "type": "integer"
+                          },
+                          "contacts_with_email": {
+                            "type": "integer"
+                          },
+                          "contacts_with_phone": {
+                            "type": "integer"
+                          },
+                          "valid_email_count": {
+                            "type": "integer"
+                          },
+                          "website_active": {
+                            "type": "boolean"
+                          },
+                          "website_for_sale": {
+                            "type": "boolean"
+                          },
+                          "sic_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "naics_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "sic_description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "naics_description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "predicted_naics_2022_code": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "domain_tld": {
+                            "type": "string"
+                          },
+                          "total_app_reviews": {
+                            "type": "integer"
+                          },
+                          "crm_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "marketing_automation_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "sales_automation_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "analytics_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "cloud_provider_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "development_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "ecommerce_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "erp_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "email_hosting_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "email_security_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "abm_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "cms_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "conversation_intelligence_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "app_security_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "cloud_security_tech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "company_martech": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "category": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "found": {
+                      "type": "boolean",
+                      "description": "Present for one-company lookup requests."
+                    },
+                    "company": {
+                      "type": "object",
+                      "nullable": true,
+                      "additionalProperties": true,
+                      "description": "Present for one-company lookup requests. Contains the first returned company row."
+                    },
+                    "companyName": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Present for one-company lookup requests. Alias for company.company_name."
+                    },
+                    "companyDomain": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Present for one-company lookup requests. Alias for company.company_domain."
+                    },
+                    "websiteUrl": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Present for one-company lookup requests. Alias for company.company_website."
+                    },
+                    "linkedinUrl": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Present for one-company lookup requests. Alias for company.linkedin_url."
+                    },
+                    "count": {
+                      "type": "integer"
+                    },
+                    "returned_count": {
+                      "type": "integer"
+                    },
+                    "limit_applied": {
+                      "type": "integer"
+                    },
+                    "offset": {
+                      "type": "integer"
+                    },
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "next_cursor": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Opaque signed token for the next page, or null on the last page. Send back as cursor with offset 0. Cursor pagination is stable and cached."
+                    },
+                    "interpreted_search": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "pagination": {
+                          "type": "string",
+                          "enum": [
+                            "snapshot",
+                            "cursor",
+                            "offset"
+                          ],
+                          "description": "snapshot/cursor for cursor/first-page responses; offset for legacy offset responses."
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Companies found",
+                  "credits_consumed": 0,
+                  "count": 120,
+                  "returned_count": 25,
+                  "limit_applied": 25,
+                  "offset": 25,
+                  "has_more": true,
+                  "next_cursor": null,
+                  "metadata": {
+                    "pagination": "offset"
+                  },
+                  "companies": [
+                    {
+                      "company_domain": "leadmagic.io",
+                      "company_name": "Leadmagic",
+                      "company_website": "https://www.leadmagic.io",
+                      "employee_range": "11 to 50"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          }
+        }
+      }
+    },
+    "/v3/companies/lookalike": {
+      "post": {
+        "summary": "Company Lookalike",
+        "description": "Find similar companies from a seed domain or description with full company output.\nCosts **5 credits** when one or more lookalikes are returned; **free** when empty.\nCommon aliases (`domain`, `website`, `company_website`, `name`) and misspellings\n(`companny_domain`, `limmit`, …) are accepted and remapped. `preview: true` is\nchatbot-UI only — API keys receive 400.\n",
+        "operationId": "company-lookalike-v3",
+        "tags": [
+          "Company Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Seed company domain. Aliases include domain, website, company_website, seed.domain. Typos like companny_domain are remapped.",
+                    "example": "leadmagic.io"
+                  },
+                  "domain": {
+                    "type": "string",
+                    "description": "Alias for company_domain."
+                  },
+                  "website": {
+                    "type": "string",
+                    "description": "Seed website URL or domain."
+                  },
+                  "company_website": {
+                    "type": "string",
+                    "description": "Alias for website."
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Seed company name used as text intent when no domain is supplied."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Alias for company_name."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Free-text seed description."
+                  },
+                  "company_description": {
+                    "type": "string",
+                    "description": "Alias for description."
+                  },
+                  "seed": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Optional seed object. Prefer seed.domain."
+                  },
+                  "company_filters": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Same full company filter family as Company Search. Alias filters."
+                  },
+                  "filters": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Alias for company_filters."
+                  },
+                  "preview": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Free preview — chatbot UI only. API/MCP clients receive 400."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2000,
+                    "default": 25,
+                    "description": "Page size. Typos like limmit are remapped."
+                  },
+                  "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0
+                  }
+                }
+              },
+              "example": {
+                "company_domain": "leadmagic.io",
+                "company_filters": {
+                  "country_codes": [
+                    "US"
+                  ],
+                  "location_country_codes": [
+                    "US"
+                  ],
+                  "employee_ranges": [
+                    "51 to 200",
+                    "201 to 500"
+                  ],
+                  "crm_tech": [
+                    "Salesforce"
+                  ],
+                  "has_tech_stack": true,
+                  "website_active": true
+                },
+                "limit": 25
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Company lookalike results (flat JSON body — not wrapped in data)",
+            "headers": {
+              "X-Credits-Cost": {
+                "schema": {
+                  "type": "number"
+                },
+                "description": "Credits reserved before finalization (5)"
+              },
+              "X-Credits-Consumed": {
+                "schema": {
+                  "type": "number"
+                },
+                "description": "Credits actually charged (0 or 5)"
+              },
+              "X-Credits-Remaining": {
+                "schema": {
+                  "type": "number"
+                },
+                "description": "Wallet credits remaining after this request"
+              },
+              "X-Credits-Total": {
+                "schema": {
+                  "type": "number"
+                }
+              },
+              "X-Request-Id": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "RateLimit-Remaining": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "required": [
+                    "message",
+                    "credits_consumed",
+                    "companies",
+                    "count",
+                    "returned_count"
+                  ],
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Lookalike companies found"
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "description": "Flat 5 when results returned; 0 when empty",
+                      "example": 5
+                    },
+                    "companies": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                          "company_domain": {
+                            "type": "string"
+                          },
+                          "company_name": {
+                            "type": "string"
+                          },
+                          "company_website": {
+                            "type": "string"
+                          },
+                          "company_industry_linkedin": {
+                            "type": "string"
+                          },
+                          "employee_range": {
+                            "type": "string"
+                          },
+                          "employee_min": {
+                            "type": "integer"
+                          },
+                          "employee_max": {
+                            "type": "integer"
+                          },
+                          "linkedin_employee_count": {
+                            "type": "integer"
+                          },
+                          "revenue_range": {
+                            "type": "string"
+                          },
+                          "revenue_min": {
+                            "type": "string"
+                          },
+                          "revenue_max": {
+                            "type": "string"
+                          },
+                          "hq_country": {
+                            "type": "string"
+                          },
+                          "hq_country_code": {
+                            "type": "string"
+                          },
+                          "hq_city": {
+                            "type": "string"
+                          },
+                          "hq_state": {
+                            "type": "string"
+                          },
+                          "similarity": {
+                            "type": "number",
+                            "description": "Lookalike similarity score when available"
+                          },
+                          "source_seed_domain": {
+                            "type": "string"
+                          },
+                          "match_context": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "count": {
+                      "type": "integer",
+                      "example": 5
+                    },
+                    "returned_count": {
+                      "type": "integer",
+                      "example": 5
+                    },
+                    "limit_applied": {
+                      "type": "integer",
+                      "example": 25
+                    },
+                    "offset": {
+                      "type": "integer",
+                      "example": 0
+                    },
+                    "interpreted_search": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Normalized seed and company_filters used for the query"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "query_name": {
+                          "type": "string",
+                          "example": "company_lookalike_v3"
+                        },
+                        "query_path": {
+                          "type": "string",
+                          "example": "lookalike"
+                        },
+                        "preview": {
+                          "type": "boolean"
+                        },
+                        "degraded": {
+                          "type": "boolean",
+                          "description": "True when upstream was briefly unavailable and an empty free response was returned"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Lookalike companies found",
+                  "credits_consumed": 5,
+                  "companies": [
+                    {
+                      "company_domain": "tomba.io",
+                      "company_name": "Tomba.Io",
+                      "similarity": 0.88
+                    }
+                  ],
+                  "count": 1,
+                  "returned_count": 1,
+                  "limit_applied": 25,
+                  "offset": 0,
+                  "interpreted_search": {
+                    "seed": {
+                      "domain": "leadmagic.io"
+                    },
+                    "company_filters": {}
+                  },
+                  "metadata": {
+                    "query_name": "company_lookalike_v3",
+                    "query_path": "lookalike",
+                    "preview": false
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          }
+        }
+      }
+    },
+    "/v1/jobs/jobs-finder": {
+      "post": {
+        "summary": "Jobs Finder",
+        "description": "LeadMagic's Jobs Finder",
+        "operationId": "jobs-finder",
+        "tags": [
+          "Jobs Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_name": {
+                    "type": "string",
+                    "description": "Provide the Company Name. (Optional)",
+                    "example": "Clay"
+                  },
+                  "company_website": {
+                    "type": "string",
+                    "description": "Provide the Company Website. (Optional)",
+                    "example": "clay.com"
+                  },
+                  "job_title": {
+                    "type": "string",
+                    "description": "Provide the Job Title.",
+                    "example": "RevOps Engineer"
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "Location of the job",
+                    "example": "United States"
+                  },
+                  "experience_level": {
+                    "type": "string",
+                    "description": "Indicates the required experience level for the job. Choose \"entry\" for Entry Level, \"mid\" for Mid Level, \"senior\" for Senior Level, or \"executive\" for Executive Level. If not specified, jobs from all experience levels will be included.",
+                    "example": "senior"
+                  },
+                  "job_description": {
+                    "type": "string",
+                    "description": "Filters jobs based on specific keywords or phrases found in the job description.",
+                    "example": "leadmagic"
+                  },
+                  "city_name": {
+                    "type": "string",
+                    "description": "Filter jobs by city name. Pair with `country_id` to disambiguate cities that share a name.",
+                    "example": "Austin"
+                  },
+                  "country_id": {
+                    "type": "string",
+                    "description": "Filter jobs by country code, such as US or GB. Use the country helper for supported values.",
+                    "example": "US"
+                  },
+                  "region_id": {
+                    "type": "integer",
+                    "description": "Filter jobs by region ID.",
+                    "example": 5
+                  },
+                  "job_type_id": {
+                    "type": "integer",
+                    "description": "Filter jobs by job type ID.",
+                    "example": 1
+                  },
+                  "company_type_id": {
+                    "type": "integer",
+                    "description": "Filter jobs by company type ID.",
+                    "example": 1
+                  },
+                  "company_industry_id": {
+                    "type": "integer",
+                    "description": "Filter jobs by company industry ID.",
+                    "example": 7
+                  },
+                  "min_employees": {
+                    "type": "integer",
+                    "description": "Minimum number of employees",
+                    "example": 51
+                  },
+                  "max_employees": {
+                    "type": "integer",
+                    "description": "Maximum number of employees",
+                    "example": 10000
+                  },
+                  "has_remote": {
+                    "type": "boolean",
+                    "description": "Determines whether the jobs offer remote work options. Set to true to include remote-only listings, or false to include non-remote listings.",
+                    "example": true
+                  },
+                  "posted_within": {
+                    "type": "integer",
+                    "description": "Specify the number of days within which the job was posted.",
+                    "example": 30
+                  },
+                  "posted_after": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "Filters jobs posted on or after a specific date. Use the format YYYY-MM-DD.",
+                    "example": "2026-05-01"
+                  },
+                  "posted_before": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "Filters jobs posted on or before a specific date. Use the format YYYY-MM-DD.",
+                    "example": "2026-05-15"
+                  },
+                  "page": {
+                    "type": "integer",
+                    "description": "Page number",
+                    "default": 1
+                  },
+                  "per_page": {
+                    "type": "integer",
+                    "description": "Provide number of results needed per page. (Maximum per_page can be 50)",
+                    "default": 20
+                  }
+                }
+              },
+              "example": {
+                "company_website": "clay.com",
+                "job_title": "RevOps Engineer",
+                "country_id": "US",
+                "has_remote": true,
+                "posted_within": 30,
+                "page": 1,
+                "per_page": 20
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with job listings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total_count": {
+                      "type": "integer",
+                      "default": 0
+                    },
+                    "page": {
+                      "type": "integer",
+                      "default": 0
+                    },
+                    "per_page": {
+                      "type": "integer",
+                      "default": 0
+                    },
+                    "total_pages": {
+                      "type": "integer",
+                      "default": 0
+                    },
+                    "credits_consumed": {
+                      "type": "integer",
+                      "default": 0
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "company": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "example": "LeadMagic"
+                              },
+                              "website_url": {
+                                "type": "string",
+                                "example": "https://leadmagic.io"
+                              },
+                              "b2b_profile_url": {
+                                "type": "string",
+                                "nullable": true,
+                                "example": "leadmagichq"
+                              },
+                              "twitter_handle": {
+                                "type": "string",
+                                "nullable": true,
+                                "example": "leadmagichq"
+                              },
+                              "github_url": {
+                                "type": "string",
+                                "nullable": true,
+                                "example": "https://github.com/leadmagic"
+                              }
+                            }
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "location": {
+                            "type": "string"
+                          },
+                          "types": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "default": 0
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "cities": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "geonameid": {
+                                  "type": "integer",
+                                  "default": 0
+                                },
+                                "asciiname": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "country": {
+                            "type": "object"
+                          },
+                          "timezone": {
+                            "type": "string"
+                          },
+                          "latitude": {
+                            "type": "string"
+                          },
+                          "longitude": {
+                            "type": "string"
+                          },
+                          "countries": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "region": {
+                            "type": "object"
+                          },
+                          "regions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "default": 0
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "has_remote": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "published": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "application_url": {
+                            "type": "string"
+                          },
+                          "language": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "clearance_required": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "salary_min": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "salary_max": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "salary_currency": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "experience_level": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "total_count": 50,
+                    "page": 1,
+                    "per_page": 20,
+                    "total_pages": 3,
+                    "credits_consumed": 20,
+                    "results": [
+                      {
+                        "company": {
+                          "name": "LeadMagic",
+                          "website_url": "https://leadmagic.io",
+                          "b2b_profile_url": "leadmagichq",
+                          "twitter_handle": "leadmagichq",
+                          "github_url": "https://github.com/leadmagic"
+                        },
+                        "title": "Senior Software Engineer",
+                        "location": "San Jose, San José, Costa Rica",
+                        "types": [
+                          {
+                            "id": 1,
+                            "name": "Full Time"
+                          }
+                        ],
+                        "cities": [
+                          {
+                            "geonameid": 3621849,
+                            "asciiname": "San Jose",
+                            "name": "San José",
+                            "country": {
+                              "code": "CR",
+                              "name": "Costa Rica",
+                              "region": {
+                                "id": 5,
+                                "name": "North America"
+                              }
+                            },
+                            "timezone": "America/Costa_Rica",
+                            "latitude": "9.93333",
+                            "longitude": "-84.08333"
+                          }
+                        ],
+                        "countries": [
+                          {
+                            "code": "CR",
+                            "name": "Costa Rica",
+                            "region": {
+                              "id": 5,
+                              "name": "North America"
+                            }
+                          }
+                        ],
+                        "regions": [
+                          {
+                            "id": 5,
+                            "name": "North America"
+                          }
+                        ],
+                        "has_remote": false,
+                        "published": "2024-07-23T15:25:00Z",
+                        "description": "",
+                        "application_url": "https://leadmagic.io/careers",
+                        "language": "en",
+                        "clearance_required": false,
+                        "salary_min": null,
+                        "salary_max": null,
+                        "salary_currency": null,
+                        "experience_level": "Senior Level"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v3/jobs/search": {
+      "post": {
+        "summary": "Job Search",
+        "description": "Search jobs with title, occupation taxonomy, company, location, tag, salary, seniority, and date filters. The endpoint resolves friendly values into normalized filter IDs before searching. Company objects do not include logo fields.",
+        "operationId": "job-search",
+        "tags": [
+          "Jobs Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "titles": {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "vector": {
+                        "type": "boolean",
+                        "default": false
+                      }
+                    }
+                  },
+                  "occupationTaxonomy": {
+                    "type": "object",
+                    "properties": {
+                      "level1": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "level2": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "level3": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "companies": {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "ids": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  },
+                  "location": {
+                    "type": "object",
+                    "properties": {
+                      "countries": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "regions": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "states": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "cities": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "tags": {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "salary": {
+                    "type": "object",
+                    "properties": {
+                      "min_usd": {
+                        "type": "integer"
+                      },
+                      "max_usd": {
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  "seniority": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "postedAfter": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "postedBefore": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "postedWithin": {
+                    "type": "integer",
+                    "description": "Include jobs posted within the last N days."
+                  },
+                  "languages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "hasRemote": {
+                    "type": "boolean"
+                  },
+                  "jobTypeIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "industryIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "companyTypeIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "companySizeCodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "default": 25,
+                    "maximum": 50
+                  },
+                  "cursor": {
+                    "type": "string",
+                    "description": "Opaque cursor from pagination.next_cursor. Send unchanged with the same filters and limit."
+                  },
+                  "includeDescription": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include job description text. Enabling descriptions may increase response time."
+                  },
+                  "includeFacets": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include facet metadata. Enabling facets may increase response time."
+                  },
+                  "totalMode": {
+                    "type": "string",
+                    "default": "capped",
+                    "enum": [
+                      "none",
+                      "capped",
+                      "exact"
+                    ]
+                  },
+                  "mode": {
+                    "type": "string",
+                    "default": "fast",
+                    "enum": [
+                      "fast",
+                      "deep"
+                    ],
+                    "description": "fast returns paginated browsing results when descriptions and facets are omitted; deep enables broader text matching."
+                  },
+                  "autoResolve": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                }
+              },
+              "example": {
+                "titles": {
+                  "include": [
+                    "Engineer"
+                  ],
+                  "vector": false
+                },
+                "occupationTaxonomy": {
+                  "level2": [
+                    "DevOps"
+                  ]
+                },
+                "location": {
+                  "countries": [
+                    "US"
+                  ]
+                },
+                "postedWithin": 30,
+                "limit": 5,
+                "totalMode": "none",
+                "mode": "fast",
+                "autoResolve": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Job search results",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimitLimit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimitRemaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimitReset"
+              },
+              "X-RateLimit-RPS-Limit": {
+                "$ref": "#/components/headers/SearchRpsLimit"
+              },
+              "X-RateLimit-RPS-Remaining": {
+                "$ref": "#/components/headers/SearchRpsRemaining"
+              },
+              "X-RateLimit-RPS-Reset": {
+                "$ref": "#/components/headers/SearchRpsReset"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "signals": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "totalMode": {
+                      "type": "string"
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "returned": {
+                          "type": "integer"
+                        },
+                        "has_more": {
+                          "type": "boolean"
+                        },
+                        "next_cursor": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      }
+                    },
+                    "has_more": {
+                      "type": "boolean"
+                    },
+                    "next_cursor": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "resolved": {
+                      "type": "object"
+                    },
+                    "credits_consumed": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "signals": [
+                    {
+                      "title": "Full-Stack Software Engineer",
+                      "company": {
+                        "id": 102413,
+                        "name": "Example Company",
+                        "website_url": "https://example.com"
+                      },
+                      "occupation_taxonomy": {
+                        "level1": {
+                          "id": 1,
+                          "name": "Developer"
+                        },
+                        "level2": {
+                          "id": 20,
+                          "name": "Full-Stack Development"
+                        },
+                        "level3": {
+                          "id": 774,
+                          "name": "Full-stack software engineer"
+                        }
+                      }
+                    }
+                  ],
+                  "total": 3,
+                  "totalMode": "capped",
+                  "credits_consumed": 1
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          }
+        }
+      }
+    },
+    "/v3/search/stats": {
+      "post": {
+        "summary": "Search Stats",
+        "description": "Free helper endpoint that returns cached high-level coverage, capabilities, and top dimensions for Jobs, Company, and People Search.",
+        "operationId": "search-stats-v3",
+        "tags": [
+          "Jobs Data",
+          "Company Data",
+          "People Enrichment"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "products": {
+                    "type": "array",
+                    "description": "Search products to include — jobs, company, and/or people stats.",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "jobs",
+                        "company",
+                        "people"
+                      ]
+                    },
+                    "default": [
+                      "jobs",
+                      "company",
+                      "people"
+                    ]
+                  },
+                  "sections": {
+                    "type": "array",
+                    "description": "Stat sections to return — coverage counts, top dimensions, and/or filter capabilities.",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "coverage",
+                        "top",
+                        "capabilities"
+                      ]
+                    },
+                    "default": [
+                      "coverage",
+                      "top",
+                      "capabilities"
+                    ]
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "description": "Max top values per dimension. Defaults to 3.",
+                    "minimum": 1,
+                    "maximum": 25,
+                    "default": 3
+                  }
+                }
+              },
+              "example": {
+                "products": [
+                  "jobs",
+                  "company",
+                  "people"
+                ],
+                "sections": [
+                  "coverage",
+                  "top"
+                ],
+                "limit": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search stats results"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          }
+        }
+      }
+    },
+    "/v3/jobs-search": {
+      "post": {
+        "summary": "Job Search Alias",
+        "description": "Alias for POST /v3/jobs/search.",
+        "operationId": "job-search-alias",
+        "tags": [
+          "Jobs Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "titles": {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "vector": {
+                        "type": "boolean",
+                        "default": false
+                      }
+                    }
+                  },
+                  "location": {
+                    "type": "object",
+                    "properties": {
+                      "countries": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "tags": {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "default": 25,
+                    "maximum": 50
+                  },
+                  "totalMode": {
+                    "type": "string",
+                    "default": "capped",
+                    "enum": [
+                      "none",
+                      "capped",
+                      "exact"
+                    ]
+                  },
+                  "mode": {
+                    "type": "string",
+                    "default": "fast",
+                    "enum": [
+                      "fast",
+                      "deep"
+                    ]
+                  }
+                }
+              },
+              "example": {
+                "titles": {
+                  "include": [
+                    "Software Engineer"
+                  ],
+                  "vector": false
+                },
+                "location": {
+                  "countries": [
+                    "US"
+                  ]
+                },
+                "limit": 5,
+                "totalMode": "none",
+                "mode": "fast"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Job search results"
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/resolve": {
+      "post": {
+        "summary": "Resolve Job Search filters",
+        "description": "Resolve friendly companies, countries, tags, occupation taxonomy values, and titles into canonical filter IDs. This endpoint does not return job rows and is free.",
+        "operationId": "job-search-resolve",
+        "tags": [
+          "Jobs Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "companies": {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "ids": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  },
+                  "tags": {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "occupationTaxonomy": {
+                    "type": "object",
+                    "properties": {
+                      "level1": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "level2": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "level3": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "location": {
+                    "type": "object",
+                    "properties": {
+                      "countries": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "regions": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "states": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      },
+                      "cities": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "titles": {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "exclude": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "companies": {
+                    "include": [
+                      "leadmagic.io"
+                    ]
+                  },
+                  "tags": {
+                    "include": [
+                      "kubernetes"
+                    ]
+                  },
+                  "occupationTaxonomy": {
+                    "level2": [
+                      "DevOps"
+                    ]
+                  },
+                  "location": {
+                    "countries": [
+                      "US"
+                    ]
+                  },
+                  "titles": {
+                    "include": [
+                      "Site Reliability Engineer"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resolved filters"
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/companies": {
+      "get": {
+        "summary": "Job Search Companies Helper",
+        "description": "Company autocomplete and cards for Job Search.",
+        "operationId": "job-search-companies",
+        "tags": [
+          "Jobs Data"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "example": "leadmagic",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "domain",
+            "in": "query",
+            "example": "leadmagic.io",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "example": 10,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Company helper results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "companies": [
+                    {
+                      "id": 102413,
+                      "name": "LeadMagic",
+                      "domain": "leadmagic.io",
+                      "logo_domain": "leadmagic.io"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/tags": {
+      "get": {
+        "summary": "Job Search Tags Helper",
+        "description": "Tag autocomplete with occupation taxonomy metadata.",
+        "operationId": "job-search-tags",
+        "tags": [
+          "Jobs Data"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "example": "kuber",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tag_type",
+            "in": "query",
+            "example": 2,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "example": 10,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tag helper results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "tags": [
+                    {
+                      "id": 482,
+                      "name": "kubernetes",
+                      "tag_type": 2,
+                      "occupation_taxonomy": {
+                        "level1": {
+                          "id": 1,
+                          "name": "Developer"
+                        },
+                        "level2": {
+                          "id": 20,
+                          "name": "DevOps"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/titles": {
+      "get": {
+        "summary": "Job Search Titles Helper",
+        "description": "Title autocomplete with occupation taxonomy metadata.",
+        "operationId": "job-search-titles",
+        "tags": [
+          "Jobs Data"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "example": "devops engineer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "example": 10,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Title helper results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "titles": [
+                    {
+                      "id": 774,
+                      "name": "DevOps Engineer",
+                      "occupation_taxonomy": {
+                        "level1": {
+                          "id": 1,
+                          "name": "Developer"
+                        },
+                        "level2": {
+                          "id": 20,
+                          "name": "DevOps"
+                        },
+                        "level3": {
+                          "id": 774,
+                          "name": "DevOps Engineer"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/occupation-taxonomy": {
+      "get": {
+        "summary": "Job Search Occupation Taxonomy Helper",
+        "description": "Occupation taxonomy autocomplete with level1, level2, and level3 IDs and labels.",
+        "operationId": "job-search-occupation-taxonomy",
+        "tags": [
+          "Jobs Data"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "example": "DevOps",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "example": "level2",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "level1",
+                "level2",
+                "level3"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "example": 10,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Occupation taxonomy helper results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "occupation_taxonomy": [
+                    {
+                      "id": 1700834,
+                      "name": ".NET & DevOps",
+                      "type": 2,
+                      "level1": {
+                        "id": 7,
+                        "name": "Engineer"
+                      },
+                      "level2": {
+                        "id": 1700834,
+                        "name": ".NET & DevOps"
+                      },
+                      "level3": null,
+                      "path": "Engineer > .NET & DevOps"
+                    }
+                  ],
+                  "credits_consumed": 0
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/locations": {
+      "get": {
+        "summary": "Job Search Locations Helper",
+        "description": "Country, region, state, and city autocomplete for exact geo filters.",
+        "operationId": "job-search-locations",
+        "tags": [
+          "Jobs Data"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "example": "United",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "example": "country",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "country",
+                "region",
+                "state",
+                "city"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "example": 10,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Location helper results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "locations": [
+                    {
+                      "id": 840,
+                      "name": "United States",
+                      "type": "country"
+                    },
+                    {
+                      "id": 826,
+                      "name": "United Kingdom",
+                      "type": "country"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/catalogs": {
+      "get": {
+        "summary": "Job Search Catalogs",
+        "description": "Filter catalogs for countries, regions, job types, industries, company types, seniority, and public-safe Jobs Search stats.",
+        "operationId": "job-search-catalogs",
+        "tags": [
+          "Jobs Data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Catalog response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "countries": [
+                    {
+                      "id": 840,
+                      "name": "United States"
+                    },
+                    {
+                      "id": 826,
+                      "name": "United Kingdom"
+                    }
+                  ],
+                  "job_types": [
+                    {
+                      "id": 1,
+                      "name": "Full-time"
+                    },
+                    {
+                      "id": 2,
+                      "name": "Part-time"
+                    },
+                    {
+                      "id": 3,
+                      "name": "Contract"
+                    }
+                  ],
+                  "industries": [
+                    {
+                      "id": 96,
+                      "name": "Software"
+                    }
+                  ],
+                  "company_types": [
+                    {
+                      "id": 1,
+                      "name": "Private"
+                    },
+                    {
+                      "id": 2,
+                      "name": "Public"
+                    }
+                  ],
+                  "seniority": [
+                    {
+                      "id": 1,
+                      "name": "Entry"
+                    },
+                    {
+                      "id": 5,
+                      "name": "VP"
+                    }
+                  ],
+                  "stats": {
+                    "total_jobs_indexed": 12500000,
+                    "freshness_days": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/roles": {
+      "get": {
+        "summary": "Job Search Roles Helper",
+        "description": "Role autocomplete for occupation-based filtering, mapped to occupation taxonomy IDs.",
+        "operationId": "job-search-roles",
+        "tags": [
+          "Jobs Data"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "example": "revenue operations",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "example": 10,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Role helper results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "roles": [
+                    {
+                      "id": 20,
+                      "name": "Revenue Operations",
+                      "occupation_taxonomy": {
+                        "level1": {
+                          "id": 5,
+                          "name": "Operations"
+                        },
+                        "level2": {
+                          "id": 20,
+                          "name": "Revenue Operations"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/stats": {
+      "get": {
+        "summary": "Job Search Dataset Stats",
+        "description": "Public-safe dataset statistics for the Jobs Search index — totals and freshness. Free.",
+        "operationId": "job-search-stats",
+        "tags": [
+          "Jobs Data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataset statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "stats": {
+                    "total_jobs_indexed": 12500000,
+                    "freshness_days": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/job-board/stats": {
+      "get": {
+        "summary": "Job Board Stats",
+        "description": "Alias of Job Search Dataset Stats for job-board integrations. Free.",
+        "operationId": "job-board-stats",
+        "tags": [
+          "Jobs Data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataset statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "stats": {
+                    "total_jobs_indexed": 12500000,
+                    "freshness_days": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/jobs/search/export": {
+      "post": {
+        "summary": "Job Search Export",
+        "description": "Bulk export of job postings using the full Job Search filter vocabulary. Returns up to 5,000 jobs per request with descriptions included by default. Credit-metered on all plans.",
+        "operationId": "job-search-export",
+        "tags": [
+          "Jobs Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "titles": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Same title filters as Job Search, including include/exclude and vector."
+                  },
+                  "companies": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "location": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "tags": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "occupationTaxonomy": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "salary": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "workModes": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "postedWithin": {
+                    "type": "integer",
+                    "description": "Days back, max 365."
+                  },
+                  "includeDescription": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeCompany": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5000,
+                    "default": 100,
+                    "description": "Maximum jobs to export. Cursor pagination is not supported on export; narrow filters instead."
+                  }
+                }
+              },
+              "example": {
+                "titles": {
+                  "include": [
+                    "Software Engineer"
+                  ]
+                },
+                "location": {
+                  "countries": [
+                    "US"
+                  ]
+                },
+                "postedWithin": 30,
+                "limit": 500
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Exported jobs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "jobs": [
+                    {
+                      "id": "j_01hxyz",
+                      "title": "Software Engineer",
+                      "company": {
+                        "name": "Example Corp",
+                        "domain": "example.com"
+                      },
+                      "location": "United States",
+                      "posted_at": "2026-08-01",
+                      "description": "Full posting text…"
+                    }
+                  ],
+                  "total_returned": 500,
+                  "credits_consumed": 500
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/jobs/countries": {
+      "get": {
+        "summary": "Job Country",
+        "description": "Use this API to retrieve the country ID, which can then be used in the Jobs Finder API to filter jobs by country.",
+        "operationId": "job-country",
+        "tags": [
+          "Jobs Data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with country list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "id": "AL",
+                      "name": "Albania"
+                    },
+                    {
+                      "id": "DZ",
+                      "name": "Algeria"
+                    },
+                    {
+                      "id": "AD",
+                      "name": "Andorra"
+                    },
+                    {
+                      "id": "AO",
+                      "name": "Angola"
+                    },
+                    {
+                      "id": "AG",
+                      "name": "Antigua and Barbuda"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/jobs/regions": {
+      "get": {
+        "summary": "Job Region",
+        "description": "Use this API to retrieve the region ID, which can then be used in the Jobs Finder API to filter jobs by region.",
+        "operationId": "job-regions",
+        "tags": [
+          "Jobs Data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with region list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "default": 0
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "id": 1,
+                      "name": "Africa"
+                    },
+                    {
+                      "id": 2,
+                      "name": "Asia/Pacific"
+                    },
+                    {
+                      "id": 3,
+                      "name": "Europe"
+                    },
+                    {
+                      "id": 4,
+                      "name": "Middle East"
+                    },
+                    {
+                      "id": 5,
+                      "name": "North America"
+                    },
+                    {
+                      "id": 6,
+                      "name": "South America"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/jobs/job-types": {
+      "get": {
+        "summary": "Job Type",
+        "description": "Use this API to retrieve the Job Type ID, which can then be used in the Jobs Finder API to filter jobs by Job Type.",
+        "operationId": "job-types",
+        "tags": [
+          "Jobs Data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with job type list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "default": 0
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "id": 1,
+                      "name": "Full Time"
+                    },
+                    {
+                      "id": 2,
+                      "name": "Part Time"
+                    },
+                    {
+                      "id": 3,
+                      "name": "Temporary"
+                    },
+                    {
+                      "id": 4,
+                      "name": "Internship"
+                    },
+                    {
+                      "id": 5,
+                      "name": "Freelance"
+                    },
+                    {
+                      "id": 6,
+                      "name": "Contract"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/jobs/company-types": {
+      "get": {
+        "summary": "Job Company Type",
+        "description": "Use this API to retrieve the Company Type ID, which can then be used in the Jobs Finder API to filter jobs by Company Type.",
+        "operationId": "job-company-types",
+        "tags": [
+          "Jobs Data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with company type list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "default": 0
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/jobs/industries": {
+      "get": {
+        "summary": "Job Industry",
+        "description": "Use this API to retrieve the Industry ID, which can then be used in the Jobs Finder API to filter jobs by Industry.",
+        "operationId": "job-industry",
+        "tags": [
+          "Jobs Data"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with industry list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "default": 0
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "id": 22,
+                      "name": "Accounting"
+                    },
+                    {
+                      "id": 318,
+                      "name": "Administration of Justice"
+                    },
+                    {
+                      "id": 297,
+                      "name": "Administrative and Support Services"
+                    },
+                    {
+                      "id": 8,
+                      "name": "Advertising Services"
+                    },
+                    {
+                      "id": 245,
+                      "name": "Agricultural Chemical Manufacturing"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/ads/google-ads-search": {
+      "post": {
+        "summary": "Google Ads Search",
+        "description": "Search for Google Ads run by a company to understand their advertising strategy.",
+        "operationId": "google-ads-search",
+        "tags": [
+          "Ads Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Company domain name",
+                    "default": "leadmagic.io",
+                    "example": "leadmagic.io"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Company name",
+                    "default": "leadmagic",
+                    "example": "leadmagic"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the credits spent on the request. Omit to return every ad found.",
+                    "example": 10
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with ads details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Google Ads retrieved successfully"
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "example": 2
+                    },
+                    "ads_count": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "ads": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "advertiser_id": {
+                            "type": "string",
+                            "example": "123456"
+                          },
+                          "creative_id": {
+                            "type": "string",
+                            "example": "789012"
+                          },
+                          "original_url": {
+                            "type": "string",
+                            "example": "https://www.example.com/ad"
+                          },
+                          "variants": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "content": {
+                                  "type": "string",
+                                  "example": "<img src=\"https://tpc.googlesyndication.com/archive/simgad/6399633577457746150\" height=\"173\" width=\"380\">"
+                                },
+                                "height": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "example": 173
+                                },
+                                "width": {
+                                  "type": "integer",
+                                  "nullable": true,
+                                  "example": 380
+                                }
+                              }
+                            }
+                          },
+                          "start": {
+                            "type": "string",
+                            "example": "2023-01-01"
+                          },
+                          "last_seen": {
+                            "type": "string",
+                            "example": "2023-12-31"
+                          },
+                          "advertiser_name": {
+                            "type": "string",
+                            "example": "Example Company"
+                          },
+                          "format": {
+                            "type": "string",
+                            "example": "Text"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "ads": [
+                      {
+                        "advertiser_id": "AR14106062795078369281",
+                        "creative_id": "CR14003695067076755457",
+                        "original_url": "https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR14003695067076755457?region=anywhere",
+                        "variants": [
+                          {
+                            "content": "<img src=\"https://tpc.googlesyndication.com/archive/simgad/6399633577457746150\" height=\"173\" width=\"380\">",
+                            "height": 173,
+                            "width": 380
+                          }
+                        ],
+                        "start": "2024-07-03",
+                        "last_seen": "2025-03-06",
+                        "advertiser_name": "LeadMagic Inc",
+                        "format": "Text"
+                      },
+                      {
+                        "advertiser_id": "AR14106062795078369281",
+                        "creative_id": "CR16065875974473908225",
+                        "original_url": "https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR16065875974473908225?region=anywhere",
+                        "variants": [
+                          {
+                            "content": "<img src=\"https://tpc.googlesyndication.com/archive/simgad/14075255850026292628\" height=\"173\" width=\"380\">",
+                            "height": 173,
+                            "width": 380
+                          }
+                        ],
+                        "start": "2025-02-04",
+                        "last_seen": "2025-03-06",
+                        "advertiser_name": "LeadMagic Inc",
+                        "format": "Text"
+                      }
+                    ],
+                    "credits_consumed": 2
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/ads/meta-ads-search": {
+      "post": {
+        "summary": "Meta Ads Search",
+        "description": "Search for Meta Ads by company domain or name.",
+        "operationId": "meta-ads-search",
+        "tags": [
+          "Ads Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Company domain name",
+                    "default": "leadmagic.io",
+                    "example": "leadmagic.io"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Company name",
+                    "default": "leadmagic",
+                    "example": "leadmagic"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the credits spent on the request. Omit to return every ad found.",
+                    "example": 10
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with ads details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Meta Ads retrieved successfully"
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "ads_count": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "ads": {
+                      "type": "array",
+                      "description": "Array of ad objects (structure varies by ad type)",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Meta Ads retrieved successfully",
+                    "credits_consumed": 1,
+                    "ads_count": 1,
+                    "ads": [
+                      {
+                        "adid": "0",
+                        "adArchiveID": "618153827656899",
+                        "archiveTypes": [],
+                        "categories": [
+                          0
+                        ],
+                        "containsDigitallyCreatedMedia": false,
+                        "containsSensitiveContent": false,
+                        "collationCount": 1,
+                        "collationID": 1015196963820298,
+                        "currency": "",
+                        "endDate": 1741248000,
+                        "entityType": "person_profile",
+                        "fevInfo": null,
+                        "finServAdData": {
+                          "is_deemed_finserv": false,
+                          "is_limited_delivery": false
+                        },
+                        "gatedType": "eligible",
+                        "hasUserReported": false,
+                        "hiddenSafetyData": false,
+                        "hideDataStatus": "NONE",
+                        "impressionsWithIndex": {
+                          "impressionsText": null,
+                          "impressionsIndex": -1
+                        },
+                        "isAAAEligible": true,
+                        "isAdAccountActioned": false,
+                        "isActive": true,
+                        "isProfilePage": false,
+                        "pageID": "105549201674375",
+                        "pageInfo": null,
+                        "pageIsDeleted": false,
+                        "pageName": "Lykkedal Retreat",
+                        "politicalCountries": [],
+                        "reachEstimate": null,
+                        "regionalRegulationData": {
+                          "finserv": {
+                            "is_deemed_finserv": false,
+                            "is_limited_delivery": false
+                          },
+                          "tw_anti_scam": {
+                            "is_limited_delivery": false
+                          }
+                        },
+                        "reportCount": null,
+                        "snapshot": {
+                          "ad_creative_id": 1159245568945589,
+                          "cards": [],
+                          "body_translations": {},
+                          "byline": null,
+                          "caption": "ezme.io",
+                          "cta_text": "Buy tickets",
+                          "dynamic_item_flags": {},
+                          "dynamic_versions": null,
+                          "edited_snapshots": [],
+                          "effective_authorization_category": "NONE",
+                          "event": {
+                            "event_promoted_type": "external_tickets",
+                            "event_start_timestamp": 1742130000,
+                            "event_end_timestamp": 1742137200,
+                            "event_location": "Dalvej 5, Helsinge",
+                            "event_timezone": "Europe/Copenhagen"
+                          },
+                          "extra_images": [],
+                          "extra_links": [],
+                          "extra_texts": [],
+                          "extra_videos": [],
+                          "instagram_shopping_products": [],
+                          "display_format": "event",
+                          "title": "Yin Yoga & Yoga Nidra til LeadMagic",
+                          "link_description": "Dalvej 5, Helsinge",
+                          "link_url": "https://ezme.io/c/xHa/3KPb",
+                          "page_welcome_message": null,
+                          "images": [
+                            {
+                              "original_image_url": "https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/481787314_4001422706744378_5754827939445302437_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=oLiF-cU0WxgQ7kNvgEM6GgD&_nc_oc=AdgH2C1dxKtFX8-Nb0xC8YJj9RAGxYUVx4s72-vlBMvSF8NqRSDRTgLtQ49bxn4GKvU&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYFCcwS06k5-Zs4REiVNPyDBnDiH2m3ry6__l8b-xYVnNw&oe=67D010D7",
+                              "resized_image_url": "https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/482055202_1183219813458252_5286390622516633466_n.jpg?stp=dst-jpg_s600x600_tt6&_nc_cat=106&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=UpMVtSZb0FoQ7kNvgGYCYSO&_nc_oc=AdioNK9N0BC6jFliPpZBoCB7q8c6RxzPm1sjxYyWN8gW1fEzj5ort06-PEXPS9aRQtY&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYET5FXrho887m4dU5OxwmVKM8nNNYMDyPzbcrFDRHPNkQ&oe=67CFD900",
+                              "watermarked_resized_image_url": "",
+                              "image_crops": {}
+                            }
+                          ],
+                          "videos": [],
+                          "creation_time": 1741291804,
+                          "page_id": 105549201674375,
+                          "page_name": "Lykkedal Retreat",
+                          "page_profile_picture_url": "https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482021866_1335378004273354_6611332374691484765_n.jpg?stp=dst-jpg_s60x60_tt6&_nc_cat=107&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=9OkGTrz7rR0Q7kNvgG57RTD&_nc_oc=AdhR7nxSqcwLeXf4E6zMven92LUORzNF9f6UG5HdXPkNcCJwnCvuJsEFIkd2qEkf1mc&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYHvvv7TVyYBBZbUWdFtsMMF1Zw19HFrCguT8PizFkDG-w&oe=67CFF9CB",
+                          "page_categories": {
+                            "1215982301785137": "Meditation Center"
+                          },
+                          "page_entity_type": "person_profile",
+                          "page_is_profile_page": false,
+                          "instagram_actor_name": "🔆 ET LIV I BALANCE 🔆",
+                          "instagram_profile_pic_url": "https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482221977_1473904650233662_1812261223336634635_n.jpg?_nc_cat=102&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=pt8glJ939ioQ7kNvgEhv2uO&_nc_oc=Adi7fFY9dROfonTLhbM1HQhTr-sBDcj7xGQeKttehNVcjEKjKkBqWDm69xB9k8lQLk4&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYH7uq0g9Ag0DFiPvgZdXyt_1LXYO8ZrWuCq--rMrhWQfw&oe=67CFE12C",
+                          "instagram_url": "",
+                          "instagram_handle": "",
+                          "is_reshared": false,
+                          "version": 3,
+                          "body": {
+                            "context": {},
+                            "markup": {
+                              "__html": "🌿 Yin Yoga &amp; LeadMagic Meditation i jurten på Lykkedal Retreat 🌿<br /> <br /> Trænger du til en dyb pause, hvor krop og sind får lov at give slip og finde ro? ✨<br /> <br /> 🧘‍♀️ Yin Yoga er en blid, meditativ yogaform, der arbejder med kroppens bindevæv, led og energibaner gennem lange, rolige stræk. Stillingerne holdes i flere minutter, så kroppen får tid til at slippe spændinger og finde dybere afslapning. Alle kan være med – uanset erfaring.<br /> <br /> 🎶 LeadMagic Meditation fordyber din afslapning gennem dybe, vibrerende lyde, der beroliger nervesystemet og inviterer sindet til at give slip. Mange oplever en følelse af lethed, ro og fornyet energi efter en meditation.<br /> <br /> 📅 Dato: Søndag d. 16. marts<br /> ⏰ Tid: Kl. 14:00 - 16:00<br /> 📍 Sted: Lykkedal Retreat, Dalvej 5, Helsinge<br />       Pris: 275 kr.<br /> <br /> 🌿 Efter workshoppen byder vi på økologisk urtete og lækre snacks i vores hyggelige skovcafé. Her kan du nyde en stille stund og mærke effekten af din praksis. Tag en mindful gåtur i naturen og hils på dyrene – en smuk måde at afslutte dagen på.<br /> <br /> 🔔 Alle er velkomne – uanset erfaring! 🔔<br /> <br /> 💚 Tilmelding &amp; info:<br /> 📩 Send besked til Natassia på info&#064;lykkedalretreat.dk eller tlf. 2390 7473<br /> <br /> 🌾 Lykkedal Retreat – en perle i Nordsjællands natur 🌾<br /> Her finder du åbne marker med heste, høje træer og den smukke gamle Pibe Mølle. Workshoppen afholdes i den stemningsfulde jurt/rundsal, hvor du kan fordybe dig i ro og nærvær.<br /> <br /> ✨ Tidligere deltagere siger:<br /> 🌟 &quot;Lykkedal er et åndehul i naturen&quot;<br /> 🌟 &quot;Jeg kom hjem i mig selv&quot;<br /> 🌟 &quot;Jeg havde glemt, hvor meget jeg savner naturen&quot;<br /> <br /> 📩 Book din plads i dag – vi glæder os til at byde dig velkommen!<br /> <br /> #YinYoga #LeadMagicMeditation #LykkedalRetreat #IndreRo #NaturligBalance #Mindfulness #Selvforkælelse #TidTilDigSelv"
+                            },
+                            "callerHash": "c339298372ed2a9ebf3ad02f136b05d2"
+                          },
+                          "brazil_tax_id": null,
+                          "branded_content": null,
+                          "current_page_name": "Lykkedal Retreat",
+                          "disclaimer_label": null,
+                          "page_like_count": 1198,
+                          "page_profile_uri": "https://facebook.com/LykkedalRetreat",
+                          "page_is_deleted": false,
+                          "root_reshared_post": null,
+                          "cta_type": "BUY_TICKETS",
+                          "additional_info": null,
+                          "ec_certificates": null,
+                          "country_iso_code": null,
+                          "instagram_branded_content": null
+                        },
+                        "spend": null,
+                        "startDate": 1741248000,
+                        "stateMediaRunLabel": null,
+                        "publisherPlatform": [
+                          "facebook",
+                          "instagram"
+                        ],
+                        "menuItems": [],
+                        "targetedOrReachedCountries": [],
+                        "totalActiveTime": 7915
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/ads/b2b-ads-search": {
+      "post": {
+        "summary": "B2B Search Ads",
+        "description": "Search for B2B ads by company domain or name. Charged 1 base credit plus 1 credit per ad returned (minimum 1 credit).",
+        "operationId": "b2b-ads-search",
+        "tags": [
+          "Ads Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_domain": {
+                    "type": "string",
+                    "description": "Company domain name",
+                    "default": "gong.io",
+                    "example": "gong.io"
+                  },
+                  "company_name": {
+                    "type": "string",
+                    "description": "Company name",
+                    "default": "gong",
+                    "example": "gong"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the per-ad credits spent on the request; the 1 base credit per search still applies. Omit to return every ad found.",
+                    "example": 10
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with ads details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "B2B ads found for the given company."
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "example": 25
+                    },
+                    "ads_count": {
+                      "type": "integer",
+                      "example": 24
+                    },
+                    "company": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "domain": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "industry": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "company_size": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "linkedin_url": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "B2B company profile URL (/company/{slug})"
+                        },
+                        "logo_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "city": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "state": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "country": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      }
+                    },
+                    "ads": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "ad_id": {
+                            "type": "string"
+                          },
+                          "headline": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "content": {
+                            "type": "string"
+                          },
+                          "link": {
+                            "type": "string"
+                          },
+                          "ad_url": {
+                            "type": "string"
+                          },
+                          "image_url": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "carousel_images": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "ad_type": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "creative_type": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "advertiser": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "advertiser_linkedin_url": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Advertiser B2B company profile URL (/company/{slug})"
+                          },
+                          "cta_text": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "landing_page_url": {
+                            "type": "string",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "B2B ads found for the given company.",
+                    "credits_consumed": 25,
+                    "ads_count": 24,
+                    "company": {
+                      "name": "gong",
+                      "domain": "gong.io",
+                      "industry": "computer software",
+                      "company_size": "1001-5000",
+                      "linkedin_url": "/company/gong-io",
+                      "logo_url": "https://logo.leadmagic.io/gong.io",
+                      "city": "san francisco",
+                      "state": "california",
+                      "country": "united states"
+                    },
+                    "ads": [
+                      {
+                        "ad_id": "1436673673",
+                        "headline": null,
+                        "description": "See how revenue teams use Gong to win more deals.",
+                        "content": "See how revenue teams use Gong to win more deals.",
+                        "link": "1436673673",
+                        "ad_url": "/ad-library/detail/1436673673",
+                        "ad_type": "Document Ad",
+                        "creative_type": "SPONSORED_UPDATE_NATIVE_DOCUMENT",
+                        "advertiser": "Gong",
+                        "advertiser_linkedin_url": "/company/gong-io"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/ads/b2b-ads-details": {
+      "post": {
+        "summary": "B2B Ad Details",
+        "description": "Get detailed information about a specific B2B ad using its ad library URL, path, or numeric ID.",
+        "operationId": "b2b-ad-details",
+        "tags": [
+          "Ads Data"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ad_url": {
+                    "type": "string",
+                    "description": "B2B ad library URL, path (/ad-library/detail/{id}), or numeric ad ID",
+                    "example": "1436673673"
+                  }
+                },
+                "required": [
+                  "ad_url"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with ad details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Ad details retrieved successfully"
+                    },
+                    "credits_consumed": {
+                      "type": "number",
+                      "example": 2
+                    },
+                    "company": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "domain": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "industry": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "company_size": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "linkedin_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "logo_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "city": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "state": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "country": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      }
+                    },
+                    "ad_details": {
+                      "type": "object",
+                      "description": "Normalized ad object (same shape as B2B Ads Search) plus raw source payload",
+                      "properties": {
+                        "ad_id": {
+                          "type": "string"
+                        },
+                        "headline": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "content": {
+                          "type": "string"
+                        },
+                        "link": {
+                          "type": "string"
+                        },
+                        "ad_url": {
+                          "type": "string"
+                        },
+                        "ad_type": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "creative_type": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "advertiser": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "advertiser_linkedin_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "cta_text": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "landing_page_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "image_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "carousel_images": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "video_url": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "targeting": {
+                          "type": "object",
+                          "nullable": true
+                        },
+                        "total_impressions": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "impressions_by_country": {
+                          "type": "array",
+                          "items": {}
+                        },
+                        "message_ad": {
+                          "type": "object",
+                          "nullable": true
+                        },
+                        "raw": {
+                          "type": "object",
+                          "description": "Original ad payload for unmapped fields"
+                        }
+                      }
+                    }
+                  },
+                  "example": {
+                    "message": "Ad details retrieved successfully",
+                    "credits_consumed": 2,
+                    "company": {
+                      "name": "Gong",
+                      "linkedin_url": "/company/gong-io"
+                    },
+                    "ad_details": {
+                      "ad_id": "1436673673",
+                      "content": "See how revenue teams use Gong to win more deals.",
+                      "link": "1436673673",
+                      "ad_url": "/ad-library/detail/1436673673",
+                      "ad_type": "Document Ad",
+                      "creative_type": "SPONSORED_UPDATE_NATIVE_DOCUMENT",
+                      "advertiser": "Gong",
+                      "advertiser_linkedin_url": "/company/gong-io",
+                      "raw": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/bulk/submit": {
+      "post": {
+        "summary": "Submit Bulk Job",
+        "description": "Submit data for bulk enrichment. Provide exactly one of rows (JSON array), csv (string), fileUrl (HTTPS URL), or scrape (browser rendering config). The job is processed asynchronously; use the returned jobId to poll status via GET /bulk/jobs/{jobId}. **Security**: fileUrl and callback.url are SSRF-validated server-side. Private/internal IP ranges, localhost, cloud metadata endpoints (169.254.169.254), and non-HTTPS protocols are rejected.",
+        "operationId": "bulk-submit",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkSubmissionRequest"
+              },
+              "example": {
+                "product": "email_finder",
+                "rows": [
+                  {
+                    "profile_url": "https://example.com/in/jane-doe",
+                    "company_name": "LeadMagic"
+                  }
+                ],
+                "callback": {
+                  "url": "https://hooks.example.com/leadmagic/bulk",
+                  "events": [
+                    "completed"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Bulk job accepted and queued for processing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkSubmissionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. The request body failed validation, or a provided URL failed SSRF validation (SSRF_VALIDATION_FAILED).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/BadRequest"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/bulk/jobs": {
+      "get": {
+        "summary": "List Bulk Jobs",
+        "description": "Retrieve a paginated list of bulk jobs owned by the authenticated account, newest first.",
+        "operationId": "bulk-job-list",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter jobs by current status.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "product",
+            "in": "query",
+            "required": false,
+            "description": "Filter jobs by enrichment product.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of jobs per page.",
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of jobs to skip.",
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0,
+              "maximum": 10000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of bulk jobs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobsListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}": {
+      "get": {
+        "summary": "Get Bulk Job Status",
+        "description": "Retrieve the current status and progress of a specific bulk job. Accepts progress-token auth from the submit response.",
+        "operationId": "bulk-job-status",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "UUID identifier of the bulk job.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current status of the requested bulk job.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobDetailResponse"
+                },
+                "example": {
+                  "job_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "status": "processing",
+                  "products": [
+                    "email_finder"
+                  ],
+                  "submission_product": "email_finder",
+                  "submission_endpoint": null,
+                  "execution_mode": null,
+                  "total_rows": 5000,
+                  "processed_items": 2125,
+                  "succeeded_items": 2080,
+                  "failed_items": 45,
+                  "skipped_items": 0,
+                  "total_credits_consumed": "2080.00",
+                  "total_duration_ms": null,
+                  "created_at": "2026-07-09T14:30:00.000Z",
+                  "started_at": "2026-07-09T14:30:05.000Z",
+                  "completed_at": null,
+                  "last_progress_at": "2026-07-09T14:35:12.000Z",
+                  "file_name": "q3-contacts.csv",
+                  "callback_url": "https://hooks.example.com/leadmagic/bulk",
+                  "callback_event": "completed",
+                  "priority": 0,
+                  "output_transform": null,
+                  "links": {
+                    "statusUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890?token=...",
+                    "streamUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stream?token=...",
+                    "wsUrl": "wss://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/ws?token=...",
+                    "resultsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/results?token=...",
+                    "rowsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rows?token=...",
+                    "errorsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/errors?token=...",
+                    "eventsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events?token=...",
+                    "eventsExportUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events/export?token=...",
+                    "logsUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/logs?token=...",
+                    "downloadUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/download?token=...",
+                    "progressUrl": "https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/progress?token=...",
+                    "token": "prt_abc123...",
+                    "exp": 1752259200
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/review": {
+      "post": {
+        "summary": "Review Bulk Job (Cancel or Approve)",
+        "description": "Cancel a queued or processing bulk job by submitting {\"action\": \"reject\"}, or resume a paused job with {\"action\": \"approve\"}. Completed or failed jobs cannot be reviewed.",
+        "operationId": "bulk-job-review",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "UUID identifier of the bulk job.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "action"
+                ],
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "approve",
+                      "reject"
+                    ]
+                  }
+                }
+              },
+              "example": {
+                "action": "reject"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Review action confirmed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/results": {
+      "get": {
+        "summary": "Get Bulk Job Results",
+        "description": "Retrieve paginated row-level results for a bulk job as JSON.",
+        "operationId": "bulk-job-results",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "UUID identifier of the bulk job.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 200,
+              "minimum": 1,
+              "maximum": 1000
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter rows by status.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated row results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobRowsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/download": {
+      "get": {
+        "summary": "Download Bulk Job Results as CSV",
+        "description": "Stream the full results as a CSV file. No pagination — all rows are included.",
+        "operationId": "bulk-job-download",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "UUID identifier of the bulk job.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV stream.",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/bulk/capabilities": {
+      "get": {
+        "summary": "Get Bulk API Capabilities",
+        "description": "Return the machine-readable bulk enrichment capability and tool manifest.",
+        "operationId": "bulk-capabilities",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "responses": {
+          "200": {
+            "description": "Bulk capability manifest.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/bulk/validate": {
+      "post": {
+        "summary": "Validate a Bulk Submission",
+        "description": "Validate a bulk submission payload without persisting or processing a job.",
+        "operationId": "bulk-validate",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkSubmissionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validation result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/bulk/local-leads": {
+      "post": {
+        "summary": "Submit a Local Leads Search",
+        "description": "Submit long-running local-leads searches to the dedicated bulk queue.",
+        "operationId": "bulk-local-leads",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "keywords",
+                  "cities"
+                ],
+                "properties": {
+                  "keywords": {
+                    "type": "array",
+                    "description": "Search terms. Expanded against every city — one search row per keyword × city pair.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "plumber",
+                      "hvac contractor"
+                    ]
+                  },
+                  "cities": {
+                    "type": "array",
+                    "description": "Cities to search. Expanded against every keyword.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "Austin",
+                      "Dallas"
+                    ]
+                  },
+                  "countryCodes": {
+                    "type": "array",
+                    "description": "Two-letter country code per city, aligned by index. Defaults to `US` when omitted.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "US",
+                      "US"
+                    ]
+                  },
+                  "fileName": {
+                    "type": "string",
+                    "description": "Label for the resulting job, shown in the dashboard.",
+                    "example": "texas-trades"
+                  },
+                  "magicKey": {
+                    "type": "string",
+                    "description": "Promotional key that waives credit charges when valid."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Local-leads job accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkSubmissionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/bulk/progress": {
+      "get": {
+        "summary": "Get Lightweight Bulk Job Progress",
+        "description": "Return a compact progress snapshot for frequent polling.",
+        "operationId": "bulk-job-progress",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "query",
+            "required": true,
+            "description": "UUID identifier of the bulk job.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "description": "Signed progress token returned when the job was submitted.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lightweight progress snapshot.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "status": "processing",
+                  "processed_items": 2125,
+                  "total_rows": 5000,
+                  "succeeded_items": 2080,
+                  "failed_items": 45
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/errors": {
+      "get": {
+        "summary": "Get Failed Bulk Job Rows",
+        "description": "Return failed rows and their error details for a bulk job.",
+        "operationId": "bulk-job-errors",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BulkJobId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Rows to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 200
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Zero-based row offset for pagination.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1000000,
+              "default": 0
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter failed rows by status.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated failed rows.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "rows": [
+                    {
+                      "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                      "row_index": 42,
+                      "status": "failed",
+                      "lm_input": {
+                        "email": "invalid-format"
+                      },
+                      "lm_output": null,
+                      "error_message": "Invalid email format: invalid-format",
+                      "http_status_code": 422,
+                      "response_time_ms": 45,
+                      "completed_at": "2026-07-09T14:30:06.000Z"
+                    }
+                  ],
+                  "limit": 100,
+                  "offset": 0
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/events": {
+      "get": {
+        "summary": "Get Bulk Job Events",
+        "description": "Return the append-only event log for a bulk job.",
+        "operationId": "bulk-job-events",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BulkJobId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Events to return, newest first.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2000,
+              "default": 200
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated job events.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "events": [
+                    {
+                      "event_id": "e1f2g3h4-i5j6-7890-k1mn-opqrstuvwxyz",
+                      "job_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                      "event_type": "row.failed",
+                      "source": "queue-consumer",
+                      "level": "error",
+                      "message": "Row 42 failed: Invalid email format",
+                      "stage": "enrichment",
+                      "status": "processing",
+                      "details": {
+                        "row_index": 42,
+                        "error": "Invalid email format",
+                        "http_status_code": 422
+                      },
+                      "created_at": "2026-07-09T14:30:06.000Z"
+                    }
+                  ],
+                  "limit": 50
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/stream": {
+      "get": {
+        "summary": "Stream Bulk Job Progress",
+        "description": "Open a server-sent events stream for real-time bulk job progress.",
+        "operationId": "bulk-job-stream",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BulkJobId"
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server-sent event stream.",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/pause": {
+      "post": {
+        "summary": "Pause a Bulk Job",
+        "description": "Pause a queued or running bulk job.",
+        "operationId": "bulk-job-pause",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BulkJobId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job paused."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/resume": {
+      "post": {
+        "summary": "Resume a Bulk Job",
+        "description": "Resume a paused bulk job.",
+        "operationId": "bulk-job-resume",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BulkJobId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job resumed."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/restart": {
+      "post": {
+        "summary": "Restart a Bulk Job",
+        "description": "Restart a bulk job in full, from failed rows, or from a specified position.",
+        "operationId": "bulk-job-restart",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BulkJobId"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "description": "Which rows to reprocess.",
+                    "enum": [
+                      "full",
+                      "failed_only",
+                      "from_row",
+                      "from_shard"
+                    ],
+                    "default": "full"
+                  },
+                  "startRowIndex": {
+                    "type": "integer",
+                    "description": "Zero-based row to restart from. Required when `mode` is `from_row`.",
+                    "minimum": 0
+                  },
+                  "startShardIndex": {
+                    "type": "integer",
+                    "description": "Zero-based shard to restart from. Required when `mode` is `from_shard`.",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Restart accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "restarted": true,
+                  "newJobId": null,
+                  "mode": "failed_only",
+                  "started": false,
+                  "position": 1
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/bulk/jobs/{jobId}/priority": {
+      "patch": {
+        "summary": "Update Bulk Job Priority",
+        "description": "Change the processing priority of a queued or running bulk job.",
+        "operationId": "bulk-job-priority",
+        "tags": [
+          "Bulk Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/BulkJobId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "priority"
+                ],
+                "properties": {
+                  "priority": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "normal",
+                      "high"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Priority updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "jobId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "priority": 100
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/batch": {
+      "get": {
+        "summary": "List Batches",
+        "description": "List batches across all products for the authenticated organization.",
+        "operationId": "batch-list",
+        "tags": [
+          "Batch"
+        ],
+        "parameters": [
+          {
+            "name": "product",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "client_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated batch list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Submit a Mixed-Product Batch",
+        "description": "Submit a batch containing items for one or more enrichment products.",
+        "operationId": "batch-submit",
+        "tags": [
+          "Batch"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "items"
+                ],
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "description": "Batch items. Each item carries `product` (required for mixed-product batches), `input`, and optional `client_id`, `client_name`, and `metadata`.",
+                    "minItems": 1,
+                    "maxItems": 500,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "product": {
+                          "type": "string",
+                          "description": "Product to run this item against."
+                        },
+                        "input": {
+                          "type": "object",
+                          "description": "Product-specific input fields."
+                        },
+                        "client_id": {
+                          "type": "string"
+                        },
+                        "client_name": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  },
+                  "idempotencyKey": {
+                    "type": "string",
+                    "description": "Submitting the same key twice returns the original batch instead of creating a duplicate."
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Arbitrary metadata stored with the batch."
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "description": "Associate the whole batch with a client record."
+                  },
+                  "client_name": {
+                    "type": "string",
+                    "description": "Client name recorded alongside the batch."
+                  },
+                  "budget_user_id": {
+                    "type": "string",
+                    "description": "Charge the batch against this member's credit budget."
+                  },
+                  "webhook_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "HTTPS URL notified when the batch completes. SSRF-validated — must resolve to a public IP."
+                  },
+                  "priority": {
+                    "type": "string",
+                    "description": "Queue priority for this batch.",
+                    "enum": [
+                      "normal",
+                      "low"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Batch accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "example": {
+                  "batchId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                  "status": "accepted",
+                  "items_count": 2
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/batch/{batchId}": {
+      "get": {
+        "summary": "Get Batch Status",
+        "description": "Return status, progress, cost, and metadata for a mixed-product batch.",
+        "operationId": "batch-status",
+        "tags": [
+          "Batch"
+        ],
+        "parameters": [
+          {
+            "name": "batchId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier of the batch returned when it was submitted.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Batch status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/{product}/batch/{batchId}": {
+      "patch": {
+        "summary": "Update Batch Metadata",
+        "description": "Update batch metadata or its associated client within the mutable window.",
+        "operationId": "batch-update",
+        "tags": [
+          "Batch"
+        ],
+        "parameters": [
+          {
+            "name": "product",
+            "in": "path",
+            "required": true,
+            "description": "Enrichment product slug, e.g. `email-finder`. Hyphens and underscores are both accepted.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "email-finder"
+          },
+          {
+            "name": "batchId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier of the batch returned when it was submitted.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "client_id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated batch."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/batch/campaign/{campaignId}/metrics": {
+      "get": {
+        "summary": "Get Campaign Metrics",
+        "description": "Aggregate usage and success metrics across batches in a campaign.",
+        "operationId": "batch-campaign-metrics",
+        "tags": [
+          "Batch"
+        ],
+        "parameters": [
+          {
+            "name": "campaignId",
+            "in": "path",
+            "required": true,
+            "description": "Campaign identifier used to group related batches.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "c1d2e3f4-a5b6-7890-cdef-123456789012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Campaign metrics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/batch/clients": {
+      "get": {
+        "summary": "List Batch Clients",
+        "description": "List client records for the authenticated organization.",
+        "operationId": "batch-client-list",
+        "tags": [
+          "Batch"
+        ],
+        "responses": {
+          "200": {
+            "description": "Client list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a Batch Client",
+        "description": "Create an organization-scoped client for segmenting downstream batch work.",
+        "operationId": "batch-client-create",
+        "tags": [
+          "Batch"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Unique client identifier (slug). Lowercase, alphanumeric with hyphens.",
+                    "example": "acme-corp"
+                  },
+                  "display_name": {
+                    "type": "string",
+                    "description": "Human-readable display name.",
+                    "example": "Acme Corporation"
+                  },
+                  "contact_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Contact email for notifications."
+                  },
+                  "billing_rate": {
+                    "type": "number",
+                    "description": "Optional billing rate applied to this client."
+                  },
+                  "notes": {
+                    "type": "string",
+                    "description": "Internal notes."
+                  },
+                  "industry": {
+                    "type": "string",
+                    "description": "Industry classification."
+                  },
+                  "website": {
+                    "type": "string",
+                    "description": "Client website."
+                  },
+                  "phone": {
+                    "type": "string",
+                    "description": "Phone number."
+                  },
+                  "address": {
+                    "type": "object",
+                    "description": "Physical address object."
+                  },
+                  "custom_fields": {
+                    "type": "object",
+                    "description": "Arbitrary custom fields stored with the client."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Client created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/batch/clients/{clientId}/metrics": {
+      "get": {
+        "summary": "Get Batch Client Metrics",
+        "description": "Return aggregate batch usage and success metrics for a client.",
+        "operationId": "batch-client-metrics",
+        "tags": [
+          "Batch"
+        ],
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "path",
+            "required": true,
+            "description": "UUID of the client record, returned when the client was created.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "d1e2f3a4-b5c6-7890-def1-234567890123"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Client metrics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/batch/clients/{clientId}/webhooks": {
+      "get": {
+        "summary": "List Batch Client Webhooks",
+        "description": "List delivery webhooks configured for a client.",
+        "operationId": "batch-client-webhook-list",
+        "tags": [
+          "Batch"
+        ],
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "path",
+            "required": true,
+            "description": "UUID of the client record, returned when the client was created.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "d1e2f3a4-b5c6-7890-def1-234567890123"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Client webhook list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a Batch Client Webhook",
+        "description": "Register a webhook for client batch lifecycle events.",
+        "operationId": "batch-client-webhook-create",
+        "tags": [
+          "Batch"
+        ],
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "path",
+            "required": true,
+            "description": "UUID of the client record, returned when the client was created.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "d1e2f3a4-b5c6-7890-def1-234567890123"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Webhook created."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/batch/providers": {
+      "get": {
+        "summary": "List External Batch Providers",
+        "description": "List external enrichment providers registered by the organization.",
+        "operationId": "batch-provider-list",
+        "tags": [
+          "Batch"
+        ],
+        "responses": {
+          "200": {
+            "description": "Provider list with credentials redacted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an External Batch Provider",
+        "description": "Register an HTTPS external enrichment provider.",
+        "operationId": "batch-provider-create",
+        "tags": [
+          "Batch"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "baseUrl",
+                  "authType",
+                  "authCredentialName",
+                  "authCredentialValue"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Display name for the provider.",
+                    "example": "acme-enrichment"
+                  },
+                  "baseUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "HTTPS endpoint to call. Private IP addresses are rejected.",
+                    "example": "https://api.acme.com/enrich"
+                  },
+                  "authType": {
+                    "type": "string",
+                    "description": "How the credential is presented to the provider.",
+                    "enum": [
+                      "api_key",
+                      "bearer",
+                      "header"
+                    ]
+                  },
+                  "authCredentialName": {
+                    "type": "string",
+                    "description": "Header or parameter name carrying the credential.",
+                    "example": "X-API-Key"
+                  },
+                  "authCredentialValue": {
+                    "type": "string",
+                    "description": "Credential value. Redacted in every response."
+                  },
+                  "defaultMethod": {
+                    "type": "string",
+                    "description": "HTTP method used for provider calls.",
+                    "enum": [
+                      "GET",
+                      "POST"
+                    ]
+                  },
+                  "defaultHeaders": {
+                    "type": "object",
+                    "description": "Extra headers sent with every provider call."
+                  },
+                  "rateLimitRpm": {
+                    "type": "integer",
+                    "description": "Requests per minute ceiling for this provider."
+                  },
+                  "responseMapping": {
+                    "type": "object",
+                    "description": "Maps provider response fields onto LeadMagic output columns."
+                  },
+                  "healthCheckUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL polled to determine provider health."
+                  },
+                  "healthCheckExpectedStatus": {
+                    "type": "integer",
+                    "description": "HTTP status treated as healthy.",
+                    "example": 200
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Provider created with credentials redacted."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/batch/preview-cost": {
+      "post": {
+        "summary": "Preview Batch Cost",
+        "description": "Estimate the credit cost and budget impact of a batch enrichment without reserving or consuming credits. FREE dry-run.",
+        "operationId": "preview-cost-mixed",
+        "tags": [
+          "Cost Control"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreviewCostRequest"
+              },
+              "example": {
+                "items": [
+                  {
+                    "product": "email_finder",
+                    "input": {
+                      "profile_url": "https://example.com/in/jane-doe"
+                    }
+                  }
+                ],
+                "budget_user_id": "user_abc123"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cost estimate returned (no credits consumed).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewCostResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/batch/budgets": {
+      "post": {
+        "summary": "Create Credit Budget",
+        "description": "Create a new credit budget to cap spend per scope.",
+        "operationId": "create-budget",
+        "tags": [
+          "Cost Control"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "scope",
+                  "scope_value",
+                  "max_credits"
+                ],
+                "properties": {
+                  "scope": {
+                    "type": "string"
+                  },
+                  "scope_value": {
+                    "type": "string"
+                  },
+                  "max_credits": {
+                    "type": "number"
+                  },
+                  "period": {
+                    "type": "string"
+                  },
+                  "alert_threshold_pct": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": 0,
+                    "maximum": 1,
+                    "exclusiveMaximum": 1
+                  },
+                  "alert_email": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                }
+              },
+              "example": {
+                "scope": "user",
+                "scope_value": "user_abc123",
+                "max_credits": 10000,
+                "period": "monthly",
+                "alert_threshold_pct": 0.8,
+                "alert_email": "ops@example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Budget created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Budget"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimitExceeded"
+          }
+        }
+      },
+      "get": {
+        "summary": "List Credit Budgets",
+        "description": "List all credit budgets for the authenticated account.",
+        "operationId": "list-budgets",
+        "tags": [
+          "Cost Control"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of budgets.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Budget"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/batch/budgets/status": {
+      "get": {
+        "summary": "Get Budget Status",
+        "description": "Consumption status for all budgets.",
+        "operationId": "budget-status",
+        "tags": [
+          "Cost Control"
+        ],
+        "responses": {
+          "200": {
+            "description": "Budget consumption status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BudgetStatus"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/batch/budgets/{id}": {
+      "patch": {
+        "summary": "Update Credit Budget",
+        "description": "Update max_credits, period, alert_threshold_pct, and/or alert_email.",
+        "operationId": "update-budget",
+        "tags": [
+          "Cost Control"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Identifier of the credit budget.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "bg_4a7d2e9c1f60"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "max_credits": {
+                    "type": "number"
+                  },
+                  "period": {
+                    "type": "string"
+                  },
+                  "alert_threshold_pct": {
+                    "type": "number"
+                  },
+                  "alert_email": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated budget.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Budget"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Credit Budget",
+        "description": "Hard-delete a credit budget.",
+        "operationId": "delete-budget",
+        "tags": [
+          "Cost Control"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Identifier of the credit budget.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "bg_4a7d2e9c1f60"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Budget deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/v1/batch/suppression-lists": {
+      "post": {
+        "summary": "Create Suppression List",
+        "description": "Create a new suppression list with initial emails. Emails are SHA-256 hashed server-side.",
+        "operationId": "create-suppression-list",
+        "tags": [
+          "Cost Control"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "list_id",
+                  "emails"
+                ],
+                "properties": {
+                  "list_id": {
+                    "type": "string"
+                  },
+                  "emails": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "example": {
+                "list_id": "bounced-2026-q3",
+                "emails": [
+                  "bounced1@example.com"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Suppression list created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuppressionList"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "get": {
+        "summary": "List Suppression Lists",
+        "description": "List all suppression lists for the authenticated account.",
+        "operationId": "list-suppression-lists",
+        "tags": [
+          "Cost Control"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of suppression lists.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SuppressionList"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/batch/suppression-lists/{listId}": {
+      "get": {
+        "summary": "Get Suppression List",
+        "description": "Get list details and paginated email hashes.",
+        "operationId": "get-suppression-list",
+        "tags": [
+          "Cost Control"
+        ],
+        "parameters": [
+          {
+            "name": "listId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier of the suppression list.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "sl_9f2c1d7e4b8a"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 200,
+              "maximum": 1000
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List details with paginated hashes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuppressionList"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Suppression List",
+        "description": "Delete an entire suppression list.",
+        "operationId": "delete-suppression-list",
+        "tags": [
+          "Cost Control"
+        ],
+        "parameters": [
+          {
+            "name": "listId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier of the suppression list.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "sl_9f2c1d7e4b8a"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/batch/suppression-lists/{listId}/emails": {
+      "post": {
+        "summary": "Add Emails to Suppression List",
+        "description": "Add emails to an existing suppression list. Emails are SHA-256 hashed server-side.",
+        "operationId": "add-suppression-emails",
+        "tags": [
+          "Cost Control"
+        ],
+        "parameters": [
+          {
+            "name": "listId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier of the suppression list.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "sl_9f2c1d7e4b8a"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "emails"
+                ],
+                "properties": {
+                  "emails": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Emails added."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove Emails from Suppression List",
+        "description": "Remove emails from a suppression list.",
+        "operationId": "remove-suppression-emails",
+        "tags": [
+          "Cost Control"
+        ],
+        "parameters": [
+          {
+            "name": "listId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier of the suppression list.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "sl_9f2c1d7e4b8a"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "emails"
+                ],
+                "properties": {
+                  "emails": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Emails removed."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    }
+  }
 }

--- a/leadmagic-openapi-3.1.yaml
+++ b/leadmagic-openapi-3.1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: LeadMagic API
-  version: "1.4.35"
+  version: 1.4.35
   description: |
     # LeadMagic API Documentation
 
@@ -46,7 +46,7 @@ components:
       type: apiKey
       in: header
       name: X-API-Key
-      description: "Your LeadMagic API key. Header name is case-insensitive (X-API-Key, X-API-KEY, x-api-key all work)."
+      description: Your LeadMagic API key. Header name is case-insensitive (X-API-Key, X-API-KEY, x-api-key all work).
   parameters:
     BulkJobId:
       name: jobId
@@ -56,7 +56,9 @@ components:
       schema:
         type: string
         format: uuid
-      example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+      examples:
+        default:
+          value: a1b2c3d4-e5f6-7890-abcd-ef1234567890
   headers:
     RateLimitLimit:
       description: Effective organization request ceiling for the current minute.
@@ -83,10 +85,6 @@ components:
       schema:
         type: integer
   schemas:
-    # ============================================================
-    # RFC 9457 Problem Details Error Response Format
-    # https://www.rfc-editor.org/rfc/rfc9457
-    # ============================================================
     ErrorResponse:
       type: object
       description: RFC 9457 Problem Details error response
@@ -96,15 +94,16 @@ components:
       properties:
         success:
           type: boolean
-          example: false
           description: Always false for error responses
+          examples:
+            - false
         errors:
           type: array
           description: Array of error details (typically one, but can be multiple)
           items:
-            $ref: '#/components/schemas/ErrorDetail'
+            $ref: "#/components/schemas/ErrorDetail"
         meta:
-          $ref: '#/components/schemas/ResponseMeta'
+          $ref: "#/components/schemas/ResponseMeta"
     ErrorDetail:
       type: object
       description: RFC 9457 compliant error detail
@@ -117,43 +116,52 @@ components:
           type: string
           format: uri
           description: RFC 9457 - URI reference identifying the error type
-          example: "https://api.leadmagic.io/errors/validation_error"
+          examples:
+            - https://api.leadmagic.io/errors/validation_error
         title:
           type: string
           description: RFC 9457 - Short human-readable summary
-          example: "Request validation failed. Check your input parameters."
+          examples:
+            - Request validation failed. Check your input parameters.
         status:
           type: integer
           description: RFC 9457 - HTTP status code
-          example: 400
+          examples:
+            - 400
         detail:
           type: string
           description: RFC 9457 - Human-readable explanation specific to this occurrence
-          example: "The email field is required but was not provided."
+          examples:
+            - The email field is required but was not provided.
         instance:
           type: string
           format: uri-reference
           description: RFC 9457 - URI reference for this specific occurrence
-          example: "/v1/people/email-validation#req_abc123"
+          examples:
+            - /v1/people/email-validation#req_abc123
         code:
           type: string
           description: Machine-readable error code for programmatic handling
-          example: "validation_error"
+          examples:
+            - validation_error
         param:
           type: array
           description: Parameters that caused the error
           items:
             type: string
-          example: ["email"]
+          examples:
+            - - email
         action:
           type: string
           description: Suggested action to resolve the error
-          example: "Provide a valid email address in the 'email' field."
+          examples:
+            - Provide a valid email address in the 'email' field.
         docs:
           type: string
           format: uri
           description: Link to relevant documentation
-          example: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+          examples:
+            - https://leadmagic.io/docs/v1/making-api-calls#error-handling
         context:
           type: object
           description: Additional context specific to this error type
@@ -166,432 +174,442 @@ components:
           type: string
           format: uuid
           description: Unique identifier for this request (use for debugging/support)
-          example: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          examples:
+            - ea6e3248-f4d2-437d-bca3-20881b529129
         timestamp:
           type: string
           format: date-time
           description: ISO 8601 timestamp when the response was generated
-          example: "2024-02-01T12:00:00.000Z"
+          examples:
+            - 2024-02-01T12:00:00.000Z
         environment:
           type: string
           description: API environment (production, staging)
-          example: "production"
-    # ============================================================
-    # Specific Error Types
-    # ============================================================
+          examples:
+            - production
     ValidationError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/validation_error"
-            title: "Request validation failed. Check your input parameters."
-            status: 400
-            code: "validation_error"
-            param: ["email"]
-            detail: "Email format is invalid. Expected format: user@domain.com"
-            action: "Provide a valid email address in the 'email' field."
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/validation_error
+              title: Request validation failed. Check your input parameters.
+              status: 400
+              code: validation_error
+              param:
+                - email
+              detail: "Email format is invalid. Expected format: user@domain.com"
+              action: Provide a valid email address in the 'email' field.
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     MissingFieldError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/missing_required_field"
-            title: "Missing required field: email. Add this field to your request."
-            status: 400
-            code: "missing_required_field"
-            param: ["email"]
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/missing_required_field
+              title: "Missing required field: email. Add this field to your request."
+              status: 400
+              code: missing_required_field
+              param:
+                - email
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     InvalidJsonError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/invalid_json"
-            title: "Invalid JSON in request body. Check your JSON syntax."
-            status: 400
-            code: "invalid_json"
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/invalid_json
+              title: Invalid JSON in request body. Check your JSON syntax.
+              status: 400
+              code: invalid_json
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     InvalidParameterError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/invalid_parameter"
-            title: "Invalid parameter: experience_level. Valid options: entry, mid, senior, executive."
-            status: 400
-            code: "invalid_parameter"
-            param: ["experience_level"]
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/invalid_parameter
+              title: "Invalid parameter: experience_level. Valid options: entry, mid, senior, executive."
+              status: 400
+              code: invalid_parameter
+              param:
+                - experience_level
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     MissingAuthenticationError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/missing_authentication"
-            title: "Authentication required. Provide a valid API key in the X-API-Key header (case-insensitive)."
-            status: 401
-            code: "missing_authentication"
-            docs: "https://leadmagic.io/docs/v1/authentication"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/missing_authentication
+              title: Authentication required. Provide a valid API key in the X-API-Key header (case-insensitive).
+              status: 401
+              code: missing_authentication
+              docs: https://leadmagic.io/docs/v1/authentication
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     InvalidApiKeyError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/invalid_api_key"
-            title: "Invalid API key. The key does not exist or is incorrect."
-            status: 401
-            code: "invalid_api_key"
-            docs: "https://leadmagic.io/docs/v1/authentication"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/invalid_api_key
+              title: Invalid API key. The key does not exist or is incorrect.
+              status: 401
+              code: invalid_api_key
+              docs: https://leadmagic.io/docs/v1/authentication
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     InsufficientPermissionsError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/insufficient_permissions"
-            title: "Access denied to this resource. Upgrade your plan or contact support."
-            status: 403
-            code: "insufficient_permissions"
-            docs: "https://leadmagic.io/docs/v1/authentication"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/insufficient_permissions
+              title: Access denied to this resource. Upgrade your plan or contact support.
+              status: 403
+              code: insufficient_permissions
+              docs: https://leadmagic.io/docs/v1/authentication
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     InsufficientCreditsError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/insufficient_credits"
-            title: "Insufficient credits: need 5, have 2.50. Add credits to continue."
-            status: 402
-            code: "insufficient_credits"
-            detail: "This request requires 5 credit(s) but your account only has 2.50 credits remaining."
-            action: "Add credits to your account at https://app.leadmagic.io/settings/billing or contact support@leadmagic.io for enterprise plans."
-            docs: "https://leadmagic.io/docs/v1/credits"
-            context:
-              credits_required: 5
-              credits_available: 2.50
-              credits_needed: 2.50
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/insufficient_credits
+              title: "Insufficient credits: need 5, have 2.50. Add credits to continue."
+              status: 402
+              code: insufficient_credits
+              detail: This request requires 5 credit(s) but your account only has 2.50 credits remaining.
+              action: Add credits to your account at https://app.leadmagic.io/settings/billing or contact support@leadmagic.io for enterprise plans.
+              docs: https://leadmagic.io/docs/v1/credits
+              context:
+                credits_required: 5
+                credits_available: 2.5
+                credits_needed: 2.5
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     ResourceNotFoundError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/resource_not_found"
-            title: "Resource not found."
-            status: 404
-            code: "resource_not_found"
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/resource_not_found
+              title: Resource not found.
+              status: 404
+              code: resource_not_found
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     ProfileNotFoundError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/profile_not_found"
-            title: "Profile not found or not accessible"
-            status: 404
-            code: "profile_not_found"
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/profile_not_found
+              title: Profile not found or not accessible
+              status: 404
+              code: profile_not_found
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     RateLimitExceededError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/rate_limit_exceeded"
-            title: "Rate limit exceeded: 600 requests per 1 minute. Wait and try again."
-            status: 429
-            code: "rate_limit_exceeded"
-            detail: "You have exceeded the maximum allowed request rate. Please wait before making additional requests."
-            action: "Wait 42 seconds before retrying. Consider implementing exponential backoff."
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#rate-limits"
-            context:
-              limit: 600
-              window: "1 minute"
-              remaining: 0
-              reset_at: 1706745642
-              retry_after_seconds: 42
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/rate_limit_exceeded
+              title: "Rate limit exceeded: 600 requests per 1 minute. Wait and try again."
+              status: 429
+              code: rate_limit_exceeded
+              detail: You have exceeded the maximum allowed request rate. Please wait before making additional requests.
+              action: Wait 42 seconds before retrying. Consider implementing exponential backoff.
+              docs: https://leadmagic.io/docs/v1/making-api-calls#rate-limits
+              context:
+                limit: 600
+                window: 1 minute
+                remaining: 0
+                reset_at: 1706745642
+                retry_after_seconds: 42
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     InternalServerError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/INTERNAL_ERROR"
-            title: "Something went wrong on our end. Our team has been notified and is investigating."
-            status: 500
-            code: "INTERNAL_ERROR"
-            detail: "This is a temporary server error. The issue has been automatically reported to our team."
-            action: "Wait 30 seconds and retry your request. If the problem persists, contact support@leadmagic.io"
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/INTERNAL_ERROR
+              title: Something went wrong on our end. Our team has been notified and is investigating.
+              status: 500
+              code: INTERNAL_ERROR
+              detail: This is a temporary server error. The issue has been automatically reported to our team.
+              action: Wait 30 seconds and retry your request. If the problem persists, contact support@leadmagic.io
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     ExternalServiceError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/external_service_error"
-            title: "Error communicating with external service. Please try again."
-            status: 502
-            code: "external_service_error"
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/external_service_error
+              title: Error communicating with external service. Please try again.
+              status: 502
+              code: external_service_error
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     ServiceUnavailableError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/service_unavailable"
-            title: "Service temporarily unavailable. Please try again later."
-            status: 503
-            code: "service_unavailable"
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/service_unavailable
+              title: Service temporarily unavailable. Please try again later.
+              status: 503
+              code: service_unavailable
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     ConflictError:
       allOf:
-        - $ref: '#/components/schemas/ErrorResponse'
-      example:
-        success: false
-        errors:
-          - type: "https://api.leadmagic.io/errors/conflict"
-            title: "Resource conflict detected."
-            status: 409
-            code: "conflict"
-            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
-        meta:
-          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
-          timestamp: "2024-02-01T12:00:00.000Z"
-    # ============================================================
-    # Success Message Types (for endpoint responses)
-    # ============================================================
+        - $ref: "#/components/schemas/ErrorResponse"
+      examples:
+        - success: false
+          errors:
+            - type: https://api.leadmagic.io/errors/conflict
+              title: Resource conflict detected.
+              status: 409
+              code: conflict
+              docs: https://leadmagic.io/docs/v1/making-api-calls#error-handling
+          meta:
+            request_id: ea6e3248-f4d2-437d-bca3-20881b529129
+            timestamp: 2024-02-01T12:00:00.000Z
     EmailValidationMessages:
       type: string
       description: Possible success messages for email validation
       enum:
-        - "Email is valid."
-        - "Email is invalid."
-        - "Unable to determine email validity."
+        - Email is valid.
+        - Email is invalid.
+        - Unable to determine email validity.
     EmailFinderMessages:
       type: string
       description: Possible success messages for email finder
       enum:
-        - "Valid email found."
-        - "No email found for this person at this company."
+        - Valid email found.
+        - No email found for this person at this company.
     MobileFinderMessages:
       type: string
       description: Possible success messages for mobile finder
       enum:
-        - "Mobile number found."
-        - "No mobile number found for this contact."
+        - Mobile number found.
+        - No mobile number found for this contact.
     ProfileSearchMessages:
       type: string
       description: Possible success messages for profile search
       enum:
-        - "Profile found."
-        - "Profile not found or not accessible."
+        - Profile found.
+        - Profile not found or not accessible.
     CompanySearchMessages:
       type: string
       description: Possible success messages for company search
       enum:
-        - "Company found."
-        - "Company not found"
+        - Company found.
+        - Company not found
     RoleFinderMessages:
       type: string
       description: Possible success messages for role finder
       enum:
-        - "Role found."
-        - "No matching role found at this company."
+        - Role found.
+        - No matching role found at this company.
     EmployeeFinderMessages:
       type: string
       description: Possible success messages for employee finder
       enum:
-        - "Employees found."
-        - "No employees found for this company."
+        - Employees found.
+        - No employees found for this company.
     JobChangeDetectorMessages:
       type: string
       description: Possible success messages for job change detector
       enum:
-        - "No job change detected. Still employed at expected company."
-        - "Job change detected. Person has moved to a new company."
-        - "Never worked at the expected company."
+        - No job change detected. Still employed at expected company.
+        - Job change detected. Person has moved to a new company.
+        - Never worked at the expected company.
     CompetitorsSearchMessages:
       type: string
       description: Possible success messages for competitors search
       enum:
-        - "Competitors found."
-        - "No competitors found for this company."
+        - Competitors found.
+        - No competitors found for this company.
     CompanyFundingMessages:
       type: string
       description: Possible success messages for company funding
       enum:
-        - "Funding data found."
-        - "Company funding data not found"
+        - Funding data found.
+        - Company funding data not found
     TechnographicsMessages:
       type: string
       description: Possible success messages for technographics
       enum:
-        - "Technologies found."
-        - "No technology data found for this domain."
+        - Technologies found.
+        - No technology data found for this domain.
     AdsSearchMessages:
       type: string
       description: Possible success messages for ads search endpoints
       enum:
-        - "Ads found."
-        - "No ads found for this company."
+        - Ads found.
+        - No ads found for this company.
     PersonalEmailFinderMessages:
       type: string
       description: Possible success messages for personal email finder
       enum:
-        - "Personal email found."
-        - "No personal email found for this contact."
+        - Personal email found.
+        - No personal email found for this contact.
     B2BProfileToEmailMessages:
       type: string
       description: Possible success messages for B2B profile to email
       enum:
-        - "Email found for this profile."
-        - "No email found for this profile."
+        - Email found for this profile.
+        - No email found for this profile.
     EmailToB2BProfileMessages:
       type: string
       description: Possible success messages for email to B2B profile
       enum:
-        - "Profile URL found."
-        - "No profile found for this email."
-    # ============================================================
-    # Response Headers Documentation
-    # ============================================================
+        - Profile URL found.
+        - No profile found for this email.
     RateLimitHeaders:
       type: object
       description: Rate limit headers returned with every response
       properties:
         RateLimit-Limit:
           type: integer
-          description: "IETF Standard - Maximum requests per minute"
-          example: 600
+          description: IETF Standard - Maximum requests per minute
+          examples:
+            - 600
         RateLimit-Remaining:
           type: integer
-          description: "IETF Standard - Requests remaining this minute"
-          example: 587
+          description: IETF Standard - Requests remaining this minute
+          examples:
+            - 587
         RateLimit-Reset:
           type: integer
-          description: "IETF Standard - Seconds until limit resets"
-          example: 42
+          description: IETF Standard - Seconds until limit resets
+          examples:
+            - 42
         X-RateLimit-Limit:
           type: integer
-          description: "Legacy - Maximum requests per minute"
-          example: 600
+          description: Legacy - Maximum requests per minute
+          examples:
+            - 600
         X-RateLimit-Remaining:
           type: integer
-          description: "Legacy - Requests remaining this minute"
-          example: 587
+          description: Legacy - Requests remaining this minute
+          examples:
+            - 587
         X-RateLimit-Reset:
           type: integer
-          description: "Legacy - Unix timestamp when limit resets"
-          example: 1706745600
+          description: Legacy - Unix timestamp when limit resets
+          examples:
+            - 1706745600
         X-RateLimit-Limit-Daily:
           type: integer
-          description: "Daily request limit"
-          example: 500000
+          description: Daily request limit
+          examples:
+            - 500000
         X-RateLimit-Remaining-Daily:
           type: integer
-          description: "Requests remaining today"
-          example: 485000
+          description: Requests remaining today
+          examples:
+            - 485000
         X-RateLimit-Reset-Daily:
           type: integer
-          description: "Unix timestamp when daily limit resets"
-          example: 1706832000
+          description: Unix timestamp when daily limit resets
+          examples:
+            - 1706832000
         X-Credits-Remaining:
           type: number
-          description: "Wallet credits remaining after this request"
-          example: 15432.50
+          description: Wallet credits remaining after this request
+          examples:
+            - 15432.5
         X-Credits-Cost:
           type: number
-          description: "Credits reserved for this route before finalization (may exceed credits actually charged)"
-          example: 1
+          description: Credits reserved for this route before finalization (may exceed credits actually charged)
+          examples:
+            - 1
         X-Credits-Consumed:
           type: number
-          description: "Credits actually charged after finalization (matches body credits_consumed)"
-          example: 1
+          description: Credits actually charged after finalization (matches body credits_consumed)
+          examples:
+            - 1
         X-Credits-Total:
           type: number
-          description: "Wallet credit balance at authorization"
-          example: 15433.50
+          description: Wallet credit balance at authorization
+          examples:
+            - 15433.5
         X-Credits-Max-Cost:
           type: number
-          description: "Maximum credits that could be charged for this request"
-          example: 1
+          description: Maximum credits that could be charged for this request
+          examples:
+            - 1
         X-Request-Id:
           type: string
-          description: "Correlation id for support troubleshooting"
+          description: Correlation id for support troubleshooting
         X-RateLimit-Soft-Mode:
           type: string
-          description: "Whether soft mode is enabled (warn but don't block)"
-          example: "true"
+          description: Whether soft mode is enabled (warn but don't block)
+          examples:
+            - "true"
         X-RateLimit-Daily-Usage-Percent:
           type: integer
-          description: "Daily usage as percentage"
-          example: 15
+          description: Daily usage as percentage
+          examples:
+            - 15
         X-RateLimit-RPM-Usage-Percent:
           type: integer
-          description: "Current minute usage as percentage"
-          example: 5
+          description: Current minute usage as percentage
+          examples:
+            - 5
         Retry-After:
           type: integer
-          description: "Seconds to wait before retrying (only on 429 responses)"
-          example: 42
-    # ============================================================
-    # Bulk Jobs Schemas
-    # ============================================================
-    # Bulk Jobs Schemas (real /bulk/* surface)
-    # ============================================================
+          description: Seconds to wait before retrying (only on 429 responses)
+          examples:
+            - 42
     BulkSubmissionRequest:
       type: object
       description: Request body for submitting a bulk enrichment job via POST /bulk/submit. Provide exactly one of rows, csv, fileUrl, or scrape.
@@ -601,7 +619,8 @@ components:
         product:
           type: string
           description: The enrichment product to run on each row (e.g. email_finder, email_validation, mobile_finder, profile_search, company_search).
-          example: email_finder
+          examples:
+            - email_finder
         rows:
           type: array
           description: JSON array of row objects for /bulk/json (or /bulk/submit auto-detect). Each row is an object whose keys match the input fields the selected product expects.
@@ -704,7 +723,8 @@ components:
           properties:
             model:
               type: string
-              example: "llama-3.1-8b-instruct"
+              examples:
+                - llama-3.1-8b-instruct
             prompt:
               type: string
             jsonSchema: {}
@@ -728,7 +748,8 @@ components:
           type: string
           format: uuid
           description: UUID identifier for the bulk job.
-          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          examples:
+            - a1b2c3d4-e5f6-7890-abcd-ef1234567890
         product:
           type: string
           description: The enrichment product this job is running.
@@ -741,7 +762,8 @@ components:
         status:
           type: string
           description: Always 'uploaded' for a freshly submitted job.
-          example: uploaded
+          examples:
+            - uploaded
         queue:
           type: object
           properties:
@@ -856,7 +878,7 @@ components:
         jobs:
           type: array
           items:
-            $ref: '#/components/schemas/JobSummary'
+            $ref: "#/components/schemas/JobSummary"
         limit:
           type: integer
         offset:
@@ -936,11 +958,13 @@ components:
           type: integer
           nullable: true
         output_transform:
-          type: [object, "null"]
+          type:
+            - object
+            - "null"
           description: Optional output transform applied to result rows.
     JobDetailResponse:
       allOf:
-        - $ref: '#/components/schemas/JobSnapshot'
+        - $ref: "#/components/schemas/JobSnapshot"
         - type: object
           properties:
             links:
@@ -1031,14 +1055,11 @@ components:
         rows:
           type: array
           items:
-            $ref: '#/components/schemas/JobRow'
+            $ref: "#/components/schemas/JobRow"
         limit:
           type: integer
         offset:
           type: integer
-    # ============================================================
-    # Cost Control Schemas ( /v1/batch/* )
-    # ============================================================
     PreviewCostRequest:
       type: object
       required:
@@ -1150,9 +1171,6 @@ components:
         created_at:
           type: string
           format: date-time
-  # ============================================================
-  # Reusable Response Definitions
-  # ============================================================
   responses:
     BadRequest:
       description: |
@@ -1166,7 +1184,7 @@ components:
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: "#/components/schemas/ValidationError"
     Unauthorized:
       description: |
         Unauthorized - Authentication failed.
@@ -1179,8 +1197,8 @@ components:
         application/problem+json:
           schema:
             oneOf:
-              - $ref: '#/components/schemas/MissingAuthenticationError'
-              - $ref: '#/components/schemas/InvalidApiKeyError'
+              - $ref: "#/components/schemas/MissingAuthenticationError"
+              - $ref: "#/components/schemas/InvalidApiKeyError"
     Forbidden:
       description: |
         Forbidden - You don't have permission to access this resource.
@@ -1191,7 +1209,7 @@ components:
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/InsufficientPermissionsError'
+            $ref: "#/components/schemas/InsufficientPermissionsError"
     PaymentRequired:
       description: |
         Payment Required - Insufficient credits for this request.
@@ -1200,7 +1218,7 @@ components:
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/InsufficientCreditsError'
+            $ref: "#/components/schemas/InsufficientCreditsError"
     NotFound:
       description: |
         Not Found - The requested resource could not be found.
@@ -1213,15 +1231,15 @@ components:
         application/problem+json:
           schema:
             oneOf:
-              - $ref: '#/components/schemas/ResourceNotFoundError'
-              - $ref: '#/components/schemas/ProfileNotFoundError'
+              - $ref: "#/components/schemas/ResourceNotFoundError"
+              - $ref: "#/components/schemas/ProfileNotFoundError"
     Conflict:
       description: |
         Conflict - The request conflicts with the current state of the resource.
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ConflictError'
+            $ref: "#/components/schemas/ConflictError"
     RateLimitExceeded:
       description: |
         Too Many Requests - Rate limit exceeded.
@@ -1253,7 +1271,7 @@ components:
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/RateLimitExceededError'
+            $ref: "#/components/schemas/RateLimitExceededError"
     InternalServerError:
       description: |
         Internal Server Error - Something went wrong on our end.
@@ -1262,7 +1280,7 @@ components:
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/InternalServerError'
+            $ref: "#/components/schemas/InternalServerError"
     BadGateway:
       description: |
         Bad Gateway - Error communicating with an upstream service.
@@ -1271,7 +1289,7 @@ components:
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ExternalServiceError'
+            $ref: "#/components/schemas/ExternalServiceError"
     ServiceUnavailable:
       description: |
         Service Unavailable - The service is temporarily unavailable.
@@ -1280,7 +1298,7 @@ components:
       content:
         application/problem+json:
           schema:
-            $ref: '#/components/schemas/ServiceUnavailableError'
+            $ref: "#/components/schemas/ServiceUnavailableError"
 security:
   - ApiKeyAuth: []
 tags:
@@ -1303,9 +1321,6 @@ tags:
   - name: Cost Control
     description: Preview costs, manage credit budgets, and maintain suppression lists to control spend
 paths:
-  # ============================================================
-  # Account Endpoints
-  # ============================================================
   /v1/credits:
     get:
       summary: Check Credits
@@ -1323,9 +1338,10 @@ paths:
                 properties:
                   credits:
                     type: number
-                    example: 2200
+                    examples:
+                      - 2200
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/analytics/dashboard:
     get:
       summary: Dashboard Overview
@@ -1346,19 +1362,23 @@ paths:
                     properties:
                       id:
                         type: string
-                        example: "user_abc123"
+                        examples:
+                          - user_abc123
                       email:
                         type: string
-                        example: "developer@leadmagic.io"
+                        examples:
+                          - developer@leadmagic.io
                   credits:
                     type: object
                     properties:
                       current:
                         type: number
-                        example: 15432.50
+                        examples:
+                          - 15432.5
                       formatted:
                         type: string
-                        example: "$154.33"
+                        examples:
+                          - $154.33
                   rate_limit:
                     type: object
                     properties:
@@ -1367,43 +1387,54 @@ paths:
                         properties:
                           limit:
                             type: integer
-                            example: 600
+                            examples:
+                              - 600
                           used:
                             type: integer
-                            example: 45
+                            examples:
+                              - 45
                           remaining:
                             type: integer
-                            example: 555
+                            examples:
+                              - 555
                           utilization:
                             type: number
-                            example: 15.0
+                            examples:
+                              - 15
                       daily:
                         type: object
                         properties:
                           limit:
                             type: integer
-                            example: 500000
+                            examples:
+                              - 500000
                           used:
                             type: integer
-                            example: 12500
+                            examples:
+                              - 12500
                           remaining:
                             type: integer
-                            example: 487500
+                            examples:
+                              - 487500
                           utilization:
                             type: number
-                            example: 2.5
+                            examples:
+                              - 2.5
                   concurrency:
                     type: object
                     properties:
                       current:
                         type: integer
-                        example: 0
+                        examples:
+                          - 0
                       peak:
                         type: integer
-                        example: 23
+                        examples:
+                          - 23
                       active_reservations:
                         type: integer
-                        example: 0
+                        examples:
+                          - 0
                   stats:
                     type: object
                     properties:
@@ -1412,57 +1443,72 @@ paths:
                         properties:
                           requests:
                             type: integer
-                            example: 1250
+                            examples:
+                              - 1250
                           credits:
                             type: number
-                            example: 875.50
+                            examples:
+                              - 875.5
                           chargeable_requests:
                             type: integer
-                            example: 1100
+                            examples:
+                              - 1100
                           chargeable_rate:
                             type: number
-                            example: 88.0
+                            examples:
+                              - 88
                           unique_products:
                             type: integer
-                            example: 5
+                            examples:
+                              - 5
                       this_week:
                         type: object
                         properties:
                           requests:
                             type: integer
-                            example: 8500
+                            examples:
+                              - 8500
                           credits:
                             type: number
-                            example: 5200.25
+                            examples:
+                              - 5200.25
                           chargeable_requests:
                             type: integer
-                            example: 7200
+                            examples:
+                              - 7200
                           chargeable_rate:
                             type: number
-                            example: 84.7
+                            examples:
+                              - 84.7
                           unique_products:
                             type: integer
-                            example: 8
+                            examples:
+                              - 8
                       this_month:
                         type: object
                         properties:
                           requests:
                             type: integer
-                            example: 45000
+                            examples:
+                              - 45000
                           credits:
                             type: number
-                            example: 28500.00
+                            examples:
+                              - 28500
                           chargeable_requests:
                             type: integer
-                            example: 38000
+                            examples:
+                              - 38000
                           chargeable_rate:
                             type: number
-                            example: 84.4
+                            examples:
+                              - 84.4
                           unique_products:
                             type: integer
-                            example: 12
+                            examples:
+                              - 12
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/analytics/usage:
     get:
       summary: Usage Summary
@@ -1493,35 +1539,44 @@ paths:
                       start:
                         type: string
                         format: date
-                        example: "2024-01-02"
+                        examples:
+                          - 2024-01-02
                       end:
                         type: string
                         format: date
-                        example: "2024-02-01"
+                        examples:
+                          - 2024-02-01
                       days:
                         type: integer
-                        example: 30
+                        examples:
+                          - 30
                   summary:
                     type: object
                     properties:
                       total_requests:
                         type: integer
-                        example: 45000
+                        examples:
+                          - 45000
                       chargeable_requests:
                         type: integer
-                        example: 38000
+                        examples:
+                          - 38000
                       total_credits:
                         type: number
-                        example: 28500.00
+                        examples:
+                          - 28500
                       avg_credits_per_request:
                         type: number
-                        example: 0.63
+                        examples:
+                          - 0.63
                       chargeable_rate:
                         type: number
-                        example: 84.4
+                        examples:
+                          - 84.4
                       unique_products:
                         type: integer
-                        example: 12
+                        examples:
+                          - 12
                   daily:
                     type: array
                     items:
@@ -1530,23 +1585,28 @@ paths:
                         date:
                           type: string
                           format: date
-                          example: "2024-02-01"
+                          examples:
+                            - 2024-02-01
                         total_requests:
                           type: integer
-                          example: 1250
+                          examples:
+                            - 1250
                         chargeable_requests:
                           type: integer
-                          example: 1100
+                          examples:
+                            - 1100
                         total_credits:
                           type: number
-                          example: 875.50
+                          examples:
+                            - 875.5
                         unique_products_used:
                           type: integer
-                          example: 5
+                          examples:
+                            - 5
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/analytics/products:
     get:
       summary: Products Breakdown
@@ -1589,28 +1649,34 @@ paths:
                       properties:
                         total_requests:
                           type: integer
-                          example: 20000
+                          examples:
+                            - 20000
                         total_credits:
                           type: number
-                          example: 1000.00
+                          examples:
+                            - 1000
                         successful_requests:
                           type: integer
-                          example: 19500
+                          examples:
+                            - 19500
                         failed_requests:
                           type: integer
-                          example: 500
+                          examples:
+                            - 500
                         success_rate:
                           type: number
-                          example: 97.5
+                          examples:
+                            - 97.5
                         avg_credits_per_request:
                           type: number
-                          example: 0.25
+                          examples:
+                            - 0.25
                   daily:
                     type: array
                     items:
                       type: object
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/analytics/credits:
     get:
       summary: Credit History
@@ -1651,19 +1717,24 @@ paths:
                     properties:
                       total_credits:
                         type: number
-                        example: 28500.00
+                        examples:
+                          - 28500
                       total_requests:
                         type: integer
-                        example: 45000
+                        examples:
+                          - 45000
                       chargeable_requests:
                         type: integer
-                        example: 38000
+                        examples:
+                          - 38000
                       avg_credits_per_request:
                         type: number
-                        example: 0.63
+                        examples:
+                          - 0.63
                       chargeable_rate:
                         type: number
-                        example: 84.4
+                        examples:
+                          - 84.4
                   daily:
                     type: array
                     items:
@@ -1679,7 +1750,7 @@ paths:
                         chargeable_requests:
                           type: integer
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/analytics/summary:
     get:
       summary: All-Time Summary
@@ -1710,37 +1781,46 @@ paths:
                 properties:
                   total_api_requests:
                     type: integer
-                    example: 1250000
+                    examples:
+                      - 1250000
                   total_credits_consumed:
                     type: number
-                    example: 425000.50
+                    examples:
+                      - 425000.5
                   unique_products_used:
                     type: integer
-                    example: 15
+                    examples:
+                      - 15
                   successful_requests:
                     type: integer
-                    example: 1150000
+                    examples:
+                      - 1150000
                   failed_requests:
                     type: integer
-                    example: 100000
+                    examples:
+                      - 100000
                   success_rate:
                     type: number
-                    example: 92.0
+                    examples:
+                      - 92
                   avg_response_time_ms:
                     type: number
-                    example: 245
+                    examples:
+                      - 245
                   first_request:
                     type: string
                     format: date-time
                     nullable: true
-                    example: "2023-06-15T10:30:00.000Z"
+                    examples:
+                      - 2023-06-15T10:30:00.000Z
                   last_request:
                     type: string
                     format: date-time
                     nullable: true
-                    example: "2024-02-01T14:22:00.000Z"
+                    examples:
+                      - 2024-02-01T14:22:00.000Z
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/analytics/daily:
     get:
       summary: Daily Metrics
@@ -1801,7 +1881,7 @@ paths:
                         error_rate:
                           type: number
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/analytics/day/{date}:
     get:
       summary: Day Breakdown
@@ -1828,19 +1908,23 @@ paths:
                   date:
                     type: string
                     format: date
-                    example: "2024-02-01"
+                    examples:
+                      - 2024-02-01
                   summary:
                     type: object
                     properties:
                       total_credits:
                         type: number
-                        example: 875.50
+                        examples:
+                          - 875.5
                       total_requests:
                         type: integer
-                        example: 1250
+                        examples:
+                          - 1250
                       products_count:
                         type: integer
-                        example: 8
+                        examples:
+                          - 8
                   products:
                     type: array
                     items:
@@ -1848,29 +1932,32 @@ paths:
                       properties:
                         product_id:
                           type: string
-                          example: "email_validation"
+                          examples:
+                            - email_validation
                         requests:
                           type: integer
-                          example: 500
+                          examples:
+                            - 500
                         credits:
                           type: number
-                          example: 25.00
+                          examples:
+                            - 25
                         credits_percentage:
                           type: number
-                          example: 2.86
+                          examples:
+                            - 2.86
                         avg_credits_per_request:
                           type: number
-                          example: 0.25
+                          examples:
+                            - 0.25
                         max_credits:
                           type: number
-                          example: 0.25
+                          examples:
+                            - 0.25
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
-  # ============================================================
-  # Email Endpoints
-  # ============================================================
+          $ref: "#/components/responses/Unauthorized"
   /v1/people/email-validation:
     post:
       summary: Email Validation
@@ -1889,7 +1976,8 @@ paths:
                   type: string
                   format: email
                   description: Email address to validate
-                  example: alex.rivera@example.com
+                  examples:
+                    - alex.rivera@example.com
               required:
                 - email
       responses:
@@ -1902,110 +1990,138 @@ paths:
                 properties:
                   email:
                     type: string
-                    example: alex.rivera@example.com
+                    examples:
+                      - alex.rivera@example.com
                   email_status:
                     type: string
-                    example: valid
+                    examples:
+                      - valid
                   credits_consumed:
                     type: number
-                    example: 0.25
+                    examples:
+                      - 0.25
                   message:
                     type: string
-                    example: Email is valid.
+                    examples:
+                      - Email is valid.
                   mx_record:
                     type: string
-                    example: mx1.example.com
+                    examples:
+                      - mx1.example.com
                   mx_provider:
                     type: string
-                    example: Example Mail
+                    examples:
+                      - Example Mail
                   mx_gateway:
                     type: string
                     nullable: true
                     description: Security gateway vendor name
-                    example: null
+                    examples:
+                      - null
                   mx_gateway_type:
                     type: string
                     nullable: true
                     description: Security gateway type
-                    example: null
+                    examples:
+                      - null
                   mx_security_gateway:
                     type: boolean
-                    example: false
+                    examples:
+                      - false
                   company_name:
                     type: string
-                    example: Leadmagic
+                    examples:
+                      - Leadmagic
                   company_industry:
                     type: string
-                    example: Internet
+                    examples:
+                      - Internet
                   company_size:
                     type: string
-                    example: 11-50
+                    examples:
+                      - 11-50
                   company_founded:
                     type: integer
-                    example: 2022
+                    examples:
+                      - 2022
                   company_type:
                     type: string
-                    example: Private
+                    examples:
+                      - Private
                   company_location:
                     type: object
                     properties:
                       name:
                         type: string
-                        example: Boston, Massachusetts, United States
+                        examples:
+                          - Boston, Massachusetts, United States
                       locality:
                         type: string
-                        example: Boston
+                        examples:
+                          - Boston
                       region:
                         type: string
-                        example: Massachusetts
+                        examples:
+                          - Massachusetts
                       metro:
                         type: string
-                        example: Boston
+                        examples:
+                          - Boston
                       country:
                         type: string
-                        example: United States
+                        examples:
+                          - United States
                       continent:
                         type: string
-                        example: North America
+                        examples:
+                          - North America
                       street_address:
                         type: string
-                        example: 1 Seaport Lane
+                        examples:
+                          - 1 Seaport Lane
                       address_line_2:
                         type: string
                         nullable: true
-                        example: null
+                        examples:
+                          - null
                       postal_code:
                         type: string
-                        example: "02210"
+                        examples:
+                          - "02210"
                       geo:
                         type: string
                         nullable: true
-                        example: null
+                        examples:
+                          - null
                   company_linkedin_url:
                     type: string
                     description: Legacy field name for the B2B company profile.
-                    example: example.com/company/acme
+                    examples:
+                      - example.com/company/acme
                   company_linkedin_id:
                     type: string
-                    example: "75153174"
+                    examples:
+                      - "75153174"
                   company_facebook_url:
                     type: string
                     nullable: true
-                    example: null
+                    examples:
+                      - null
                   company_twitter_url:
                     type: string
                     nullable: true
-                    example: null
+                    examples:
+                      - null
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/email-finder:
     post:
       summary: Email Finder
@@ -2052,38 +2168,49 @@ paths:
                 properties:
                   email:
                     type: string
-                    example: alex.rivera@example.com
+                    examples:
+                      - alex.rivera@example.com
                   status:
                     type: string
-                    example: valid
+                    examples:
+                      - valid
                   credits_consumed:
                     type: integer
-                    example: 1
+                    examples:
+                      - 1
                   message:
                     type: string
-                    example: Valid email found.
+                    examples:
+                      - Valid email found.
                   first_name:
                     type: string
-                    example: Alex
+                    examples:
+                      - Alex
                   last_name:
                     type: string
-                    example: Rivera
+                    examples:
+                      - Rivera
                   domain:
                     type: string
-                    example: leadmagic.io
+                    examples:
+                      - leadmagic.io
                   mx_record:
                     type: string
-                    example: alt3.mx1.example.com
+                    examples:
+                      - alt3.mx1.example.com
                   mx_provider:
                     type: string
-                    example: Example Mail
+                    examples:
+                      - Example Mail
                   mx_security_gateway:
                     type: boolean
-                    example: false
+                    examples:
+                      - false
                   has_mx:
                     type: boolean
                     description: Whether the domain has MX records
-                    example: true
+                    examples:
+                      - true
                   mx_records_full:
                     type: array
                     description: Complete list of MX records with priorities
@@ -2092,84 +2219,105 @@ paths:
                       properties:
                         priority:
                           type: integer
-                          example: 10
+                          examples:
+                            - 10
                         exchange:
                           type: string
-                          example: mx1.example.com
+                          examples:
+                            - mx1.example.com
                   company_name:
                     type: string
-                    example: Leadmagic
+                    examples:
+                      - Leadmagic
                   company_industry:
                     type: string
-                    example: ""
+                    examples:
+                      - ""
                   company_size:
                     type: string
-                    example: 11-50
+                    examples:
+                      - 11-50
                   company_founded:
                     type: integer
-                    example: 2022
+                    examples:
+                      - 2022
                   company_location:
                     type: object
                     properties:
                       name:
                         type: string
-                        example: boston, massachusetts, united states
+                        examples:
+                          - boston, massachusetts, united states
                       locality:
                         type: string
-                        example: boston
+                        examples:
+                          - boston
                       region:
                         type: string
-                        example: massachusetts
+                        examples:
+                          - massachusetts
                       metro:
                         type: string
-                        example: boston, massachusetts
+                        examples:
+                          - boston, massachusetts
                       country:
                         type: string
-                        example: united states
+                        examples:
+                          - united states
                       continent:
                         type: string
-                        example: north america
+                        examples:
+                          - north america
                       street_address:
                         type: string
-                        example: 1 seaport lane
+                        examples:
+                          - 1 seaport lane
                       address_line_2:
                         type: string
                       postal_code:
                         type: string
-                        example: "02210"
+                        examples:
+                          - "02210"
                       geo:
                         type: string
-                        example: 42.35,-71.06
+                        examples:
+                          - 42.35,-71.06
                   company_profile_url:
                     type: string
-                    example: leadmagichq
+                    examples:
+                      - leadmagichq
                   company_profile_id:
                     type: string
-                    example: "75153174"
+                    examples:
+                      - "75153174"
                   company_facebook_url:
                     type: string
-                    example: ""
+                    examples:
+                      - ""
                   company_twitter_url:
                     type: string
-                    example: ""
+                    examples:
+                      - ""
                   company_type:
                     type: string
-                    example: private
+                    examples:
+                      - private
                   employment_verified:
                     type: boolean
                     nullable: true
                     description: Whether the employment at the domain was verified
-                    example: true
+                    examples:
+                      - true
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/personal-email-finder:
     post:
       summary: Personal Email Finder
@@ -2200,37 +2348,42 @@ paths:
                 properties:
                   profile_url:
                     type: string
-                    example: alex-rivera
+                    examples:
+                      - alex-rivera
                   credits_consumed:
                     type: integer
-                    example: 2
+                    examples:
+                      - 2
                   message:
                     type: string
-                    example: Personal Email Found.
+                    examples:
+                      - Personal Email Found.
                   name:
                     type: string
-                    example: Alex Rivera
+                    examples:
+                      - Alex Rivera
                   first_personal_email:
                     type: string
-                    example: alex-riveral@gmail.com
+                    examples:
+                      - alex-riveral@gmail.com
                   personal_emails:
                     type: array
                     items:
                       type: string
-                    example:
-                      - alex-riveral@gmail.com
+                    examples:
+                      - - alex-riveral@gmail.com
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/b2b-profile-email:
     post:
       summary: B2B Person Profile to Email
@@ -2261,31 +2414,32 @@ paths:
                 properties:
                   profile_url:
                     type: string
-                    example: alex-rivera
+                    examples:
+                      - alex-rivera
                   credits_consumed:
                     type: integer
-                    example: 5
+                    examples:
+                      - 5
                   message:
                     type: string
-                    example: Email Found.
+                    examples:
+                      - Email Found.
                   email:
                     type: string
-                    example: alex.rivera@example.com
+                    examples:
+                      - alex.rivera@example.com
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
-  # ============================================================
-  # Contact Endpoints
-  # ============================================================
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/profile-search:
     post:
       summary: B2B Person Profile
@@ -2303,7 +2457,8 @@ paths:
                 profile_url:
                   type: string
                   description: B2B person profile URL or slug
-                  example: alex-rivera
+                  examples:
+                    - alex-rivera
               required:
                 - profile_url
       responses:
@@ -2316,77 +2471,95 @@ paths:
                 properties:
                   profile_url:
                     type: string
-                    example: alex-rivera
+                    examples:
+                      - alex-rivera
                   credits_consumed:
                     type: integer
-                    example: 1
+                    examples:
+                      - 1
                   first_name:
                     type: string
                     nullable: true
-                    example: Alex
+                    examples:
+                      - Alex
                   last_name:
                     type: string
                     nullable: true
-                    example: Rivera
+                    examples:
+                      - Rivera
                   full_name:
                     type: string
                     nullable: true
-                    example: Alex Rivera
+                    examples:
+                      - Alex Rivera
                   professional_title:
                     type: string
                     nullable: true
-                    example: Growth & AI Expert | Founder LeadMagic
+                    examples:
+                      - Growth & AI Expert | Founder LeadMagic
                   bio:
                     type: string
                     nullable: true
-                    example: SaaS Founder
+                    examples:
+                      - SaaS Founder
                   company_name:
                     type: string
                     nullable: true
-                    example: LeadMagic
+                    examples:
+                      - LeadMagic
                   company_industry:
                     type: string
                     nullable: true
-                    example: Internet
+                    examples:
+                      - Internet
                   company_website:
                     type: string
                     nullable: true
-                    example: leadmagic.io
+                    examples:
+                      - leadmagic.io
                   total_tenure_months:
                     type: string
                     nullable: true
-                    example: "205"
+                    examples:
+                      - "205"
                   total_tenure_days:
                     type: string
                     nullable: true
-                    example: "6240"
+                    examples:
+                      - "6240"
                   total_tenure_years:
                     type: string
                     nullable: true
-                    example: "17"
+                    examples:
+                      - "17"
                   followers_range:
                     type: string
                     nullable: true
-                    example: 45K-50K
                     description: Follower count range for privacy (e.g. "45K-50K", "1M+")
+                    examples:
+                      - 45K-50K
                   personal_website:
                     type: object
                     nullable: true
                     properties:
                       name:
                         type: string
-                        example: https://leadmagic.io
+                        examples:
+                          - https://leadmagic.io
                       link:
                         type: string
-                        example: https://leadmagic.io
+                        examples:
+                          - https://leadmagic.io
                   country:
                     type: string
                     nullable: true
-                    example: United States
+                    examples:
+                      - United States
                   location:
                     type: string
                     nullable: true
-                    example: Greater Boston
+                    examples:
+                      - Greater Boston
                   work_experience:
                     type: array
                     nullable: true
@@ -2395,23 +2568,28 @@ paths:
                       properties:
                         position_title:
                           type: string
-                          example: Founder
+                          examples:
+                            - Founder
                         company_name:
                           type: string
-                          example: LeadMagic
+                          examples:
+                            - LeadMagic
                         employment_period:
                           type: string
-                          example: Sep 2022 - Present · 3 yrs 2 mos
+                          examples:
+                            - Sep 2022 - Present · 3 yrs 2 mos
                         company_website:
                           type: string
                           nullable: true
-                          example: leadmagic.io
                           description: Only included when domain is available
+                          examples:
+                            - leadmagic.io
                         company_logo_url:
                           type: string
                           nullable: true
-                          example: https://logo.leadmagic.io/leadmagic.io
                           description: Only included when domain is available
+                          examples:
+                            - https://logo.leadmagic.io/leadmagic.io
                   education:
                     type: array
                     nullable: true
@@ -2420,13 +2598,16 @@ paths:
                       properties:
                         institution_name:
                           type: string
-                          example: University of Maine
+                          examples:
+                            - University of Maine
                         degree:
                           type: string
-                          example: University of Maine
+                          examples:
+                            - University of Maine
                         attendance_period:
                           type: string
-                          example: ""
+                          examples:
+                            - ""
                   certifications:
                     type: array
                     nullable: true
@@ -2435,13 +2616,16 @@ paths:
                       properties:
                         certification_name:
                           type: string
-                          example: Revenue Architect
+                          examples:
+                            - Revenue Architect
                         issuing_organization:
                           type: string
-                          example: Winning by Design
+                          examples:
+                            - Winning by Design
                         issue_date:
                           type: string
-                          example: Issued Nov 2020
+                          examples:
+                            - Issued Nov 2020
                   honors:
                     type: array
                     nullable: true
@@ -2450,22 +2634,24 @@ paths:
                       properties:
                         title:
                           type: string
-                          example: Hortonworks - MVP NorthEast - Region - 2016
+                          examples:
+                            - Hortonworks - MVP NorthEast - Region - 2016
                         description:
                           type: string
-                          example: Issued by Hortonworks · Jan 2016
+                          examples:
+                            - Issued by Hortonworks · Jan 2016
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/b2b-profile:
     post:
       summary: Email Address to B2B Person Profile
@@ -2498,25 +2684,28 @@ paths:
                 properties:
                   profile_url:
                     type: string
-                    example: jouellette
+                    examples:
+                      - jouellette
                   message:
                     type: string
-                    example: Profile URL found
+                    examples:
+                      - Profile URL found
                   credits_consumed:
                     type: integer
-                    example: 10
+                    examples:
+                      - 10
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/mobile-finder:
     post:
       summary: Mobile Finder
@@ -2554,34 +2743,39 @@ paths:
                   profile_url:
                     type: string
                     nullable: true
-                    example: alex-rivera
+                    examples:
+                      - alex-rivera
                   email:
                     type: string
                     nullable: true
                     description: Email address used in lookup (if provided)
-                    example: alex.rivera@example.com
+                    examples:
+                      - alex.rivera@example.com
                   mobile_number:
                     type: string
                     nullable: true
                     description: Mobile phone number if found
-                    example: "12077523358"
+                    examples:
+                      - "12077523358"
                   credits_consumed:
                     type: number
-                    example: 5
+                    examples:
+                      - 5
                   message:
                     type: string
                     description: Status message about the result
-                    example: Mobile number found.
+                    examples:
+                      - Mobile number found.
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/job-change-detector:
     post:
       summary: Job Change Detector
@@ -2599,15 +2793,18 @@ paths:
                 profile_url:
                   type: string
                   description: Professional profile URL or identifier
-                  example: alex-rivera
+                  examples:
+                    - alex-rivera
                 company_name:
                   type: string
                   description: Expected company name (either company_name or company_domain is required)
-                  example: Example Robotics
+                  examples:
+                    - Example Robotics
                 company_domain:
                   type: string
                   description: Expected company domain (either company_name or company_domain is required)
-                  example: smartlead.ai
+                  examples:
+                    - smartlead.ai
               required:
                 - profile_url
       responses:
@@ -2620,68 +2817,90 @@ paths:
                 properties:
                   job_change_detected:
                     type: boolean
-                    example: false
+                    examples:
+                      - false
                   status:
                     type: string
-                    enum: [NO_CHANGE, JOB_CHANGE_DETECTED, NEVER_WORKED_THERE]
-                    example: NEVER_WORKED_THERE
+                    enum:
+                      - NO_CHANGE
+                      - JOB_CHANGE_DETECTED
+                      - NEVER_WORKED_THERE
+                    examples:
+                      - NEVER_WORKED_THERE
                   summary:
                     type: string
-                    example: Alex Rivera has never worked at Example Robotics according to their comprehensive employment history. They are currently working at Leadmagic as Founder for 3 years. Their complete employment history shows experience at Leadmagic, Atlas Guild, Northstar Labs, and 7 other companies. The expected company does not appear in any current or past positions, confirming they have never been employed there.
+                    examples:
+                      - Alex Rivera has never worked at Example Robotics according to their comprehensive employment history. They are currently working at Leadmagic as Founder for 3 years. Their complete employment history shows experience at Leadmagic, Atlas Guild, Northstar Labs, and 7 other companies. The expected company does not appear in any current or past positions, confirming they have never been employed there.
                   employee_name:
                     type: string
-                    example: Alex Rivera
+                    examples:
+                      - Alex Rivera
                   expected_company:
                     type: string
-                    example: Example Robotics
+                    examples:
+                      - Example Robotics
                   current_company:
                     type: string
-                    example: Leadmagic
+                    examples:
+                      - Leadmagic
                   current_position:
                     type: object
                     properties:
                       title:
                         type: string
-                        example: Founder
+                        examples:
+                          - Founder
                       company:
                         type: string
-                        example: Leadmagic
+                        examples:
+                          - Leadmagic
                       start_date:
                         type: string
-                        example: Sep 2022
+                        examples:
+                          - Sep 2022
                       days_at_job:
                         type: integer
-                        example: 1111
+                        examples:
+                          - 1111
                       tenure_formatted:
                         type: string
-                        example: 3 years
+                        examples:
+                          - 3 years
                       is_current_position:
                         type: boolean
-                        example: true
+                        examples:
+                          - true
                   tenure_stats:
                     type: object
                     properties:
                       average_tenure_months:
                         type: integer
-                        example: 26
+                        examples:
+                          - 26
                       average_tenure_formatted:
                         type: string
-                        example: 2 years 2 months
+                        examples:
+                          - 2 years 2 months
                       total_positions:
                         type: integer
-                        example: 10
+                        examples:
+                          - 10
                       longest_tenure_months:
                         type: integer
-                        example: 73
+                        examples:
+                          - 73
                       longest_tenure_formatted:
                         type: string
-                        example: 6 years 1 month
+                        examples:
+                          - 6 years 1 month
                       shortest_tenure_months:
                         type: integer
-                        example: 1
+                        examples:
+                          - 1
                       shortest_tenure_formatted:
                         type: string
-                        example: 1 month
+                        examples:
+                          - 1 month
                   work_history:
                     type: array
                     items:
@@ -2689,61 +2908,65 @@ paths:
                       properties:
                         title:
                           type: string
-                          example: Founder
+                          examples:
+                            - Founder
                         company:
                           type: string
-                          example: LeadMagic
+                          examples:
+                            - LeadMagic
                         duration:
                           type: string
-                          example: Sep 2022 - Present
+                          examples:
+                            - Sep 2022 - Present
                         is_present:
                           type: boolean
-                          example: true
-                    example:
-                      - title: Founder
-                        company: Leadmagic
-                        duration: Sep 2022 - Present
-                        is_present: true
-                      - title: Executive Member
-                        company: Atlas Guild
-                        duration: Aug 2019 - Present
-                        is_present: true
-                      - title: Advisor
-                        company: Northstar Labs
-                        duration: Feb 2023 - Jan 2024
-                        is_present: false
-                      - title: Advisor
-                        company: Sales Community
-                        duration: May 2020 - Dec 2023
-                        is_present: false
-                      - title: Advisor
-                        company: Astronomer
-                        duration: Jul 2020 - Sep 2023
-                        is_present: false
+                          examples:
+                            - true
+                    examples:
+                      - - title: Founder
+                          company: Leadmagic
+                          duration: Sep 2022 - Present
+                          is_present: true
+                        - title: Executive Member
+                          company: Atlas Guild
+                          duration: Aug 2019 - Present
+                          is_present: true
+                        - title: Advisor
+                          company: Northstar Labs
+                          duration: Feb 2023 - Jan 2024
+                          is_present: false
+                        - title: Advisor
+                          company: Sales Community
+                          duration: May 2020 - Dec 2023
+                          is_present: false
+                        - title: Advisor
+                          company: Astronomer
+                          duration: Jul 2020 - Sep 2023
+                          is_present: false
                   profile_found:
                     type: boolean
-                    example: true
+                    examples:
+                      - true
                   profile_url:
                     type: string
-                    example: alex-rivera
+                    examples:
+                      - alex-rivera
                   credits_consumed:
                     type: integer
-                    example: 2
+                    examples:
+                      - 2
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
-  # ============================================================
-  # Company Data Endpoints
-  # ============================================================
+          $ref: "#/components/responses/InternalServerError"
   /v1/companies/company-search:
     post:
       summary: Company Search
@@ -2781,17 +3004,21 @@ paths:
                   message:
                     type: string
                     description: Status message
-                    example: Company found
+                    examples:
+                      - Company found
                   credits_consumed:
                     type: number
                     description: Number of credits consumed for this request
-                    example: 1
+                    examples:
+                      - 1
                   companyName:
                     type: string
-                    example: LeadMagic
+                    examples:
+                      - LeadMagic
                   companyId:
                     type: integer
-                    example: 75153174
+                    examples:
+                      - 75153174
                   locations:
                     type: array
                     items:
@@ -2799,226 +3026,274 @@ paths:
                       properties:
                         country:
                           type: string
-                          example: US
+                          examples:
+                            - US
                         city:
                           type: string
-                          example: Boston
+                          examples:
+                            - Boston
                         geographicArea:
                           type: string
-                          example: Massachusetts
+                          examples:
+                            - Massachusetts
                         postalCode:
                           type: string
-                          example: "02210"
+                          examples:
+                            - "02210"
                         line1:
                           type: string
-                          example: 1 Seaport Ln
+                          examples:
+                            - 1 Seaport Ln
                         line2:
                           type: string
                           nullable: true
-                          example: null
+                          examples:
+                            - null
                         description:
                           type: string
-                          example: Headquarters
+                          examples:
+                            - Headquarters
                         headquarter:
                           type: boolean
-                          example: true
+                          examples:
+                            - true
                         localizedName:
                           type: string
-                          example: Boston
+                          examples:
+                            - Boston
                         latitude:
                           type: number
-                          example: 42.36041
+                          examples:
+                            - 42.36041
                         longitude:
                           type: number
-                          example: -71.05798
+                          examples:
+                            - -71.05798
                   employeeCount:
                     type: integer
-                    example: 9
+                    examples:
+                      - 9
                   specialities:
                     type: array
                     items:
                       type: string
-                    example:
-                      - Sales
-                      - Marketing
-                      - ABM
-                      - RevOps
+                    examples:
+                      - - Sales
+                        - Marketing
+                        - ABM
+                        - RevOps
                   employeeCountRange:
                     type: object
                     properties:
                       start:
                         type: integer
-                        example: 11
+                        examples:
+                          - 11
                       end:
                         type: integer
-                        example: 50
+                        examples:
+                          - 50
                   tagline:
                     type: string
-                    example: Example Robotics provides enterprise software solutions for B2B companies. Their platform helps teams streamline operations and drive growth.
+                    examples:
+                      - Example Robotics provides enterprise software solutions for B2B companies. Their platform helps teams streamline operations and drive growth.
                   followerCount:
                     type: integer
-                    example: 4663
+                    examples:
+                      - 4663
                   industry:
                     type: string
-                    example: Internet
+                    examples:
+                      - Internet
                   description:
                     type: string
-                    example: LeadMagic tells you exactly what businesses are on your website and helps you enrich your contact and company data.
+                    examples:
+                      - LeadMagic tells you exactly what businesses are on your website and helps you enrich your contact and company data.
                   websiteUrl:
                     type: string
-                    example: https://leadmagic.io
+                    examples:
+                      - https://leadmagic.io
                   headquarter:
                     type: object
                     properties:
                       country:
                         type: string
-                        example: US
+                        examples:
+                          - US
                       city:
                         type: string
-                        example: Boston
+                        examples:
+                          - Boston
                       geographicArea:
                         type: string
-                        example: Massachusetts
+                        examples:
+                          - Massachusetts
                       postalCode:
                         type: string
-                        example: "02210"
+                        examples:
+                          - "02210"
                       line1:
                         type: string
-                        example: 1 Seaport Ln
+                        examples:
+                          - 1 Seaport Ln
                       line2:
                         type: string
                         nullable: true
-                        example: null
+                        examples:
+                          - null
                       description:
                         type: string
-                        example: Headquarters
+                        examples:
+                          - Headquarters
                   foundedOn:
                     type: object
                     properties:
                       month:
                         type: integer
                         nullable: true
-                        example: null
+                        examples:
+                          - null
                       year:
                         type: integer
-                        example: 2022
+                        examples:
+                          - 2022
                       day:
                         type: integer
                         nullable: true
-                        example: null
+                        examples:
+                          - null
                   universalName:
                     type: string
-                    example: leadmagichq
+                    examples:
+                      - leadmagichq
                   hashtag:
                     type: string
-                    example: "#abm"
+                    examples:
+                      - "#abm"
                   url:
                     type: string
-                    example: leadmagichq
+                    examples:
+                      - leadmagichq
                   logo_url:
                     type: string
                     nullable: true
                     description: Company logo URL from logo.leadmagic.io (generated from company domain)
-                    example: "https://logo.leadmagic.io/leadmagic.io"
+                    examples:
+                      - https://logo.leadmagic.io/leadmagic.io
                   founded_year:
                     type: string
                     nullable: true
                     description: Year the company was founded
-                    example: "2009"
+                    examples:
+                      - "2009"
                   ownership_status:
                     type: string
                     nullable: true
                     description: Ownership type (Public, Private, or Acquired)
-                    example: "Private"
+                    examples:
+                      - Private
                   revenue:
                     type: number
                     nullable: true
                     description: Estimated annual revenue
-                    example: 5100000000
+                    examples:
+                      - 5100000000
                   revenue_formatted:
                     type: string
                     nullable: true
                     description: Human-readable revenue format
-                    example: "5.1B"
+                    examples:
+                      - 5.1B
                   employee_range:
                     type: string
                     nullable: true
                     description: Employee count range
-                    example: "5,000 - 10,000"
+                    examples:
+                      - 5,000 - 10,000
                   total_funding:
                     type: string
                     nullable: true
                     description: Total funding raised
-                    example: "9.8B"
+                    examples:
+                      - 9.8B
                   funding_rounds:
                     type: integer
                     nullable: true
                     description: Number of funding rounds completed
-                    example: 5
+                    examples:
+                      - 5
                   last_funding_round:
                     type: string
                     nullable: true
                     description: Type of most recent funding round
-                    example: "Equity"
+                    examples:
+                      - Equity
                   last_funding_amount:
                     type: number
                     nullable: true
                     description: Amount raised in most recent funding round
-                    example: 694159778
+                    examples:
+                      - 694159778
                   last_funding_date:
                     type: string
                     nullable: true
                     description: Date of most recent funding round
-                    example: "Apr 2024"
+                    examples:
+                      - Apr 2024
                   competitors:
                     type: array
                     nullable: true
                     description: List of competitor company names
                     items:
                       type: string
-                    example:
-                      - "Rapyd"
-                      - "Square"
-                      - "PayPal"
-                      - "Clover"
-                      - "Payment Depot"
+                    examples:
+                      - - Rapyd
+                        - Square
+                        - PayPal
+                        - Clover
+                        - Payment Depot
                   acquisitions_count:
                     type: integer
                     nullable: true
                     description: Number of acquisitions made by the company
-                    example: 3
+                    examples:
+                      - 3
                   twitter_url:
                     type: string
                     nullable: true
                     description: Twitter/X profile URL
-                    example: "https://twitter.com/leadmagichq"
+                    examples:
+                      - https://twitter.com/leadmagichq
                   b2b_profile_url:
                     type: string
                     nullable: true
                     description: B2B company profile URL
-                    example: "leadmagichq"
+                    examples:
+                      - leadmagichq
                   facebook_url:
                     type: string
                     nullable: true
                     description: Facebook page URL
-                    example: ""
+                    examples:
+                      - ""
                   stock_ticker:
                     type: string
                     nullable: true
                     description: Stock ticker symbol (if publicly traded)
-                    example: "STRP"
+                    examples:
+                      - STRP
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/companies/company-funding:
     post:
       summary: Company Funding
@@ -3054,74 +3329,94 @@ paths:
                     properties:
                       companyName:
                         type: string
-                        example: LeadMagic Inc
+                        examples:
+                          - LeadMagic Inc
                       description:
                         type: string
-                        example: Example Robotics provides enterprise software solutions for B2B companies.
+                        examples:
+                          - Example Robotics provides enterprise software solutions for B2B companies.
                       shortName:
                         type: string
-                        example: LeadMagic
+                        examples:
+                          - LeadMagic
                       founded:
                         type: string
-                        example: "2015"
+                        examples:
+                          - "2015"
                       headquarters:
                         type: object
                         properties:
                           city:
                             type: string
-                            example: Palo Alto
+                            examples:
+                              - Palo Alto
                           state:
                             type: string
-                            example: California
+                            examples:
+                              - California
                           country:
                             type: string
-                            example: USA
+                            examples:
+                              - USA
                           fullAddress:
                             type: string
-                            example: Palo Alto, California, USA
+                            examples:
+                              - Palo Alto, California, USA
                       primaryDomain:
                         type: string
-                        example: leadmagic.io
+                        examples:
+                          - leadmagic.io
                       phone:
                         type: string
-                        example: 1-650-276-3068
+                        examples:
+                          - 1-650-276-3068
                       status:
                         type: string
-                        example: NEW
+                        examples:
+                          - NEW
                       followers:
                         type: integer
-                        example: 2422
+                        examples:
+                          - 2422
                       ownership:
                         type: string
-                        example: Private
+                        examples:
+                          - Private
                   financialInfo:
                     type: object
                     properties:
                       revenue:
                         type: integer
-                        example: 178000000
+                        examples:
+                          - 178000000
                       formattedRevenue:
                         type: string
-                        example: 178M
+                        examples:
+                          - 178M
                       totalFunding:
                         type: integer
-                        example: 584000000
+                        examples:
+                          - 584000000
                       formattedFunding:
                         type: string
-                        example: 584M
+                        examples:
+                          - 584M
                       lastFundingRound:
                         type: object
                         properties:
                           round:
                             type: string
-                            example: Series E
+                            examples:
+                              - Series E
                           date:
                             type: string
                             format: date-time
-                            example: "2021-05-01T00:00:00.000Z"
+                            examples:
+                              - 2021-05-01T00:00:00.000Z
                           amount:
                             type: integer
-                            example: 250000000
+                            examples:
+                              - 250000000
                   fundingHistory:
                     type: array
                     items:
@@ -3129,68 +3424,74 @@ paths:
                       properties:
                         round:
                           type: string
-                          example: Series E
+                          examples:
+                            - Series E
                         date:
                           type: string
                           format: date-time
-                          example: "2021-05-01T00:00:00.000Z"
+                          examples:
+                            - 2021-05-01T00:00:00.000Z
                         amount:
                           type: string
-                          example: $250,000,000
+                          examples:
+                            - $250,000,000
                         investors:
                           type: array
                           items:
                             type: string
-                          example:
+                          examples:
+                            - - Franklin Templeton
+                              - Coatue
+                              - Sequoia
+                              - Thrive Capital
+                              - Tiger Global
+                    examples:
+                      - - round: Series E
+                          date: 2021-05-01T00:00:00.000Z
+                          amount: $250,000,000
+                          investors:
                             - Franklin Templeton
                             - Coatue
                             - Sequoia
                             - Thrive Capital
                             - Tiger Global
-                    example:
-                      - round: Series E
-                        date: "2021-05-01T00:00:00.000Z"
-                        amount: $250,000,000
-                        investors:
-                          - Franklin Templeton
-                          - Coatue
-                          - Sequoia
-                          - Thrive Capital
-                          - Tiger Global
-                      - round: Series D
-                        date: "2020-08-01T00:00:00.000Z"
-                        amount: $200,000,000
-                        investors:
-                          - Coatue
-                          - Index Ventures
-                          - Thrive Capital
-                          - Battery Ventures
-                          - NextWorld Capital
-                          - Norwest Venture Partners
-                          - Sequoia Capital
-                          - Wing Venture Capital
-                      - round: Series C
-                        date: "2019-12-01T00:00:00.000Z"
-                        amount: $65,000,000
-                        investors:
-                          - Sequoia Capital
-                          - Battery Ventures
-                          - Norwest Venture Partners
-                          - Wing Venture Capital
-                          - NextWorld Capital
-                          - Cisco Investments
+                        - round: Series D
+                          date: 2020-08-01T00:00:00.000Z
+                          amount: $200,000,000
+                          investors:
+                            - Coatue
+                            - Index Ventures
+                            - Thrive Capital
+                            - Battery Ventures
+                            - NextWorld Capital
+                            - Norwest Venture Partners
+                            - Sequoia Capital
+                            - Wing Venture Capital
+                        - round: Series C
+                          date: 2019-12-01T00:00:00.000Z
+                          amount: $65,000,000
+                          investors:
+                            - Sequoia Capital
+                            - Battery Ventures
+                            - Norwest Venture Partners
+                            - Wing Venture Capital
+                            - NextWorld Capital
+                            - Cisco Investments
                   companySize:
                     type: object
                     properties:
                       employees:
                         type: integer
-                        example: 1100
+                        examples:
+                          - 1100
                       employeeRange:
                         type: string
-                        example: 1,000 - 5,000
+                        examples:
+                          - 1,000 - 5,000
                       employeeGrowth:
                         type: string
-                        example: N/A
+                        examples:
+                          - N/A
                   leadership:
                     type: object
                     properties:
@@ -3199,19 +3500,24 @@ paths:
                         properties:
                           firstName:
                             type: string
-                            example: Amit
+                            examples:
+                              - Amit
                           lastName:
                             type: string
-                            example: Bendov
+                            examples:
+                              - Bendov
                           designation:
                             type: string
-                            example: Co-Founder & CEO
+                            examples:
+                              - Co-Founder & CEO
                           b2b_profile:
                             type: string
-                            example: amitbendov
+                            examples:
+                              - amitbendov
                           twitter:
                             type: string
-                            example: https://twitter.com/banditmove
+                            examples:
+                              - https://twitter.com/banditmove
                   industryAndSectors:
                     type: object
                     properties:
@@ -3219,18 +3525,19 @@ paths:
                         type: array
                         items:
                           type: string
-                        example:
-                          - Sales Enablement Software
-                          - Business Intelligence (BI)
+                        examples:
+                          - - Sales Enablement Software
+                            - Business Intelligence (BI)
                       industries:
                         type: array
                         items:
                           type: string
-                        example:
-                          - Software, Internet & Computer Services
+                        examples:
+                          - - Software, Internet & Computer Services
                       technologyStack:
                         type: string
-                        example: N/A
+                        examples:
+                          - N/A
                   topCompetitors:
                     type: array
                     items:
@@ -3238,78 +3545,89 @@ paths:
                       properties:
                         name:
                           type: string
-                          example: Chorus
+                          examples:
+                            - Chorus
                         revenue:
                           type: string
-                          example: $21
+                          examples:
+                            - $21
                         employees:
                           type: string
-                          example: "200"
+                          examples:
+                            - "200"
                         totalFunding:
                           type: string
-                          example: $1,003
+                          examples:
+                            - $1,003
                         headquarters:
                           type: object
                           properties:
                             city:
                               type: string
-                              example: San Francisco
+                              examples:
+                                - San Francisco
                             state:
                               type: string
-                              example: US-CA
+                              examples:
+                                - US-CA
                             country:
                               type: string
-                              example: USA
+                              examples:
+                                - USA
                             fullAddress:
                               type: string
-                              example: San Francisco, US-CA, USA
+                              examples:
+                                - San Francisco, US-CA, USA
                         founded:
                           type: string
                           format: date-time
-                          example: "2015-01-01T00:00:00.000Z"
+                          examples:
+                            - 2015-01-01T00:00:00.000Z
                         ownership:
                           type: string
-                          example: Private
+                          examples:
+                            - Private
                         website:
                           type: string
-                          example: https://www.chorus.ai
-                    example:
-                      - name: BoostUp
-                        revenue: $6
-                        employees: "85"
-                        totalFunding: $425
-                        headquarters:
-                          city: Santa Clara
-                          state: US-CA
-                          country: USA
-                          fullAddress: Santa Clara, US-CA, USA
-                        founded: "2018-01-01T00:00:00.000Z"
-                        ownership: Private
-                        website: https://www.boostup.ai
-                      - name: ExecVision
-                        revenue: $43
-                        employees: "31"
-                        totalFunding: $81
-                        headquarters:
-                          city: Arlington
-                          state: US-VA
-                          country: USA
-                          fullAddress: Arlington, US-VA, USA
-                        founded: "2015-01-01T00:00:00.000Z"
-                        ownership: Private
-                        website: https://www.execvision.io
-                      - name: Seismic
-                        revenue: $375
-                        employees: 1,000
-                        totalFunding: $940
-                        headquarters:
-                          city: San Diego
-                          state: US-CA
-                          country: USA
-                          fullAddress: San Diego, US-CA, USA
-                        founded: "2010-01-01T00:00:00.000Z"
-                        ownership: Private
-                        website: https://seismic.com
+                          examples:
+                            - https://www.chorus.ai
+                    examples:
+                      - - name: BoostUp
+                          revenue: $6
+                          employees: "85"
+                          totalFunding: $425
+                          headquarters:
+                            city: Santa Clara
+                            state: US-CA
+                            country: USA
+                            fullAddress: Santa Clara, US-CA, USA
+                          founded: 2018-01-01T00:00:00.000Z
+                          ownership: Private
+                          website: https://www.boostup.ai
+                        - name: ExecVision
+                          revenue: $43
+                          employees: "31"
+                          totalFunding: $81
+                          headquarters:
+                            city: Arlington
+                            state: US-VA
+                            country: USA
+                            fullAddress: Arlington, US-VA, USA
+                          founded: 2015-01-01T00:00:00.000Z
+                          ownership: Private
+                          website: https://www.execvision.io
+                        - name: Seismic
+                          revenue: $375
+                          employees: 1,000
+                          totalFunding: $940
+                          headquarters:
+                            city: San Diego
+                            state: US-CA
+                            country: USA
+                            fullAddress: San Diego, US-CA, USA
+                          founded: 2010-01-01T00:00:00.000Z
+                          ownership: Private
+                          website: https://seismic.com
                   acquisitions:
                     type: array
                     items:
@@ -3317,26 +3635,30 @@ paths:
                       properties:
                         companyName:
                           type: string
-                          example: Vayo
+                          examples:
+                            - Vayo
                         acquisitionDate:
                           type: string
                           format: date-time
-                          example: "2020-09-01T00:00:00.000Z"
+                          examples:
+                            - 2020-09-01T00:00:00.000Z
                         description:
                           type: string
-                          example: Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business
+                          examples:
+                            - Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business
                         source:
                           type: string
-                          example: https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo
-                    example:
-                      - companyName: Vayo
-                        acquisitionDate: "2020-09-01T00:00:00.000Z"
-                        description: Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business
-                        source: https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo
-                      - companyName: ONDiGO
-                        acquisitionDate: "2018-04-01T00:00:00.000Z"
-                        description: ONDiGO is a CRM platform that offers customer retention and management services to professionals and micro-businesses.
-                        source: https://www.prnewswire.com/news-releases/leadmagic-acquires-ondigo-to-extend-its-conversation-intelligence-platform-300630168.html
+                          examples:
+                            - https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo
+                    examples:
+                      - - companyName: Vayo
+                          acquisitionDate: 2020-09-01T00:00:00.000Z
+                          description: Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business
+                          source: https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo
+                        - companyName: ONDiGO
+                          acquisitionDate: 2018-04-01T00:00:00.000Z
+                          description: ONDiGO is a CRM platform that offers customer retention and management services to professionals and micro-businesses.
+                          source: https://www.prnewswire.com/news-releases/leadmagic-acquires-ondigo-to-extend-its-conversation-intelligence-platform-300630168.html
                   socialMedia:
                     type: array
                     items:
@@ -3344,17 +3666,19 @@ paths:
                       properties:
                         platform:
                           type: string
-                          example: twitter
+                          examples:
+                            - twitter
                         url:
                           type: string
-                          example: https://twitter.com/leadmagic
-                    example:
-                      - platform: twitter
-                        url: https://twitter.com/leadmagic
-                      - platform: facebook
-                        url: https://www.facebook.com/To.LeadMagicHQ
-                      - platform: b2b_profile
-                        url: leadmagichq
+                          examples:
+                            - https://twitter.com/leadmagic
+                    examples:
+                      - - platform: twitter
+                          url: https://twitter.com/leadmagic
+                        - platform: facebook
+                          url: https://www.facebook.com/To.LeadMagicHQ
+                        - platform: b2b_profile
+                          url: leadmagichq
                   news:
                     type: array
                     items:
@@ -3362,24 +3686,27 @@ paths:
                       properties:
                         title:
                           type: string
-                          example: "Example Robotics: Example Robotics Launches New Enterprise Platform"
+                          examples:
+                            - "Example Robotics: Example Robotics Launches New Enterprise Platform"
                         source:
                           type: string
-                          example: Martech Cube
+                          examples:
+                            - Martech Cube
                         date:
                           type: string
                           format: date-time
-                          example: "2024-08-07T08:40:00.000Z"
-                    example:
-                      - title: "Example Robotics: Example Robotics Launches New Enterprise Platform"
-                        source: TechCrunch
-                        date: "2024-08-07T08:40:00.000Z"
-                      - title: "Example Robotics: Example Robotics Partners with Example CRM"
-                        source: Business Wire
-                        date: "2024-06-26T22:15:00.000Z"
-                      - title: "Example Robotics Named Best SaaS Solution in 2024 Industry Awards"
-                        source: Forbes
-                        date: "2024-06-26T00:00:00.000Z"
+                          examples:
+                            - 2024-08-07T08:40:00.000Z
+                    examples:
+                      - - title: "Example Robotics: Example Robotics Launches New Enterprise Platform"
+                          source: TechCrunch
+                          date: 2024-08-07T08:40:00.000Z
+                        - title: "Example Robotics: Example Robotics Partners with Example CRM"
+                          source: Business Wire
+                          date: 2024-06-26T22:15:00.000Z
+                        - title: Example Robotics Named Best SaaS Solution in 2024 Industry Awards
+                          source: Forbes
+                          date: 2024-06-26T00:00:00.000Z
                   pressReleases:
                     type: array
                     items:
@@ -3387,24 +3714,27 @@ paths:
                       properties:
                         title:
                           type: string
-                          example: "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
+                          examples:
+                            - "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
                         source:
                           type: string
-                          example: PR Newswire
+                          examples:
+                            - PR Newswire
                         date:
                           type: string
                           format: date-time
-                          example: "2024-10-17T22:21:00.000Z"
-                    example:
-                      - title: "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
-                        source: PR Newswire
-                        date: "2024-10-17T22:21:00.000Z"
-                      - title: "Press Release: Example Robotics Named a Winner in The Cloud Awards"
-                        source: PR Newswire
-                        date: "2024-10-09T18:28:00.000Z"
-                      - title: "Press Release: Example Robotics Recognized as Industry Leader by Example Research"
-                        source: Business Wire
-                        date: "2024-09-04T18:50:00.000Z"
+                          examples:
+                            - 2024-10-17T22:21:00.000Z
+                    examples:
+                      - - title: "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
+                          source: PR Newswire
+                          date: 2024-10-17T22:21:00.000Z
+                        - title: "Press Release: Example Robotics Named a Winner in The Cloud Awards"
+                          source: PR Newswire
+                          date: 2024-10-09T18:28:00.000Z
+                        - title: "Press Release: Example Robotics Recognized as Industry Leader by Example Research"
+                          source: Business Wire
+                          date: 2024-09-04T18:50:00.000Z
                   keyHighlights:
                     type: array
                     items:
@@ -3412,49 +3742,56 @@ paths:
                       properties:
                         type:
                           type: string
-                          example: partnership
+                          examples:
+                            - partnership
                         text:
                           type: string
-                          example: Example Robotics Announces Strategic Partnership with Example Robotics
+                          examples:
+                            - Example Robotics Announces Strategic Partnership with Example Robotics
                         date:
                           type: string
                           format: date-time
-                          example: "2024-10-17T22:21:00.000Z"
+                          examples:
+                            - 2024-10-17T22:21:00.000Z
                         src:
                           type: string
-                          example: https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html
+                          examples:
+                            - https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html
                         source:
                           type: string
-                          example: PR Newswire
-                    example:
-                      - type: partnership
-                        text: Example Robotics Announces Strategic Partnership with Example Robotics
-                        date: "2024-10-17T22:21:00.000Z"
-                        src: https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html
-                        source: PR Newswire
-                      - type: award
-                        text: Example Robotics Named a Winner in The Cloud Awards
-                        date: "2024-10-09T18:28:00.000Z"
-                        src: https://www.prnewswire.com/news-releases/acme-corp-cloud-awards-302271452.html
-                        source: PR Newswire
+                          examples:
+                            - PR Newswire
+                    examples:
+                      - - type: partnership
+                          text: Example Robotics Announces Strategic Partnership with Example Robotics
+                          date: 2024-10-17T22:21:00.000Z
+                          src: https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html
+                          source: PR Newswire
+                        - type: award
+                          text: Example Robotics Named a Winner in The Cloud Awards
+                          date: 2024-10-09T18:28:00.000Z
+                          src: https://www.prnewswire.com/news-releases/acme-corp-cloud-awards-302271452.html
+                          source: PR Newswire
                   summarySection:
                     type: string
-                    example: Example Robotics provides enterprise software solutions for B2B companies. Example Robotics was founded in 2018. Example Robotics's headquarters is located in San Francisco, California, USA.
+                    examples:
+                      - Example Robotics provides enterprise software solutions for B2B companies. Example Robotics was founded in 2018. Example Robotics's headquarters is located in San Francisco, California, USA.
                   credits_consumed:
                     type: integer
-                    example: 4
+                    examples:
+                      - 4
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/companies/competitors-search:
     post:
       summary: Competitors Search
@@ -3472,15 +3809,18 @@ paths:
                 company_domain:
                   type: string
                   description: Company website domain
-                  example: leadmagic.io
+                  examples:
+                    - leadmagic.io
                 company_url:
                   type: string
                   description: Company profile URL or identifier (optional)
-                  example: leadmagichq
+                  examples:
+                    - leadmagichq
                 company_name:
                   type: string
                   description: Company name
-                  example: LeadMagic
+                  examples:
+                    - LeadMagic
       responses:
         "200":
           description: Successful response with competitors details
@@ -3496,25 +3836,32 @@ paths:
                       properties:
                         name:
                           type: string
-                          example: LeadMagic
+                          examples:
+                            - LeadMagic
                         shortDescription:
                           type: string
-                          example: "LeadMagic is a company that develops a conversation intelligence platform for B2B sales teams. "
+                          examples:
+                            - "LeadMagic is a company that develops a conversation intelligence platform for B2B sales teams. "
                         founded_year:
                           type: string
-                          example: "2015"
+                          examples:
+                            - "2015"
                         companyType:
                           type: string
-                          example: private
+                          examples:
+                            - private
                         hq:
                           type: string
-                          example: San Francisco, US
+                          examples:
+                            - San Francisco, US
                         employeesCount:
                           type: integer
-                          example: 1504
+                          examples:
+                            - 1504
                         valuation:
                           type: integer
-                          example: 7250000000
+                          examples:
+                            - 7250000000
                         tags:
                           type: array
                           items:
@@ -3522,55 +3869,67 @@ paths:
                             properties:
                               name:
                                 type: string
-                                example: Technology
+                                examples:
+                                  - Technology
                               slug:
                                 type: string
-                                example: technology
+                                examples:
+                                  - technology
                               primary:
                                 type: boolean
-                                example: true
+                                examples:
+                                  - true
                         twitter_followers:
                           type: integer
-                          example: 7611
+                          examples:
+                            - 7611
                         growth:
                           type: integer
-                          example: 1
+                          examples:
+                            - 1
                         non_hq_locations:
                           type: array
                           items:
                             type: string
-                          example:
-                            - Dublin, IE
-                            - Ramat Gan, IL
-                            - Atlanta, US
-                            - Chicago, US
+                          examples:
+                            - - Dublin, IE
+                              - Ramat Gan, IL
+                              - Atlanta, US
+                              - Chicago, US
                         more_locations:
                           type: boolean
-                          example: false
+                          examples:
+                            - false
                         financial_metrics:
                           type: object
                           properties:
                             currency_code:
                               type: string
-                              example: USD
+                              examples:
+                                - USD
                             period:
                               type: string
-                              example: Y, 2020
+                              examples:
+                                - Y, 2020
                             revenue:
                               type: integer
-                              example: 37500000
+                              examples:
+                                - 37500000
                             cost_of_goods_sold:
                               type: integer
                               nullable: true
-                              example: null
+                              examples:
+                                - null
                             gross_profit:
                               type: integer
                               nullable: true
-                              example: null
+                              examples:
+                                - null
                             net_income:
                               type: integer
                               nullable: true
-                              example: null
+                              examples:
+                                - null
                         operating_metrics:
                           type: array
                           items:
@@ -3578,41 +3937,51 @@ paths:
                             properties:
                               period:
                                 type: string
-                                example: Dec, 2019
+                                examples:
+                                  - Dec, 2019
                               value:
                                 type: string
-                                example: "700.0"
+                                examples:
+                                  - "700.0"
                               definition:
                                 type: string
-                                example: Enterprise Customers
+                                examples:
+                                  - Enterprise Customers
                               operating_metric_group:
                                 type: string
-                                example: Customers
+                                examples:
+                                  - Customers
                               currency_code:
                                 type: string
                                 nullable: true
-                                example: null
+                                examples:
+                                  - null
                         funding_metrics:
                           type: object
                           properties:
                             date:
                               type: string
-                              example: about 3 years
+                              examples:
+                                - about 3 years
                             latest:
                               type: integer
-                              example: 250000000
+                              examples:
+                                - 250000000
                             currency_code:
                               type: string
-                              example: USD
+                              examples:
+                                - USD
                             total:
                               type: integer
-                              example: 581000000
+                              examples:
+                                - 581000000
                         twitterEngagement:
                           type: object
                           properties:
                             handle:
                               type: string
-                              example: leadmagichq
+                              examples:
+                                - leadmagichq
                             analytics:
                               type: array
                               items:
@@ -3620,43 +3989,52 @@ paths:
                                 properties:
                                   collectedAt:
                                     type: string
-                                    example: "2023-07-12T00:00:00"
+                                    examples:
+                                      - 2023-07-12T00:00:00
                                   tweets:
                                     type: integer
-                                    example: 6384
+                                    examples:
+                                      - 6384
                                   following:
                                     type: integer
-                                    example: 1854
+                                    examples:
+                                      - 1854
                                   followers:
                                     type: integer
-                                    example: 7611
+                                    examples:
+                                      - 7611
                                   tweetsForPeriod:
                                     type: integer
-                                    example: 0
+                                    examples:
+                                      - 0
                                   avgTweetsPerDay:
                                     type: number
-                                    example: 0
+                                    examples:
+                                      - 0
                                   avgRetweetsPerTweet:
                                     type: number
-                                    example: 0
+                                    examples:
+                                      - 0
                                   avgLikesPerTweet:
                                     type: number
-                                    example: 0
+                                    examples:
+                                      - 0
                                   tweetsPercentageEngagementForPeriod:
                                     type: number
-                                    example: 0
+                                    examples:
+                                      - 0
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/companies/technographics:
     post:
       summary: Company Technographics
@@ -3676,7 +4054,8 @@ paths:
                 company_domain:
                   type: string
                   description: The domain of the company to analyze
-                  example: leadmagic.io
+                  examples:
+                    - leadmagic.io
       responses:
         "200":
           description: Successful response with technology stack information
@@ -3687,10 +4066,12 @@ paths:
                 properties:
                   credits_consumed:
                     type: integer
-                    example: 1
+                    examples:
+                      - 1
                   message:
                     type: string
-                    example: Technology stack information retrieved successfully
+                    examples:
+                      - Technology stack information retrieved successfully
                   data:
                     type: array
                     description: Array of technologies found. Omitted or empty when no data is available.
@@ -3700,19 +4081,21 @@ paths:
                         name:
                           type: string
                           description: The name of the technology
-                          example: Google Analytics
+                          examples:
+                            - Google Analytics
                         description:
                           type: string
                           description: Description of the technology
-                          example: Google Analytics is a web analytics service offered by Google that tracks and reports website traffic.
+                          examples:
+                            - Google Analytics is a web analytics service offered by Google that tracks and reports website traffic.
                         categories:
                           type: array
                           description: Categories this technology belongs to
                           items:
                             type: string
-                          example:
-                            - Analytics
-                            - Marketing
+                          examples:
+                            - - Analytics
+                              - Marketing
                         sub_technologies:
                           type: array
                           description: Sub-technologies or related tools
@@ -3722,34 +4105,33 @@ paths:
                               name:
                                 type: string
                                 description: Name of the sub-technology
-                                example: Google Analytics 4
+                                examples:
+                                  - Google Analytics 4
                               description:
                                 type: string
                                 description: Description of the sub-technology
-                                example: The latest version of Google Analytics with enhanced privacy features
+                                examples:
+                                  - The latest version of Google Analytics with enhanced privacy features
                               categories:
                                 type: array
                                 items:
                                   type: string
                                 description: Categories for the sub-technology
-                                example:
-                                  - Analytics
-                                  - Privacy-focused
+                                examples:
+                                  - - Analytics
+                                    - Privacy-focused
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
-  # ============================================================
-  # People Enrichment Endpoints
-  # ============================================================
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/role-finder:
     post:
       summary: Role Finder
@@ -3786,40 +4168,48 @@ paths:
                 properties:
                   name:
                     type: string
-                    example: Alex Rivera
+                    examples:
+                      - Alex Rivera
                   profile_url:
                     type: string
-                    example: alex-rivera
+                    examples:
+                      - alex-rivera
                   first_name:
                     type: string
-                    example: Alex
+                    examples:
+                      - Alex
                   last_name:
                     type: string
-                    example: Rivera
+                    examples:
+                      - Rivera
                   message:
                     type: string
-                    example: Role found.
+                    examples:
+                      - Role found.
                   credits_consumed:
                     type: integer
-                    example: 2
+                    examples:
+                      - 2
                   company_name:
                     type: string
-                    example: Leadmagic
+                    examples:
+                      - Leadmagic
                   company_website:
                     type: string
-                    example: leadmagic.io
+                    examples:
+                      - leadmagic.io
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/people/employee-finder:
     post:
       summary: Employee Finder
@@ -3861,44 +4251,52 @@ paths:
                       properties:
                         first_name:
                           type: string
-                          example: Alex
+                          examples:
+                            - Alex
                         last_name:
                           type: string
-                          example: Rivera
+                          examples:
+                            - Rivera
                         full_name:
                           type: string
-                          example: Alex Rivera
+                          examples:
+                            - Alex Rivera
                         profile_url:
                           type: string
-                          example: example.com/in/alex-rivera
+                          examples:
+                            - example.com/in/alex-rivera
                         job_title:
                           type: string
-                          example: VP of Sales
+                          examples:
+                            - VP of Sales
                         location:
                           type: string
-                          example: San Francisco, CA
+                          examples:
+                            - San Francisco, CA
                   total_count:
                     type: integer
                     description: Total employees found (may exceed returned count when limit is set)
-                    example: 150
+                    examples:
+                      - 150
                   credits_consumed:
                     type: number
                     description: Credits used (0.05 per employee returned)
-                    example: 0.5
+                    examples:
+                      - 0.5
                   message:
-                    $ref: '#/components/schemas/EmployeeFinderMessages'
+                    $ref: "#/components/schemas/EmployeeFinderMessages"
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v3/people/search:
     post:
       summary: People Search
@@ -3916,14 +4314,17 @@ paths:
               properties:
                 company_domain:
                   type: string
-                  example: leadmagic.io
+                  examples:
+                    - leadmagic.io
                 company_name:
                   type: string
-                  example: LeadMagic
+                  examples:
+                    - LeadMagic
                 linkedin_url:
                   type: string
                   description: B2B company profile URL or slug.
-                  example: https://www.example.com/company/acme/
+                  examples:
+                    - https://www.example.com/company/acme/
                 company_filters:
                   type: object
                   additionalProperties: true
@@ -3931,22 +4332,16 @@ paths:
                 people_filters:
                   type: object
                   additionalProperties: true
-                  description: >
-                    People-level filters for names, title/function/level, geography, profile URLs,
-                    headline/about-me/industry, languages, seniority, connection count, and channel
-                    availability. Canonical keys use the contact_* prefix (e.g. contact_linkedin_about_me);
-                    bare aliases such as about_me, headline, industry, job_function, and city are accepted.
-                    contact_job_function accepts short chips (Sales, Marketing, Finance, …) or full standard
-                    labels (Sales & Business Development, …); matching is exact after chip→label expansion and
-                    response rows always return the standard label. Multiple values in one array are OR'd;
-                    different people_filters keys in one request are AND'd. Keys the search cannot honor are
-                    echoed in interpreted_search.ignored_people_filters rather than silently dropped.
+                  description: |
+                    People-level filters for names, title/function/level, geography, profile URLs, headline/about-me/industry, languages, seniority, connection count, and channel availability. Canonical keys use the contact_* prefix (e.g. contact_linkedin_about_me); bare aliases such as about_me, headline, industry, job_function, and city are accepted. contact_job_function accepts short chips (Sales, Marketing, Finance, …) or full standard labels (Sales & Business Development, …); matching is exact after chip→label expansion and response rows always return the standard label. Multiple values in one array are OR'd; different people_filters keys in one request are AND'd. Keys the search cannot honor are echoed in interpreted_search.ignored_people_filters rather than silently dropped.
                 title:
                   type: string
-                  example: VP Sales
+                  examples:
+                    - VP Sales
                 job_title:
                   type: string
-                  example: Head of Revenue
+                  examples:
+                    - Head of Revenue
                 titles:
                   type: array
                   items:
@@ -3970,11 +4365,15 @@ paths:
                   type: array
                   items:
                     type: string
-                    enum: [email, phone]
+                    enum:
+                      - email
+                      - phone
                   description: Legacy alias for contactability requirements.
                 channel_match:
                   type: string
-                  enum: [any, all]
+                  enum:
+                    - any
+                    - all
                   default: any
                 include_company:
                   type: boolean
@@ -3985,22 +4384,16 @@ paths:
                 include_contact_details:
                   type: boolean
                   default: false
-                  description: >
-                    Opt in to paid raw email/mobile fields (alias — full_search). Bills 1 extra credit
-                    per returned email and 5 per returned mobile; base results are 1 credit per returned person.
-                    Search RPS / unmetered people-search plans cannot unlock email or mobile (403); unlocks
-                    require a credit-metered plan.
+                  description: |
+                    Opt in to paid raw email/mobile fields (alias — full_search). Bills 1 extra credit per returned email and 5 per returned mobile; base results are 1 credit per returned person. Search RPS / unmetered people-search plans cannot unlock email or mobile (403); unlocks require a credit-metered plan.
                 include_email:
                   type: boolean
-                  description: >
-                    When contact details are on, return and bill raw emails (+1 credit each).
-                    If neither include_email nor include_mobile is set, both default to true.
-                    If either flag is set, the omitted flag defaults to false (include_email=true alone is email-only).
+                  description: |
+                    When contact details are on, return and bill raw emails (+1 credit each). If neither include_email nor include_mobile is set, both default to true. If either flag is set, the omitted flag defaults to false (include_email=true alone is email-only).
                 include_mobile:
                   type: boolean
-                  description: >
-                    When contact details are on, return and bill raw mobiles (+5 credits each).
-                    Same default rules as include_email.
+                  description: |
+                    When contact details are on, return and bill raw mobiles (+5 credits each). Same default rules as include_email.
                 confirm_credit_charge:
                   type: boolean
                   default: false
@@ -4019,44 +4412,45 @@ paths:
                   default: 0
                   minimum: 0
                   deprecated: true
-                  description: >
-                    Legacy offset pagination; prefer cursor. Unstable ordering, uncached.
-                    Restart at offset 0 to obtain a cursor.
-            example:
-              company_filters:
-                company_domains:
-                  - leadmagic.io
-                crm_tech:
-                  - Salesforce
-              people_filters:
-                contact_job_level:
-                  - VP
-                  - Director
-                contact_job_function:
-                  - Sales
-                is_sales: true
-                min_contactability_score: 40
-              titles:
-                - VP Sales
-                - Head of Revenue
-              required_email: true
-              limit: 10
+                  description: |
+                    Legacy offset pagination; prefer cursor. Unstable ordering, uncached. Restart at offset 0 to obtain a cursor.
+            examples:
+              default:
+                value:
+                  company_filters:
+                    company_domains:
+                      - leadmagic.io
+                    crm_tech:
+                      - Salesforce
+                  people_filters:
+                    contact_job_level:
+                      - VP
+                      - Director
+                    contact_job_function:
+                      - Sales
+                    is_sales: true
+                    min_contactability_score: 40
+                  titles:
+                    - VP Sales
+                    - Head of Revenue
+                  required_email: true
+                  limit: 10
       responses:
         "200":
           description: People search results
           headers:
             RateLimit-Limit:
-              $ref: '#/components/headers/RateLimitLimit'
+              $ref: "#/components/headers/RateLimitLimit"
             RateLimit-Remaining:
-              $ref: '#/components/headers/RateLimitRemaining'
+              $ref: "#/components/headers/RateLimitRemaining"
             RateLimit-Reset:
-              $ref: '#/components/headers/RateLimitReset'
+              $ref: "#/components/headers/RateLimitReset"
             X-RateLimit-RPS-Limit:
-              $ref: '#/components/headers/SearchRpsLimit'
+              $ref: "#/components/headers/SearchRpsLimit"
             X-RateLimit-RPS-Remaining:
-              $ref: '#/components/headers/SearchRpsRemaining'
+              $ref: "#/components/headers/SearchRpsRemaining"
             X-RateLimit-RPS-Reset:
-              $ref: '#/components/headers/SearchRpsReset'
+              $ref: "#/components/headers/SearchRpsReset"
           content:
             application/json:
               schema:
@@ -4139,10 +4533,8 @@ paths:
                         contact_job_function:
                           type: string
                           nullable: true
-                          description: >
-                            Standard department label for the person's current role
-                            (e.g. Sales & Business Development). Filter requests may use
-                            short chips such as Sales; responses always return this standard label.
+                          description: |
+                            Standard department label for the person's current role (e.g. Sales & Business Development). Filter requests may use short chips such as Sales; responses always return this standard label.
                         contact_job_level:
                           type: string
                           nullable: true
@@ -4293,95 +4685,97 @@ paths:
                           - cursor
                           - offset
                         description: snapshot/cursor for cursor/first-page responses; offset for legacy offset responses.
-              example:
-                message: People found
-                credits_consumed: 0
-                count: 120
-                returned_count: 25
-                limit_applied: 25
-                offset: 25
-                has_more: true
-                next_cursor: null
-                metadata:
-                  query_name: people_search_v3
-                  query_path: full_search
-                  pagination: offset
-                people:
-                  - contact_linkedin_url: "https://example.com/in/jane-doe"
-                    contact_linkedin_username: "jesseoue"
-                    contact_first_name: "Jesse"
-                    contact_last_name: "Ouellette"
-                    contact_full_name: "Jesse Ouellette"
-                    contact_email: "jesse@leadmagic.io"
-                    contact_email_domain: "leadmagic.io"
-                    contact_mobile_phone: "+12073561898"
-                    contact_direct_phone: null
-                    contact_linkedin_headline: "Growth & AI Expert | Founder LeadMagic"
-                    contact_linkedin_about_me: "SaaS Founder"
-                    contact_city: "Boston"
-                    contact_state: "Massachusetts"
-                    contact_state_code: "MA"
-                    contact_country: "United States"
-                    contact_country_code: "US"
-                    contact_region: "NORAM"
-                    contact_continent: "North America"
-                    contact_job_title: "Founder"
-                    contact_job_function: "General Business & Management"
-                    contact_job_level: "C-Team"
-                    contact_job_description: "LeadMagic is the Best B2B Email & Mobile Finder"
-                    contact_job_start_date: "2022-09-01"
-                    contact_job_count: 15
-                    contact_persona: "Founder/Co-Founder"
-                    contact_company_name: "Leadmagic"
-                    company_domain: "leadmagic.io"
-                    seniority_score: 5
-                    has_email: true
-                    has_mobile_phone: true
-                    has_phone: false
-                    followers: 500
-                    company:
-                      company_domain: "leadmagic.io"
-                      company_name: "Leadmagic"
-                      company_website: "https://www.leadmagic.io"
-                      company_industry_linkedin: "Internet Publishing"
-                      employee_range: "11 to 50"
-                      employee_min: 11
-                      employee_max: 50
-                      linkedin_employee_count: 10
-                      revenue_range: "$1M to <$10M"
-                      revenue_min: "4000000"
-                      revenue_max: "4000000"
-                      hq_country: "United States"
-                      hq_country_code: "US"
-                      hq_city: "Boston"
-                      hq_state: "Massachusetts"
-                      founded_year: 2022
-                      linkedin_followers: 8804
-                      growth_rate: 14
-                      linkedin_url: "https://www.example.com/company/acme"
-                      company_headline: "The data provider other data providers use. Emails, mobiles, and company data that don't bounce."
-                    domain_intel:
-                      company_domain: "leadmagic.io"
-                      company_name: "Leadmagic"
-                      company_website: "https://www.leadmagic.io"
-                      company_domain_tld: "leadmagic.io"
-                      company_website_active: true
-                      primary_email_domain: "leadmagic.io"
-                      email_pattern: "first"
-                      email_pattern_example: "soufiane@leadmagic.io"
-                      email_pattern_confidence: 100
-                      email_pattern_confidence_tier: "low"
-                      total_email_count: 4
-                      valid_email_count: 4
-                      total_contacts: 10
+              examples:
+                default:
+                  value:
+                    message: People found
+                    credits_consumed: 0
+                    count: 120
+                    returned_count: 25
+                    limit_applied: 25
+                    offset: 25
+                    has_more: true
+                    next_cursor: null
+                    metadata:
+                      query_name: people_search_v3
+                      query_path: full_search
+                      pagination: offset
+                    people:
+                      - contact_linkedin_url: https://example.com/in/jane-doe
+                        contact_linkedin_username: jesseoue
+                        contact_first_name: Jesse
+                        contact_last_name: Ouellette
+                        contact_full_name: Jesse Ouellette
+                        contact_email: jesse@leadmagic.io
+                        contact_email_domain: leadmagic.io
+                        contact_mobile_phone: "+12073561898"
+                        contact_direct_phone: null
+                        contact_linkedin_headline: Growth & AI Expert | Founder LeadMagic
+                        contact_linkedin_about_me: SaaS Founder
+                        contact_city: Boston
+                        contact_state: Massachusetts
+                        contact_state_code: MA
+                        contact_country: United States
+                        contact_country_code: US
+                        contact_region: NORAM
+                        contact_continent: North America
+                        contact_job_title: Founder
+                        contact_job_function: General Business & Management
+                        contact_job_level: C-Team
+                        contact_job_description: LeadMagic is the Best B2B Email & Mobile Finder
+                        contact_job_start_date: 2022-09-01
+                        contact_job_count: 15
+                        contact_persona: Founder/Co-Founder
+                        contact_company_name: Leadmagic
+                        company_domain: leadmagic.io
+                        seniority_score: 5
+                        has_email: true
+                        has_mobile_phone: true
+                        has_phone: false
+                        followers: 500
+                        company:
+                          company_domain: leadmagic.io
+                          company_name: Leadmagic
+                          company_website: https://www.leadmagic.io
+                          company_industry_linkedin: Internet Publishing
+                          employee_range: 11 to 50
+                          employee_min: 11
+                          employee_max: 50
+                          linkedin_employee_count: 10
+                          revenue_range: $1M to <$10M
+                          revenue_min: "4000000"
+                          revenue_max: "4000000"
+                          hq_country: United States
+                          hq_country_code: US
+                          hq_city: Boston
+                          hq_state: Massachusetts
+                          founded_year: 2022
+                          linkedin_followers: 8804
+                          growth_rate: 14
+                          linkedin_url: https://www.example.com/company/acme
+                          company_headline: The data provider other data providers use. Emails, mobiles, and company data that don't bounce.
+                        domain_intel:
+                          company_domain: leadmagic.io
+                          company_name: Leadmagic
+                          company_website: https://www.leadmagic.io
+                          company_domain_tld: leadmagic.io
+                          company_website_active: true
+                          primary_email_domain: leadmagic.io
+                          email_pattern: first
+                          email_pattern_example: soufiane@leadmagic.io
+                          email_pattern_confidence: 100
+                          email_pattern_confidence_tier: low
+                          total_email_count: 4
+                          valid_email_count: 4
+                          total_contacts: 10
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
   /v3/companies/search:
     post:
       summary: Company Search
@@ -4400,7 +4794,8 @@ paths:
                 company_domain:
                   type: string
                   description: Direct one-company lookup input. Returns one rich company row plus legacy-friendly aliases when no broad filters or explicit limit are supplied.
-                  example: leadmagic.io
+                  examples:
+                    - leadmagic.io
                 domain:
                   type: string
                   description: Alias for company_domain.
@@ -4435,38 +4830,39 @@ paths:
                   minimum: 0
                   default: 0
                   deprecated: true
-                  description: >
-                    Legacy offset pagination; prefer cursor. Unstable ordering, uncached.
-                    Restart at offset 0 to obtain a cursor.
-            example:
-              limit: 10
-              company_filters:
-                company_domains:
-                  - leadmagic.io
-                country_codes:
-                  - US
-                location_country_codes:
-                  - US
-                crm_tech:
-                  - Salesforce
-                has_funding: true
-                website_active: true
+                  description: |
+                    Legacy offset pagination; prefer cursor. Unstable ordering, uncached. Restart at offset 0 to obtain a cursor.
+            examples:
+              default:
+                value:
+                  limit: 10
+                  company_filters:
+                    company_domains:
+                      - leadmagic.io
+                    country_codes:
+                      - US
+                    location_country_codes:
+                      - US
+                    crm_tech:
+                      - Salesforce
+                    has_funding: true
+                    website_active: true
       responses:
         "200":
           description: Company search results
           headers:
             RateLimit-Limit:
-              $ref: '#/components/headers/RateLimitLimit'
+              $ref: "#/components/headers/RateLimitLimit"
             RateLimit-Remaining:
-              $ref: '#/components/headers/RateLimitRemaining'
+              $ref: "#/components/headers/RateLimitRemaining"
             RateLimit-Reset:
-              $ref: '#/components/headers/RateLimitReset'
+              $ref: "#/components/headers/RateLimitReset"
             X-RateLimit-RPS-Limit:
-              $ref: '#/components/headers/SearchRpsLimit'
+              $ref: "#/components/headers/SearchRpsLimit"
             X-RateLimit-RPS-Remaining:
-              $ref: '#/components/headers/SearchRpsRemaining'
+              $ref: "#/components/headers/SearchRpsRemaining"
             X-RateLimit-RPS-Reset:
-              $ref: '#/components/headers/SearchRpsReset'
+              $ref: "#/components/headers/SearchRpsReset"
           content:
             application/json:
               schema:
@@ -4727,30 +5123,32 @@ paths:
                           - cursor
                           - offset
                         description: snapshot/cursor for cursor/first-page responses; offset for legacy offset responses.
-              example:
-                message: Companies found
-                credits_consumed: 0
-                count: 120
-                returned_count: 25
-                limit_applied: 25
-                offset: 25
-                has_more: true
-                next_cursor: null
-                metadata:
-                  pagination: offset
-                companies:
-                  - company_domain: "leadmagic.io"
-                    company_name: "Leadmagic"
-                    company_website: "https://www.leadmagic.io"
-                    employee_range: "11 to 50"
+              examples:
+                default:
+                  value:
+                    message: Companies found
+                    credits_consumed: 0
+                    count: 120
+                    returned_count: 25
+                    limit_applied: 25
+                    offset: 25
+                    has_more: true
+                    next_cursor: null
+                    metadata:
+                      pagination: offset
+                    companies:
+                      - company_domain: leadmagic.io
+                        company_name: Leadmagic
+                        company_website: https://www.leadmagic.io
+                        employee_range: 11 to 50
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
   /v3/companies/lookalike:
     post:
       summary: Company Lookalike
@@ -4774,7 +5172,8 @@ paths:
                 company_domain:
                   type: string
                   description: Seed company domain. Aliases include domain, website, company_website, seed.domain. Typos like companny_domain are remapped.
-                  example: leadmagic.io
+                  examples:
+                    - leadmagic.io
                 domain:
                   type: string
                   description: Alias for company_domain.
@@ -4822,21 +5221,23 @@ paths:
                   type: integer
                   minimum: 0
                   default: 0
-            example:
-              company_domain: leadmagic.io
-              company_filters:
-                country_codes:
-                  - US
-                location_country_codes:
-                  - US
-                employee_ranges:
-                  - 51 to 200
-                  - 201 to 500
-                crm_tech:
-                  - Salesforce
-                has_tech_stack: true
-                website_active: true
-              limit: 25
+            examples:
+              default:
+                value:
+                  company_domain: leadmagic.io
+                  company_filters:
+                    country_codes:
+                      - US
+                    location_country_codes:
+                      - US
+                    employee_ranges:
+                      - 51 to 200
+                      - 201 to 500
+                    crm_tech:
+                      - Salesforce
+                    has_tech_stack: true
+                    website_active: true
+                  limit: 25
       responses:
         "200":
           description: Company lookalike results (flat JSON body — not wrapped in data)
@@ -4876,11 +5277,13 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: Lookalike companies found
+                    examples:
+                      - Lookalike companies found
                   credits_consumed:
                     type: number
                     description: Flat 5 when results returned; 0 when empty
-                    example: 5
+                    examples:
+                      - 5
                   companies:
                     type: array
                     items:
@@ -4926,16 +5329,20 @@ paths:
                           type: string
                   count:
                     type: integer
-                    example: 5
+                    examples:
+                      - 5
                   returned_count:
                     type: integer
-                    example: 5
+                    examples:
+                      - 5
                   limit_applied:
                     type: integer
-                    example: 25
+                    examples:
+                      - 25
                   offset:
                     type: integer
-                    example: 0
+                    examples:
+                      - 0
                   interpreted_search:
                     type: object
                     additionalProperties: true
@@ -4946,46 +5353,46 @@ paths:
                     properties:
                       query_name:
                         type: string
-                        example: company_lookalike_v3
+                        examples:
+                          - company_lookalike_v3
                       query_path:
                         type: string
-                        example: lookalike
+                        examples:
+                          - lookalike
                       preview:
                         type: boolean
                       degraded:
                         type: boolean
                         description: True when upstream was briefly unavailable and an empty free response was returned
-              example:
-                message: Lookalike companies found
-                credits_consumed: 5
-                companies:
-                  - company_domain: tomba.io
-                    company_name: Tomba.Io
-                    similarity: 0.88
-                count: 1
-                returned_count: 1
-                limit_applied: 25
-                offset: 0
-                interpreted_search:
-                  seed:
-                    domain: leadmagic.io
-                  company_filters: {}
-                metadata:
-                  query_name: company_lookalike_v3
-                  query_path: lookalike
-                  preview: false
+              examples:
+                default:
+                  value:
+                    message: Lookalike companies found
+                    credits_consumed: 5
+                    companies:
+                      - company_domain: tomba.io
+                        company_name: Tomba.Io
+                        similarity: 0.88
+                    count: 1
+                    returned_count: 1
+                    limit_applied: 25
+                    offset: 0
+                    interpreted_search:
+                      seed:
+                        domain: leadmagic.io
+                      company_filters: {}
+                    metadata:
+                      query_name: company_lookalike_v3
+                      query_path: lookalike
+                      preview: false
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
-
-  # ============================================================
-  # Jobs Endpoints
-  # ============================================================
+          $ref: "#/components/responses/RateLimitExceeded"
   /v1/jobs/jobs-finder:
     post:
       summary: Jobs Finder
@@ -5003,77 +5410,95 @@ paths:
                 company_name:
                   type: string
                   description: Provide the Company Name. (Optional)
-                  example: Clay
+                  examples:
+                    - Clay
                 company_website:
                   type: string
                   description: Provide the Company Website. (Optional)
-                  example: clay.com
+                  examples:
+                    - clay.com
                 job_title:
                   type: string
                   description: Provide the Job Title.
-                  example: RevOps Engineer
+                  examples:
+                    - RevOps Engineer
                 location:
                   type: string
                   description: Location of the job
-                  example: United States
+                  examples:
+                    - United States
                 experience_level:
                   type: string
                   description: Indicates the required experience level for the job. Choose "entry" for Entry Level, "mid" for Mid Level, "senior" for Senior Level, or "executive" for Executive Level. If not specified, jobs from all experience levels will be included.
-                  example: senior
+                  examples:
+                    - senior
                 job_description:
                   type: string
                   description: Filters jobs based on specific keywords or phrases found in the job description.
-                  example: leadmagic
+                  examples:
+                    - leadmagic
                 city_name:
                   type: string
                   description: Filter jobs by city name. Pair with `country_id` to disambiguate cities that share a name.
-                  example: Austin
+                  examples:
+                    - Austin
                 country_id:
                   type: string
                   description: Filter jobs by country code, such as US or GB. Use the country helper for supported values.
-                  example: US
+                  examples:
+                    - US
                 region_id:
                   type: integer
                   description: Filter jobs by region ID.
-                  example: 5
+                  examples:
+                    - 5
                 job_type_id:
                   type: integer
                   description: Filter jobs by job type ID.
-                  example: 1
+                  examples:
+                    - 1
                 company_type_id:
                   type: integer
                   description: Filter jobs by company type ID.
-                  example: 1
+                  examples:
+                    - 1
                 company_industry_id:
                   type: integer
                   description: Filter jobs by company industry ID.
-                  example: 7
+                  examples:
+                    - 7
                 min_employees:
                   type: integer
                   description: Minimum number of employees
-                  example: 51
+                  examples:
+                    - 51
                 max_employees:
                   type: integer
                   description: Maximum number of employees
-                  example: 10000
+                  examples:
+                    - 10000
                 has_remote:
                   type: boolean
                   description: Determines whether the jobs offer remote work options. Set to true to include remote-only listings, or false to include non-remote listings.
-                  example: true
+                  examples:
+                    - true
                 posted_within:
                   type: integer
                   description: Specify the number of days within which the job was posted.
-                  example: 30
+                  examples:
+                    - 30
                 posted_after:
                   type: string
                   format: date
                   description: Filters jobs posted on or after a specific date. Use the format YYYY-MM-DD.
-                  example: "2026-05-01"
+                  examples:
+                    - 2026-05-01
                 posted_before:
                   type: string
                   format: date
                   description: Filters jobs posted on or before a specific date. Use the format YYYY-MM-DD.
-                  example: "2026-05-15"
+                  examples:
+                    - 2026-05-15
                 page:
                   type: integer
                   description: Page number
@@ -5082,14 +5507,16 @@ paths:
                   type: integer
                   description: Provide number of results needed per page. (Maximum per_page can be 50)
                   default: 20
-            example:
-              company_website: clay.com
-              job_title: RevOps Engineer
-              country_id: US
-              has_remote: true
-              posted_within: 30
-              page: 1
-              per_page: 20
+            examples:
+              default:
+                value:
+                  company_website: clay.com
+                  job_title: RevOps Engineer
+                  country_id: US
+                  has_remote: true
+                  posted_within: 30
+                  page: 1
+                  per_page: 20
       responses:
         "200":
           description: Successful response with job listings
@@ -5123,22 +5550,27 @@ paths:
                           properties:
                             name:
                               type: string
-                              example: LeadMagic
+                              examples:
+                                - LeadMagic
                             website_url:
                               type: string
-                              example: https://leadmagic.io
+                              examples:
+                                - https://leadmagic.io
                             b2b_profile_url:
                               type: string
                               nullable: true
-                              example: leadmagichq
+                              examples:
+                                - leadmagichq
                             twitter_handle:
                               type: string
                               nullable: true
-                              example: leadmagichq
+                              examples:
+                                - leadmagichq
                             github_url:
                               type: string
                               nullable: true
-                              example: https://github.com/leadmagic
+                              examples:
+                                - https://github.com/leadmagic
                         title:
                           type: string
                         location:
@@ -5220,66 +5652,66 @@ paths:
                           nullable: true
                         experience_level:
                           type: string
-                example:
-                  total_count: 50
-                  page: 1
-                  per_page: 20
-                  total_pages: 3
-                  credits_consumed: 20
-                  results:
-                    - company:
-                        name: LeadMagic
-                        website_url: https://leadmagic.io
-                        b2b_profile_url: leadmagichq
-                        twitter_handle: leadmagichq
-                        github_url: https://github.com/leadmagic
-                      title: Senior Software Engineer
-                      location: San Jose, San José, Costa Rica
-                      types:
-                        - id: 1
-                          name: Full Time
-                      cities:
-                        - geonameid: 3621849
-                          asciiname: San Jose
-                          name: San José
-                          country:
-                            code: CR
+                examples:
+                  - total_count: 50
+                    page: 1
+                    per_page: 20
+                    total_pages: 3
+                    credits_consumed: 20
+                    results:
+                      - company:
+                          name: LeadMagic
+                          website_url: https://leadmagic.io
+                          b2b_profile_url: leadmagichq
+                          twitter_handle: leadmagichq
+                          github_url: https://github.com/leadmagic
+                        title: Senior Software Engineer
+                        location: San Jose, San José, Costa Rica
+                        types:
+                          - id: 1
+                            name: Full Time
+                        cities:
+                          - geonameid: 3621849
+                            asciiname: San Jose
+                            name: San José
+                            country:
+                              code: CR
+                              name: Costa Rica
+                              region:
+                                id: 5
+                                name: North America
+                            timezone: America/Costa_Rica
+                            latitude: "9.93333"
+                            longitude: "-84.08333"
+                        countries:
+                          - code: CR
                             name: Costa Rica
                             region:
                               id: 5
                               name: North America
-                          timezone: America/Costa_Rica
-                          latitude: "9.93333"
-                          longitude: "-84.08333"
-                      countries:
-                        - code: CR
-                          name: Costa Rica
-                          region:
-                            id: 5
+                        regions:
+                          - id: 5
                             name: North America
-                      regions:
-                        - id: 5
-                          name: North America
-                      has_remote: false
-                      published: "2024-07-23T15:25:00Z"
-                      description: ""
-                      application_url: https://leadmagic.io/careers
-                      language: en
-                      clearance_required: false
-                      salary_min: null
-                      salary_max: null
-                      salary_currency: null
-                      experience_level: Senior Level
+                        has_remote: false
+                        published: 2024-07-23T15:25:00Z
+                        description: ""
+                        application_url: https://leadmagic.io/careers
+                        language: en
+                        clearance_required: false
+                        salary_min: null
+                        salary_max: null
+                        salary_currency: null
+                        experience_level: Senior Level
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v3/jobs/search:
     post:
       summary: Job Search
@@ -5446,47 +5878,54 @@ paths:
                 totalMode:
                   type: string
                   default: capped
-                  enum: [none, capped, exact]
+                  enum:
+                    - none
+                    - capped
+                    - exact
                 mode:
                   type: string
                   default: fast
-                  enum: [fast, deep]
+                  enum:
+                    - fast
+                    - deep
                   description: fast returns paginated browsing results when descriptions and facets are omitted; deep enables broader text matching.
                 autoResolve:
                   type: boolean
                   default: true
-            example:
-              titles:
-                include:
-                  - Engineer
-                vector: false
-              occupationTaxonomy:
-                level2:
-                  - DevOps
-              location:
-                countries:
-                  - US
-              postedWithin: 30
-              limit: 5
-              totalMode: none
-              mode: fast
-              autoResolve: true
+            examples:
+              default:
+                value:
+                  titles:
+                    include:
+                      - Engineer
+                    vector: false
+                  occupationTaxonomy:
+                    level2:
+                      - DevOps
+                  location:
+                    countries:
+                      - US
+                  postedWithin: 30
+                  limit: 5
+                  totalMode: none
+                  mode: fast
+                  autoResolve: true
       responses:
         "200":
           description: Job search results
           headers:
             RateLimit-Limit:
-              $ref: '#/components/headers/RateLimitLimit'
+              $ref: "#/components/headers/RateLimitLimit"
             RateLimit-Remaining:
-              $ref: '#/components/headers/RateLimitRemaining'
+              $ref: "#/components/headers/RateLimitRemaining"
             RateLimit-Reset:
-              $ref: '#/components/headers/RateLimitReset'
+              $ref: "#/components/headers/RateLimitReset"
             X-RateLimit-RPS-Limit:
-              $ref: '#/components/headers/SearchRpsLimit'
+              $ref: "#/components/headers/SearchRpsLimit"
             X-RateLimit-RPS-Remaining:
-              $ref: '#/components/headers/SearchRpsRemaining'
+              $ref: "#/components/headers/SearchRpsRemaining"
             X-RateLimit-RPS-Reset:
-              $ref: '#/components/headers/SearchRpsReset'
+              $ref: "#/components/headers/SearchRpsReset"
           content:
             application/json:
               schema:
@@ -5521,34 +5960,36 @@ paths:
                     type: object
                   credits_consumed:
                     type: integer
-              example:
-                signals:
-                  - title: Full-Stack Software Engineer
-                    company:
-                      id: 102413
-                      name: Example Company
-                      website_url: https://example.com
-                    occupation_taxonomy:
-                      level1:
-                        id: 1
-                        name: Developer
-                      level2:
-                        id: 20
-                        name: Full-Stack Development
-                      level3:
-                        id: 774
-                        name: Full-stack software engineer
-                total: 3
-                totalMode: capped
-                credits_consumed: 1
+              examples:
+                default:
+                  value:
+                    signals:
+                      - title: Full-Stack Software Engineer
+                        company:
+                          id: 102413
+                          name: Example Company
+                          website_url: https://example.com
+                        occupation_taxonomy:
+                          level1:
+                            id: 1
+                            name: Developer
+                          level2:
+                            id: 20
+                            name: Full-Stack Development
+                          level3:
+                            id: 774
+                            name: Full-stack software engineer
+                    total: 3
+                    totalMode: capped
+                    credits_consumed: 1
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
   /v3/search/stats:
     post:
       summary: Search Stats
@@ -5571,34 +6012,53 @@ paths:
                   description: Search products to include — jobs, company, and/or people stats.
                   items:
                     type: string
-                    enum: [jobs, company, people]
-                  default: [jobs, company, people]
+                    enum:
+                      - jobs
+                      - company
+                      - people
+                  default:
+                    - jobs
+                    - company
+                    - people
                 sections:
                   type: array
                   description: Stat sections to return — coverage counts, top dimensions, and/or filter capabilities.
                   items:
                     type: string
-                    enum: [coverage, top, capabilities]
-                  default: [coverage, top, capabilities]
+                    enum:
+                      - coverage
+                      - top
+                      - capabilities
+                  default:
+                    - coverage
+                    - top
+                    - capabilities
                 limit:
                   type: integer
                   description: Max top values per dimension. Defaults to 3.
                   minimum: 1
                   maximum: 25
                   default: 3
-            example:
-              products: [jobs, company, people]
-              sections: [coverage, top]
-              limit: 10
+            examples:
+              default:
+                value:
+                  products:
+                    - jobs
+                    - company
+                    - people
+                  sections:
+                    - coverage
+                    - top
+                  limit: 10
       responses:
         "200":
           description: Search stats results
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
   /v3/jobs-search:
     post:
       summary: Job Search Alias
@@ -5644,22 +6104,29 @@ paths:
                 totalMode:
                   type: string
                   default: capped
-                  enum: [none, capped, exact]
+                  enum:
+                    - none
+                    - capped
+                    - exact
                 mode:
                   type: string
                   default: fast
-                  enum: [fast, deep]
-            example:
-              titles:
-                include:
-                  - Software Engineer
-                vector: false
-              location:
-                countries:
-                  - US
-              limit: 5
-              totalMode: none
-              mode: fast
+                  enum:
+                    - fast
+                    - deep
+            examples:
+              default:
+                value:
+                  titles:
+                    include:
+                      - Software Engineer
+                    vector: false
+                  location:
+                    countries:
+                      - US
+                  limit: 5
+                  totalMode: none
+                  mode: fast
       responses:
         "200":
           description: Job search results
@@ -5766,22 +6233,22 @@ paths:
                       type: array
                       items:
                         type: string
-              example:
-                companies:
-                  include:
-                    - leadmagic.io
-                tags:
-                  include:
-                    - kubernetes
-                occupationTaxonomy:
-                  level2:
-                    - DevOps
-                location:
-                  countries:
-                    - US
-                titles:
-                  include:
-                    - Site Reliability Engineer
+              examples:
+                - companies:
+                    include:
+                      - leadmagic.io
+                  tags:
+                    include:
+                      - kubernetes
+                  occupationTaxonomy:
+                    level2:
+                      - DevOps
+                  location:
+                    countries:
+                      - US
+                  titles:
+                    include:
+                      - Site Reliability Engineer
       responses:
         "200":
           description: Resolved filters
@@ -5795,20 +6262,26 @@ paths:
       parameters:
         - name: q
           in: query
-          example: leadmagic
           schema:
             type: string
+          examples:
+            default:
+              value: leadmagic
         - name: domain
           in: query
-          example: leadmagic.io
           schema:
             type: string
+          examples:
+            default:
+              value: leadmagic.io
         - name: limit
           in: query
-          example: 10
           schema:
             type: integer
             default: 10
+          examples:
+            default:
+              value: 10
       responses:
         "200":
           description: Company helper results
@@ -5817,12 +6290,14 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                companies:
-                  - id: 102413
-                    name: LeadMagic
-                    domain: leadmagic.io
-                    logo_domain: leadmagic.io
+              examples:
+                default:
+                  value:
+                    companies:
+                      - id: 102413
+                        name: LeadMagic
+                        domain: leadmagic.io
+                        logo_domain: leadmagic.io
   /v3/jobs/search/tags:
     get:
       summary: Job Search Tags Helper
@@ -5833,20 +6308,26 @@ paths:
       parameters:
         - name: q
           in: query
-          example: kuber
           schema:
             type: string
+          examples:
+            default:
+              value: kuber
         - name: tag_type
           in: query
-          example: 2
           schema:
             type: integer
+          examples:
+            default:
+              value: 2
         - name: limit
           in: query
-          example: 10
           schema:
             type: integer
             default: 10
+          examples:
+            default:
+              value: 10
       responses:
         "200":
           description: Tag helper results
@@ -5855,18 +6336,20 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                tags:
-                  - id: 482
-                    name: kubernetes
-                    tag_type: 2
-                    occupation_taxonomy:
-                      level1:
-                        id: 1
-                        name: Developer
-                      level2:
-                        id: 20
-                        name: DevOps
+              examples:
+                default:
+                  value:
+                    tags:
+                      - id: 482
+                        name: kubernetes
+                        tag_type: 2
+                        occupation_taxonomy:
+                          level1:
+                            id: 1
+                            name: Developer
+                          level2:
+                            id: 20
+                            name: DevOps
   /v3/jobs/search/titles:
     get:
       summary: Job Search Titles Helper
@@ -5877,15 +6360,19 @@ paths:
       parameters:
         - name: q
           in: query
-          example: devops engineer
           schema:
             type: string
+          examples:
+            default:
+              value: devops engineer
         - name: limit
           in: query
-          example: 10
           schema:
             type: integer
             default: 10
+          examples:
+            default:
+              value: 10
       responses:
         "200":
           description: Title helper results
@@ -5894,20 +6381,22 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                titles:
-                  - id: 774
-                    name: DevOps Engineer
-                    occupation_taxonomy:
-                      level1:
-                        id: 1
-                        name: Developer
-                      level2:
-                        id: 20
-                        name: DevOps
-                      level3:
-                        id: 774
+              examples:
+                default:
+                  value:
+                    titles:
+                      - id: 774
                         name: DevOps Engineer
+                        occupation_taxonomy:
+                          level1:
+                            id: 1
+                            name: Developer
+                          level2:
+                            id: 20
+                            name: DevOps
+                          level3:
+                            id: 774
+                            name: DevOps Engineer
   /v3/jobs/search/occupation-taxonomy:
     get:
       summary: Job Search Occupation Taxonomy Helper
@@ -5918,21 +6407,30 @@ paths:
       parameters:
         - name: q
           in: query
-          example: DevOps
           schema:
             type: string
+          examples:
+            default:
+              value: DevOps
         - name: level
           in: query
-          example: level2
           schema:
             type: string
-            enum: [level1, level2, level3]
+            enum:
+              - level1
+              - level2
+              - level3
+          examples:
+            default:
+              value: level2
         - name: limit
           in: query
-          example: 10
           schema:
             type: integer
             default: 10
+          examples:
+            default:
+              value: 10
       responses:
         "200":
           description: Occupation taxonomy helper results
@@ -5941,20 +6439,22 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                occupation_taxonomy:
-                  - id: 1700834
-                    name: .NET & DevOps
-                    type: 2
-                    level1:
-                      id: 7
-                      name: Engineer
-                    level2:
-                      id: 1700834
-                      name: .NET & DevOps
-                    level3: null
-                    path: Engineer > .NET & DevOps
-                credits_consumed: 0
+              examples:
+                default:
+                  value:
+                    occupation_taxonomy:
+                      - id: 1700834
+                        name: .NET & DevOps
+                        type: 2
+                        level1:
+                          id: 7
+                          name: Engineer
+                        level2:
+                          id: 1700834
+                          name: .NET & DevOps
+                        level3: null
+                        path: Engineer > .NET & DevOps
+                    credits_consumed: 0
   /v3/jobs/search/locations:
     get:
       summary: Job Search Locations Helper
@@ -5965,21 +6465,31 @@ paths:
       parameters:
         - name: q
           in: query
-          example: United
           schema:
             type: string
+          examples:
+            default:
+              value: United
         - name: type
           in: query
-          example: country
           schema:
             type: string
-            enum: [country, region, state, city]
+            enum:
+              - country
+              - region
+              - state
+              - city
+          examples:
+            default:
+              value: country
         - name: limit
           in: query
-          example: 10
           schema:
             type: integer
             default: 10
+          examples:
+            default:
+              value: 10
       responses:
         "200":
           description: Location helper results
@@ -5988,14 +6498,16 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                locations:
-                  - id: 840
-                    name: United States
-                    type: country
-                  - id: 826
-                    name: United Kingdom
-                    type: country
+              examples:
+                default:
+                  value:
+                    locations:
+                      - id: 840
+                        name: United States
+                        type: country
+                      - id: 826
+                        name: United Kingdom
+                        type: country
   /v3/jobs/search/catalogs:
     get:
       summary: Job Search Catalogs
@@ -6011,35 +6523,37 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                countries:
-                  - id: 840
-                    name: United States
-                  - id: 826
-                    name: United Kingdom
-                job_types:
-                  - id: 1
-                    name: Full-time
-                  - id: 2
-                    name: Part-time
-                  - id: 3
-                    name: Contract
-                industries:
-                  - id: 96
-                    name: Software
-                company_types:
-                  - id: 1
-                    name: Private
-                  - id: 2
-                    name: Public
-                seniority:
-                  - id: 1
-                    name: Entry
-                  - id: 5
-                    name: VP
-                stats:
-                  total_jobs_indexed: 12500000
-                  freshness_days: 1
+              examples:
+                default:
+                  value:
+                    countries:
+                      - id: 840
+                        name: United States
+                      - id: 826
+                        name: United Kingdom
+                    job_types:
+                      - id: 1
+                        name: Full-time
+                      - id: 2
+                        name: Part-time
+                      - id: 3
+                        name: Contract
+                    industries:
+                      - id: 96
+                        name: Software
+                    company_types:
+                      - id: 1
+                        name: Private
+                      - id: 2
+                        name: Public
+                    seniority:
+                      - id: 1
+                        name: Entry
+                      - id: 5
+                        name: VP
+                    stats:
+                      total_jobs_indexed: 12500000
+                      freshness_days: 1
   /v3/jobs/search/roles:
     get:
       summary: Job Search Roles Helper
@@ -6050,15 +6564,19 @@ paths:
       parameters:
         - name: q
           in: query
-          example: revenue operations
           schema:
             type: string
+          examples:
+            default:
+              value: revenue operations
         - name: limit
           in: query
-          example: 10
           schema:
             type: integer
             default: 10
+          examples:
+            default:
+              value: 10
       responses:
         "200":
           description: Role helper results
@@ -6067,17 +6585,19 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                roles:
-                  - id: 20
-                    name: Revenue Operations
-                    occupation_taxonomy:
-                      level1:
-                        id: 5
-                        name: Operations
-                      level2:
-                        id: 20
+              examples:
+                default:
+                  value:
+                    roles:
+                      - id: 20
                         name: Revenue Operations
+                        occupation_taxonomy:
+                          level1:
+                            id: 5
+                            name: Operations
+                          level2:
+                            id: 20
+                            name: Revenue Operations
   /v3/jobs/search/stats:
     get:
       summary: Job Search Dataset Stats
@@ -6093,10 +6613,12 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                stats:
-                  total_jobs_indexed: 12500000
-                  freshness_days: 1
+              examples:
+                default:
+                  value:
+                    stats:
+                      total_jobs_indexed: 12500000
+                      freshness_days: 1
   /v3/jobs/search/job-board/stats:
     get:
       summary: Job Board Stats
@@ -6112,10 +6634,12 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                stats:
-                  total_jobs_indexed: 12500000
-                  freshness_days: 1
+              examples:
+                default:
+                  value:
+                    stats:
+                      total_jobs_indexed: 12500000
+                      freshness_days: 1
   /v3/jobs/search/export:
     post:
       summary: Job Search Export
@@ -6169,13 +6693,17 @@ paths:
                   maximum: 5000
                   default: 100
                   description: Maximum jobs to export. Cursor pagination is not supported on export; narrow filters instead.
-            example:
-              titles:
-                include: ["Software Engineer"]
-              location:
-                countries: ["US"]
-              postedWithin: 30
-              limit: 500
+            examples:
+              default:
+                value:
+                  titles:
+                    include:
+                      - Software Engineer
+                  location:
+                    countries:
+                      - US
+                  postedWithin: 30
+                  limit: 500
       responses:
         "200":
           description: Exported jobs
@@ -6184,18 +6712,20 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                jobs:
-                  - id: "j_01hxyz"
-                    title: Software Engineer
-                    company:
-                      name: Example Corp
-                      domain: example.com
-                    location: United States
-                    posted_at: "2026-08-01"
-                    description: Full posting text…
-                total_returned: 500
-                credits_consumed: 500
+              examples:
+                default:
+                  value:
+                    jobs:
+                      - id: j_01hxyz
+                        title: Software Engineer
+                        company:
+                          name: Example Corp
+                          domain: example.com
+                        location: United States
+                        posted_at: 2026-08-01
+                        description: Full posting text…
+                    total_returned: 500
+                    credits_consumed: 500
   /v1/jobs/countries:
     get:
       summary: Job Country
@@ -6217,21 +6747,21 @@ paths:
                       type: string
                     name:
                       type: string
-                example:
-                  - id: AL
-                    name: Albania
-                  - id: DZ
-                    name: Algeria
-                  - id: AD
-                    name: Andorra
-                  - id: AO
-                    name: Angola
-                  - id: AG
-                    name: Antigua and Barbuda
+                examples:
+                  - - id: AL
+                      name: Albania
+                    - id: DZ
+                      name: Algeria
+                    - id: AD
+                      name: Andorra
+                    - id: AO
+                      name: Angola
+                    - id: AG
+                      name: Antigua and Barbuda
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/jobs/regions:
     get:
       summary: Job Region
@@ -6254,23 +6784,23 @@ paths:
                       default: 0
                     name:
                       type: string
-                example:
-                  - id: 1
-                    name: Africa
-                  - id: 2
-                    name: Asia/Pacific
-                  - id: 3
-                    name: Europe
-                  - id: 4
-                    name: Middle East
-                  - id: 5
-                    name: North America
-                  - id: 6
-                    name: South America
+                examples:
+                  - - id: 1
+                      name: Africa
+                    - id: 2
+                      name: Asia/Pacific
+                    - id: 3
+                      name: Europe
+                    - id: 4
+                      name: Middle East
+                    - id: 5
+                      name: North America
+                    - id: 6
+                      name: South America
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/jobs/job-types:
     get:
       summary: Job Type
@@ -6293,23 +6823,23 @@ paths:
                       default: 0
                     name:
                       type: string
-                example:
-                  - id: 1
-                    name: Full Time
-                  - id: 2
-                    name: Part Time
-                  - id: 3
-                    name: Temporary
-                  - id: 4
-                    name: Internship
-                  - id: 5
-                    name: Freelance
-                  - id: 6
-                    name: Contract
+                examples:
+                  - - id: 1
+                      name: Full Time
+                    - id: 2
+                      name: Part Time
+                    - id: 3
+                      name: Temporary
+                    - id: 4
+                      name: Internship
+                    - id: 5
+                      name: Freelance
+                    - id: 6
+                      name: Contract
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/jobs/company-types:
     get:
       summary: Job Company Type
@@ -6333,9 +6863,9 @@ paths:
                     name:
                       type: string
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/jobs/industries:
     get:
       summary: Job Industry
@@ -6358,24 +6888,21 @@ paths:
                       default: 0
                     name:
                       type: string
-                example:
-                  - id: 22
-                    name: Accounting
-                  - id: 318
-                    name: Administration of Justice
-                  - id: 297
-                    name: Administrative and Support Services
-                  - id: 8
-                    name: Advertising Services
-                  - id: 245
-                    name: Agricultural Chemical Manufacturing
+                examples:
+                  - - id: 22
+                      name: Accounting
+                    - id: 318
+                      name: Administration of Justice
+                    - id: 297
+                      name: Administrative and Support Services
+                    - id: 8
+                      name: Advertising Services
+                    - id: 245
+                      name: Agricultural Chemical Manufacturing
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "500":
-          $ref: '#/components/responses/InternalServerError'
-  # ============================================================
-  # Ads Data Endpoints
-  # ============================================================
+          $ref: "#/components/responses/InternalServerError"
   /v1/ads/google-ads-search:
     post:
       summary: Google Ads Search
@@ -6394,21 +6921,21 @@ paths:
                   type: string
                   description: Company domain name
                   default: leadmagic.io
-                  example: leadmagic.io
+                  examples:
+                    - leadmagic.io
                 company_name:
                   type: string
                   description: Company name
                   default: leadmagic
-                  example: leadmagic
+                  examples:
+                    - leadmagic
                 limit:
                   type: integer
                   minimum: 1
                   maximum: 100
-                  description: >-
-                    Maximum number of ads to return. Because you are charged 1 credit
-                    per ad returned, this also caps the credits spent on the request.
-                    Omit to return every ad found.
-                  example: 10
+                  description: Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the credits spent on the request. Omit to return every ad found.
+                  examples:
+                    - 10
       responses:
         "200":
           description: Successful response with ads details
@@ -6419,13 +6946,16 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "Google Ads retrieved successfully"
+                    examples:
+                      - Google Ads retrieved successfully
                   credits_consumed:
                     type: number
-                    example: 2
+                    examples:
+                      - 2
                   ads_count:
                     type: integer
-                    example: 2
+                    examples:
+                      - 2
                   ads:
                     type: array
                     items:
@@ -6433,13 +6963,16 @@ paths:
                       properties:
                         advertiser_id:
                           type: string
-                          example: "123456"
+                          examples:
+                            - "123456"
                         creative_id:
                           type: string
-                          example: "789012"
+                          examples:
+                            - "789012"
                         original_url:
                           type: string
-                          example: https://www.example.com/ad
+                          examples:
+                            - https://www.example.com/ad
                         variants:
                           type: array
                           items:
@@ -6447,63 +6980,69 @@ paths:
                             properties:
                               content:
                                 type: string
-                                example: <img src="https://tpc.googlesyndication.com/archive/simgad/6399633577457746150" height="173" width="380">
+                                examples:
+                                  - <img src="https://tpc.googlesyndication.com/archive/simgad/6399633577457746150" height="173" width="380">
                               height:
                                 type: integer
                                 nullable: true
-                                example: 173
+                                examples:
+                                  - 173
                               width:
                                 type: integer
                                 nullable: true
-                                example: 380
+                                examples:
+                                  - 380
                         start:
                           type: string
-                          example: "2023-01-01"
+                          examples:
+                            - 2023-01-01
                         last_seen:
                           type: string
-                          example: "2023-12-31"
+                          examples:
+                            - 2023-12-31
                         advertiser_name:
                           type: string
-                          example: Example Company
+                          examples:
+                            - Example Company
                         format:
                           type: string
-                          example: Text
-                example:
-                  ads:
-                    - advertiser_id: AR14106062795078369281
-                      creative_id: CR14003695067076755457
-                      original_url: https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR14003695067076755457?region=anywhere
-                      variants:
-                        - content: <img src="https://tpc.googlesyndication.com/archive/simgad/6399633577457746150" height="173" width="380">
-                          height: 173
-                          width: 380
-                      start: "2024-07-03"
-                      last_seen: "2025-03-06"
-                      advertiser_name: LeadMagic Inc
-                      format: Text
-                    - advertiser_id: AR14106062795078369281
-                      creative_id: CR16065875974473908225
-                      original_url: https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR16065875974473908225?region=anywhere
-                      variants:
-                        - content: <img src="https://tpc.googlesyndication.com/archive/simgad/14075255850026292628" height="173" width="380">
-                          height: 173
-                          width: 380
-                      start: "2025-02-04"
-                      last_seen: "2025-03-06"
-                      advertiser_name: LeadMagic Inc
-                      format: Text
-
-                  credits_consumed: 2
+                          examples:
+                            - Text
+                examples:
+                  - ads:
+                      - advertiser_id: AR14106062795078369281
+                        creative_id: CR14003695067076755457
+                        original_url: https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR14003695067076755457?region=anywhere
+                        variants:
+                          - content: <img src="https://tpc.googlesyndication.com/archive/simgad/6399633577457746150" height="173" width="380">
+                            height: 173
+                            width: 380
+                        start: 2024-07-03
+                        last_seen: 2025-03-06
+                        advertiser_name: LeadMagic Inc
+                        format: Text
+                      - advertiser_id: AR14106062795078369281
+                        creative_id: CR16065875974473908225
+                        original_url: https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR16065875974473908225?region=anywhere
+                        variants:
+                          - content: <img src="https://tpc.googlesyndication.com/archive/simgad/14075255850026292628" height="173" width="380">
+                            height: 173
+                            width: 380
+                        start: 2025-02-04
+                        last_seen: 2025-03-06
+                        advertiser_name: LeadMagic Inc
+                        format: Text
+                    credits_consumed: 2
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/ads/meta-ads-search:
     post:
       summary: Meta Ads Search
@@ -6522,21 +7061,21 @@ paths:
                   type: string
                   description: Company domain name
                   default: leadmagic.io
-                  example: leadmagic.io
+                  examples:
+                    - leadmagic.io
                 company_name:
                   type: string
                   description: Company name
                   default: leadmagic
-                  example: leadmagic
+                  examples:
+                    - leadmagic
                 limit:
                   type: integer
                   minimum: 1
                   maximum: 100
-                  description: >-
-                    Maximum number of ads to return. Because you are charged 1 credit
-                    per ad returned, this also caps the credits spent on the request.
-                    Omit to return every ad found.
-                  example: 10
+                  description: Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the credits spent on the request. Omit to return every ad found.
+                  examples:
+                    - 10
       responses:
         "200":
           description: Successful response with ads details
@@ -6547,147 +7086,150 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "Meta Ads retrieved successfully"
+                    examples:
+                      - Meta Ads retrieved successfully
                   credits_consumed:
                     type: number
-                    example: 1
+                    examples:
+                      - 1
                   ads_count:
                     type: integer
-                    example: 1
+                    examples:
+                      - 1
                   ads:
                     type: array
                     description: Array of ad objects (structure varies by ad type)
                     items:
                       type: object
-                example:
-                  message: "Meta Ads retrieved successfully"
-                  credits_consumed: 1
-                  ads_count: 1
-                  ads:
-                    - adid: "0"
-                      adArchiveID: "618153827656899"
-                      archiveTypes: []
-                      categories:
-                        - 0
-                      containsDigitallyCreatedMedia: false
-                      containsSensitiveContent: false
-                      collationCount: 1
-                      collationID: 1015196963820298
-                      currency: ""
-                      endDate: 1741248000
-                      entityType: person_profile
-                      fevInfo: null
-                      finServAdData:
-                        is_deemed_finserv: false
-                        is_limited_delivery: false
-                      gatedType: eligible
-                      hasUserReported: false
-                      hiddenSafetyData: false
-                      hideDataStatus: NONE
-                      impressionsWithIndex:
-                        impressionsText: null
-                        impressionsIndex: -1
-                      isAAAEligible: true
-                      isAdAccountActioned: false
-                      isActive: true
-                      isProfilePage: false
-                      pageID: "105549201674375"
-                      pageInfo: null
-                      pageIsDeleted: false
-                      pageName: Lykkedal Retreat
-                      politicalCountries: []
-                      reachEstimate: null
-                      regionalRegulationData:
-                        finserv:
+                examples:
+                  - message: Meta Ads retrieved successfully
+                    credits_consumed: 1
+                    ads_count: 1
+                    ads:
+                      - adid: "0"
+                        adArchiveID: "618153827656899"
+                        archiveTypes: []
+                        categories:
+                          - 0
+                        containsDigitallyCreatedMedia: false
+                        containsSensitiveContent: false
+                        collationCount: 1
+                        collationID: 1015196963820298
+                        currency: ""
+                        endDate: 1741248000
+                        entityType: person_profile
+                        fevInfo: null
+                        finServAdData:
                           is_deemed_finserv: false
                           is_limited_delivery: false
-                        tw_anti_scam:
-                          is_limited_delivery: false
-                      reportCount: null
-                      snapshot:
-                        ad_creative_id: 1159245568945589
-                        cards: []
-                        body_translations: {}
-                        byline: null
-                        caption: ezme.io
-                        cta_text: Buy tickets
-                        dynamic_item_flags: {}
-                        dynamic_versions: null
-                        edited_snapshots: []
-                        effective_authorization_category: NONE
-                        event:
-                          event_promoted_type: external_tickets
-                          event_start_timestamp: 1742130000
-                          event_end_timestamp: 1742137200
-                          event_location: Dalvej 5, Helsinge
-                          event_timezone: Europe/Copenhagen
-                        extra_images: []
-                        extra_links: []
-                        extra_texts: []
-                        extra_videos: []
-                        instagram_shopping_products: []
-                        display_format: event
-                        title: Yin Yoga & Yoga Nidra til LeadMagic
-                        link_description: Dalvej 5, Helsinge
-                        link_url: https://ezme.io/c/xHa/3KPb
-                        page_welcome_message: null
-                        images:
-                          - original_image_url: https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/481787314_4001422706744378_5754827939445302437_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=oLiF-cU0WxgQ7kNvgEM6GgD&_nc_oc=AdgH2C1dxKtFX8-Nb0xC8YJj9RAGxYUVx4s72-vlBMvSF8NqRSDRTgLtQ49bxn4GKvU&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYFCcwS06k5-Zs4REiVNPyDBnDiH2m3ry6__l8b-xYVnNw&oe=67D010D7
-                            resized_image_url: https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/482055202_1183219813458252_5286390622516633466_n.jpg?stp=dst-jpg_s600x600_tt6&_nc_cat=106&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=UpMVtSZb0FoQ7kNvgGYCYSO&_nc_oc=AdioNK9N0BC6jFliPpZBoCB7q8c6RxzPm1sjxYyWN8gW1fEzj5ort06-PEXPS9aRQtY&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYET5FXrho887m4dU5OxwmVKM8nNNYMDyPzbcrFDRHPNkQ&oe=67CFD900
-                            watermarked_resized_image_url: ""
-                            image_crops: {}
-                        videos: []
-                        creation_time: 1741291804
-                        page_id: 105549201674375
-                        page_name: Lykkedal Retreat
-                        page_profile_picture_url: https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482021866_1335378004273354_6611332374691484765_n.jpg?stp=dst-jpg_s60x60_tt6&_nc_cat=107&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=9OkGTrz7rR0Q7kNvgG57RTD&_nc_oc=AdhR7nxSqcwLeXf4E6zMven92LUORzNF9f6UG5HdXPkNcCJwnCvuJsEFIkd2qEkf1mc&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYHvvv7TVyYBBZbUWdFtsMMF1Zw19HFrCguT8PizFkDG-w&oe=67CFF9CB
-                        page_categories:
-                          "1215982301785137": Meditation Center
-                        page_entity_type: person_profile
-                        page_is_profile_page: false
-                        instagram_actor_name: 🔆 ET LIV I BALANCE 🔆
-                        instagram_profile_pic_url: https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482221977_1473904650233662_1812261223336634635_n.jpg?_nc_cat=102&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=pt8glJ939ioQ7kNvgEhv2uO&_nc_oc=Adi7fFY9dROfonTLhbM1HQhTr-sBDcj7xGQeKttehNVcjEKjKkBqWDm69xB9k8lQLk4&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYH7uq0g9Ag0DFiPvgZdXyt_1LXYO8ZrWuCq--rMrhWQfw&oe=67CFE12C
-                        instagram_url: ""
-                        instagram_handle: ""
-                        is_reshared: false
-                        version: 3
-                        body:
-                          context: {}
-                          markup:
-                            __html: "🌿 Yin Yoga &amp; LeadMagic Meditation i jurten på Lykkedal Retreat 🌿<br /> <br /> Trænger du til en dyb pause, hvor krop og sind får lov at give slip og finde ro? ✨<br /> <br /> 🧘‍♀️ Yin Yoga er en blid, meditativ yogaform, der arbejder med kroppens bindevæv, led og energibaner gennem lange, rolige stræk. Stillingerne holdes i flere minutter, så kroppen får tid til at slippe spændinger og finde dybere afslapning. Alle kan være med – uanset erfaring.<br /> <br /> 🎶 LeadMagic Meditation fordyber din afslapning gennem dybe, vibrerende lyde, der beroliger nervesystemet og inviterer sindet til at give slip. Mange oplever en følelse af lethed, ro og fornyet energi efter en meditation.<br /> <br /> 📅 Dato: Søndag d. 16. marts<br /> ⏰ Tid: Kl. 14:00 - 16:00<br /> 📍 Sted: Lykkedal Retreat, Dalvej 5, Helsinge<br />       Pris: 275 kr.<br /> <br /> 🌿 Efter workshoppen byder vi på økologisk urtete og lækre snacks i vores hyggelige skovcafé. Her kan du nyde en stille stund og mærke effekten af din praksis. Tag en mindful gåtur i naturen og hils på dyrene – en smuk måde at afslutte dagen på.<br /> <br /> 🔔 Alle er velkomne – uanset erfaring! 🔔<br /> <br /> 💚 Tilmelding &amp; info:<br /> 📩 Send besked til Natassia på info&#064;lykkedalretreat.dk eller tlf. 2390 7473<br /> <br /> 🌾 Lykkedal Retreat – en perle i Nordsjællands natur 🌾<br /> Her finder du åbne marker med heste, høje træer og den smukke gamle Pibe Mølle. Workshoppen afholdes i den stemningsfulde jurt/rundsal, hvor du kan fordybe dig i ro og nærvær.<br /> <br /> ✨ Tidligere deltagere siger:<br /> 🌟 &quot;Lykkedal er et åndehul i naturen&quot;<br /> 🌟 &quot;Jeg kom hjem i mig selv&quot;<br /> 🌟 &quot;Jeg havde glemt, hvor meget jeg savner naturen&quot;<br /> <br /> 📩 Book din plads i dag – vi glæder os til at byde dig velkommen!<br /> <br /> #YinYoga #LeadMagicMeditation #LykkedalRetreat #IndreRo #NaturligBalance #Mindfulness #Selvforkælelse #TidTilDigSelv"
-                          callerHash: c339298372ed2a9ebf3ad02f136b05d2
-                        brazil_tax_id: null
-                        branded_content: null
-                        current_page_name: Lykkedal Retreat
-                        disclaimer_label: null
-                        page_like_count: 1198
-                        page_profile_uri: https://facebook.com/LykkedalRetreat
-                        page_is_deleted: false
-                        root_reshared_post: null
-                        cta_type: BUY_TICKETS
-                        additional_info: null
-                        ec_certificates: null
-                        country_iso_code: null
-                        instagram_branded_content: null
-                      spend: null
-                      startDate: 1741248000
-                      stateMediaRunLabel: null
-                      publisherPlatform:
-                        - facebook
-                        - instagram
-                      menuItems: []
-                      targetedOrReachedCountries: []
-                      totalActiveTime: 7915
+                        gatedType: eligible
+                        hasUserReported: false
+                        hiddenSafetyData: false
+                        hideDataStatus: NONE
+                        impressionsWithIndex:
+                          impressionsText: null
+                          impressionsIndex: -1
+                        isAAAEligible: true
+                        isAdAccountActioned: false
+                        isActive: true
+                        isProfilePage: false
+                        pageID: "105549201674375"
+                        pageInfo: null
+                        pageIsDeleted: false
+                        pageName: Lykkedal Retreat
+                        politicalCountries: []
+                        reachEstimate: null
+                        regionalRegulationData:
+                          finserv:
+                            is_deemed_finserv: false
+                            is_limited_delivery: false
+                          tw_anti_scam:
+                            is_limited_delivery: false
+                        reportCount: null
+                        snapshot:
+                          ad_creative_id: 1159245568945589
+                          cards: []
+                          body_translations: {}
+                          byline: null
+                          caption: ezme.io
+                          cta_text: Buy tickets
+                          dynamic_item_flags: {}
+                          dynamic_versions: null
+                          edited_snapshots: []
+                          effective_authorization_category: NONE
+                          event:
+                            event_promoted_type: external_tickets
+                            event_start_timestamp: 1742130000
+                            event_end_timestamp: 1742137200
+                            event_location: Dalvej 5, Helsinge
+                            event_timezone: Europe/Copenhagen
+                          extra_images: []
+                          extra_links: []
+                          extra_texts: []
+                          extra_videos: []
+                          instagram_shopping_products: []
+                          display_format: event
+                          title: Yin Yoga & Yoga Nidra til LeadMagic
+                          link_description: Dalvej 5, Helsinge
+                          link_url: https://ezme.io/c/xHa/3KPb
+                          page_welcome_message: null
+                          images:
+                            - original_image_url: https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/481787314_4001422706744378_5754827939445302437_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=oLiF-cU0WxgQ7kNvgEM6GgD&_nc_oc=AdgH2C1dxKtFX8-Nb0xC8YJj9RAGxYUVx4s72-vlBMvSF8NqRSDRTgLtQ49bxn4GKvU&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYFCcwS06k5-Zs4REiVNPyDBnDiH2m3ry6__l8b-xYVnNw&oe=67D010D7
+                              resized_image_url: https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/482055202_1183219813458252_5286390622516633466_n.jpg?stp=dst-jpg_s600x600_tt6&_nc_cat=106&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=UpMVtSZb0FoQ7kNvgGYCYSO&_nc_oc=AdioNK9N0BC6jFliPpZBoCB7q8c6RxzPm1sjxYyWN8gW1fEzj5ort06-PEXPS9aRQtY&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYET5FXrho887m4dU5OxwmVKM8nNNYMDyPzbcrFDRHPNkQ&oe=67CFD900
+                              watermarked_resized_image_url: ""
+                              image_crops: {}
+                          videos: []
+                          creation_time: 1741291804
+                          page_id: 105549201674375
+                          page_name: Lykkedal Retreat
+                          page_profile_picture_url: https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482021866_1335378004273354_6611332374691484765_n.jpg?stp=dst-jpg_s60x60_tt6&_nc_cat=107&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=9OkGTrz7rR0Q7kNvgG57RTD&_nc_oc=AdhR7nxSqcwLeXf4E6zMven92LUORzNF9f6UG5HdXPkNcCJwnCvuJsEFIkd2qEkf1mc&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYHvvv7TVyYBBZbUWdFtsMMF1Zw19HFrCguT8PizFkDG-w&oe=67CFF9CB
+                          page_categories:
+                            "1215982301785137": Meditation Center
+                          page_entity_type: person_profile
+                          page_is_profile_page: false
+                          instagram_actor_name: 🔆 ET LIV I BALANCE 🔆
+                          instagram_profile_pic_url: https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482221977_1473904650233662_1812261223336634635_n.jpg?_nc_cat=102&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=pt8glJ939ioQ7kNvgEhv2uO&_nc_oc=Adi7fFY9dROfonTLhbM1HQhTr-sBDcj7xGQeKttehNVcjEKjKkBqWDm69xB9k8lQLk4&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYH7uq0g9Ag0DFiPvgZdXyt_1LXYO8ZrWuCq--rMrhWQfw&oe=67CFE12C
+                          instagram_url: ""
+                          instagram_handle: ""
+                          is_reshared: false
+                          version: 3
+                          body:
+                            context: {}
+                            markup:
+                              __html: "🌿 Yin Yoga &amp; LeadMagic Meditation i jurten på Lykkedal Retreat 🌿<br /> <br /> Trænger du til en dyb pause, hvor krop og sind får lov at give slip og finde ro? ✨<br /> <br /> 🧘‍♀️ Yin Yoga er en blid, meditativ yogaform, der arbejder med kroppens bindevæv, led og energibaner gennem lange, rolige stræk. Stillingerne holdes i flere minutter, så kroppen får tid til at slippe spændinger og finde dybere afslapning. Alle kan være med – uanset erfaring.<br /> <br /> 🎶 LeadMagic Meditation fordyber din afslapning gennem dybe, vibrerende lyde, der beroliger nervesystemet og inviterer sindet til at give slip. Mange oplever en følelse af lethed, ro og fornyet energi efter en meditation.<br /> <br /> 📅 Dato: Søndag d. 16. marts<br /> ⏰ Tid: Kl. 14:00 - 16:00<br /> 📍 Sted: Lykkedal Retreat, Dalvej 5, Helsinge<br />       Pris: 275 kr.<br /> <br /> 🌿 Efter workshoppen byder vi på økologisk urtete og lækre snacks i vores hyggelige skovcafé. Her kan du nyde en stille stund og mærke effekten af din praksis. Tag en mindful gåtur i naturen og hils på dyrene – en smuk måde at afslutte dagen på.<br /> <br /> 🔔 Alle er velkomne – uanset erfaring! 🔔<br /> <br /> 💚 Tilmelding &amp; info:<br /> 📩 Send besked til Natassia på info&#064;lykkedalretreat.dk eller tlf. 2390 7473<br /> <br /> 🌾 Lykkedal Retreat – en perle i Nordsjællands natur 🌾<br /> Her finder du åbne marker med heste, høje træer og den smukke gamle Pibe Mølle. Workshoppen afholdes i den stemningsfulde jurt/rundsal, hvor du kan fordybe dig i ro og nærvær.<br /> <br /> ✨ Tidligere deltagere siger:<br /> 🌟 &quot;Lykkedal er et åndehul i naturen&quot;<br /> 🌟 &quot;Jeg kom hjem i mig selv&quot;<br /> 🌟 &quot;Jeg havde glemt, hvor meget jeg savner naturen&quot;<br /> <br /> 📩 Book din plads i dag – vi glæder os til at byde dig velkommen!<br /> <br /> #YinYoga #LeadMagicMeditation #LykkedalRetreat #IndreRo #NaturligBalance #Mindfulness #Selvforkælelse #TidTilDigSelv"
+                            callerHash: c339298372ed2a9ebf3ad02f136b05d2
+                          brazil_tax_id: null
+                          branded_content: null
+                          current_page_name: Lykkedal Retreat
+                          disclaimer_label: null
+                          page_like_count: 1198
+                          page_profile_uri: https://facebook.com/LykkedalRetreat
+                          page_is_deleted: false
+                          root_reshared_post: null
+                          cta_type: BUY_TICKETS
+                          additional_info: null
+                          ec_certificates: null
+                          country_iso_code: null
+                          instagram_branded_content: null
+                        spend: null
+                        startDate: 1741248000
+                        stateMediaRunLabel: null
+                        publisherPlatform:
+                          - facebook
+                          - instagram
+                        menuItems: []
+                        targetedOrReachedCountries: []
+                        totalActiveTime: 7915
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/ads/b2b-ads-search:
     post:
       summary: B2B Search Ads
@@ -6706,22 +7248,21 @@ paths:
                   type: string
                   description: Company domain name
                   default: gong.io
-                  example: gong.io
+                  examples:
+                    - gong.io
                 company_name:
                   type: string
                   description: Company name
                   default: gong
-                  example: gong
+                  examples:
+                    - gong
                 limit:
                   type: integer
                   minimum: 1
                   maximum: 100
-                  description: >-
-                    Maximum number of ads to return. Because you are charged 1 credit
-                    per ad returned, this also caps the per-ad credits spent on the
-                    request; the 1 base credit per search still applies. Omit to return
-                    every ad found.
-                  example: 10
+                  description: Maximum number of ads to return. Because you are charged 1 credit per ad returned, this also caps the per-ad credits spent on the request; the 1 base credit per search still applies. Omit to return every ad found.
+                  examples:
+                    - 10
       responses:
         "200":
           description: Successful response with ads details
@@ -6732,13 +7273,16 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "B2B ads found for the given company."
+                    examples:
+                      - B2B ads found for the given company.
                   credits_consumed:
                     type: number
-                    example: 25
+                    examples:
+                      - 25
                   ads_count:
                     type: integer
-                    example: 24
+                    examples:
+                      - 24
                   company:
                     type: object
                     properties:
@@ -6815,41 +7359,41 @@ paths:
                         landing_page_url:
                           type: string
                           nullable: true
-                example:
-                  message: "B2B ads found for the given company."
-                  credits_consumed: 25
-                  ads_count: 24
-                  company:
-                    name: gong
-                    domain: gong.io
-                    industry: computer software
-                    company_size: 1001-5000
-                    linkedin_url: /company/gong-io
-                    logo_url: https://logo.leadmagic.io/gong.io
-                    city: san francisco
-                    state: california
-                    country: united states
-                  ads:
-                    - ad_id: "1436673673"
-                      headline: null
-                      description: See how revenue teams use Gong to win more deals.
-                      content: See how revenue teams use Gong to win more deals.
-                      link: "1436673673"
-                      ad_url: /ad-library/detail/1436673673
-                      ad_type: Document Ad
-                      creative_type: SPONSORED_UPDATE_NATIVE_DOCUMENT
-                      advertiser: Gong
-                      advertiser_linkedin_url: /company/gong-io
+                examples:
+                  - message: B2B ads found for the given company.
+                    credits_consumed: 25
+                    ads_count: 24
+                    company:
+                      name: gong
+                      domain: gong.io
+                      industry: computer software
+                      company_size: 1001-5000
+                      linkedin_url: /company/gong-io
+                      logo_url: https://logo.leadmagic.io/gong.io
+                      city: san francisco
+                      state: california
+                      country: united states
+                    ads:
+                      - ad_id: "1436673673"
+                        headline: null
+                        description: See how revenue teams use Gong to win more deals.
+                        content: See how revenue teams use Gong to win more deals.
+                        link: "1436673673"
+                        ad_url: /ad-library/detail/1436673673
+                        ad_type: Document Ad
+                        creative_type: SPONSORED_UPDATE_NATIVE_DOCUMENT
+                        advertiser: Gong
+                        advertiser_linkedin_url: /company/gong-io
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/ads/b2b-ads-details:
     post:
       summary: B2B Ad Details
@@ -6867,7 +7411,8 @@ paths:
                 ad_url:
                   type: string
                   description: B2B ad library URL, path (/ad-library/detail/{id}), or numeric ad ID
-                  example: "1436673673"
+                  examples:
+                    - "1436673673"
               required:
                 - ad_url
       responses:
@@ -6880,10 +7425,12 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "Ad details retrieved successfully"
+                    examples:
+                      - Ad details retrieved successfully
                   credits_consumed:
                     type: number
-                    example: 2
+                    examples:
+                      - 2
                   company:
                     type: object
                     properties:
@@ -6975,37 +7522,34 @@ paths:
                       raw:
                         type: object
                         description: Original ad payload for unmapped fields
-                example:
-                  message: "Ad details retrieved successfully"
-                  credits_consumed: 2
-                  company:
-                    name: Gong
-                    linkedin_url: /company/gong-io
-                  ad_details:
-                    ad_id: "1436673673"
-                    content: See how revenue teams use Gong to win more deals.
-                    link: "1436673673"
-                    ad_url: /ad-library/detail/1436673673
-                    ad_type: Document Ad
-                    creative_type: SPONSORED_UPDATE_NATIVE_DOCUMENT
-                    advertiser: Gong
-                    advertiser_linkedin_url: /company/gong-io
-                    raw: {}
+                examples:
+                  - message: Ad details retrieved successfully
+                    credits_consumed: 2
+                    company:
+                      name: Gong
+                      linkedin_url: /company/gong-io
+                    ad_details:
+                      ad_id: "1436673673"
+                      content: See how revenue teams use Gong to win more deals.
+                      link: "1436673673"
+                      ad_url: /ad-library/detail/1436673673
+                      ad_type: Document Ad
+                      creative_type: SPONSORED_UPDATE_NATIVE_DOCUMENT
+                      advertiser: Gong
+                      advertiser_linkedin_url: /company/gong-io
+                      raw: {}
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
-  # ============================================================
-  # Bulk Jobs Endpoints (real /bulk/* surface)
-  # ============================================================
+          $ref: "#/components/responses/InternalServerError"
   /bulk/submit:
     post:
       summary: Submit Bulk Job
@@ -7018,37 +7562,39 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BulkSubmissionRequest'
-            example:
-              product: email_finder
-              rows:
-                - profile_url: https://example.com/in/jane-doe
-                  company_name: LeadMagic
-              callback:
-                url: https://hooks.example.com/leadmagic/bulk
-                events:
-                  - completed
+              $ref: "#/components/schemas/BulkSubmissionRequest"
+            examples:
+              default:
+                value:
+                  product: email_finder
+                  rows:
+                    - profile_url: https://example.com/in/jane-doe
+                      company_name: LeadMagic
+                  callback:
+                    url: https://hooks.example.com/leadmagic/bulk
+                    events:
+                      - completed
       responses:
         "202":
           description: Bulk job accepted and queued for processing.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BulkSubmissionResponse'
+                $ref: "#/components/schemas/BulkSubmissionResponse"
         "400":
-          description: "Bad request. The request body failed validation, or a provided URL failed SSRF validation (SSRF_VALIDATION_FAILED)."
+          description: Bad request. The request body failed validation, or a provided URL failed SSRF validation (SSRF_VALIDATION_FAILED).
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/BadRequest'
+                $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "402":
-          $ref: '#/components/responses/PaymentRequired'
+          $ref: "#/components/responses/PaymentRequired"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /bulk/jobs:
     get:
       summary: List Bulk Jobs
@@ -7093,13 +7639,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobsListResponse'
+                $ref: "#/components/schemas/JobsListResponse"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /bulk/jobs/{jobId}:
     get:
       summary: Get Bulk Job Status
@@ -7115,64 +7661,68 @@ paths:
           schema:
             type: string
             format: uuid
-          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          examples:
+            default:
+              value: a1b2c3d4-e5f6-7890-abcd-ef1234567890
       responses:
         "200":
           description: Current status of the requested bulk job.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobDetailResponse'
-              example:
-                job_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-                status: processing
-                products:
-                  - email_finder
-                submission_product: email_finder
-                submission_endpoint: null
-                execution_mode: null
-                total_rows: 5000
-                processed_items: 2125
-                succeeded_items: 2080
-                failed_items: 45
-                skipped_items: 0
-                total_credits_consumed: "2080.00"
-                total_duration_ms: null
-                created_at: 2026-07-09T14:30:00.000Z
-                started_at: 2026-07-09T14:30:05.000Z
-                completed_at: null
-                last_progress_at: 2026-07-09T14:35:12.000Z
-                file_name: q3-contacts.csv
-                callback_url: https://hooks.example.com/leadmagic/bulk
-                callback_event: completed
-                priority: 0
-                output_transform: null
-                links:
-                  statusUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890?token=...
-                  streamUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stream?token=...
-                  wsUrl: wss://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/ws?token=...
-                  resultsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/results?token=...
-                  rowsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rows?token=...
-                  errorsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/errors?token=...
-                  eventsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events?token=...
-                  eventsExportUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events/export?token=...
-                  logsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/logs?token=...
-                  downloadUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/download?token=...
-                  progressUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/progress?token=...
-                  token: prt_abc123...
-                  exp: 1752259200
+                $ref: "#/components/schemas/JobDetailResponse"
+              examples:
+                default:
+                  value:
+                    job_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                    status: processing
+                    products:
+                      - email_finder
+                    submission_product: email_finder
+                    submission_endpoint: null
+                    execution_mode: null
+                    total_rows: 5000
+                    processed_items: 2125
+                    succeeded_items: 2080
+                    failed_items: 45
+                    skipped_items: 0
+                    total_credits_consumed: "2080.00"
+                    total_duration_ms: null
+                    created_at: 2026-07-09T14:30:00.000Z
+                    started_at: 2026-07-09T14:30:05.000Z
+                    completed_at: null
+                    last_progress_at: 2026-07-09T14:35:12.000Z
+                    file_name: q3-contacts.csv
+                    callback_url: https://hooks.example.com/leadmagic/bulk
+                    callback_event: completed
+                    priority: 0
+                    output_transform: null
+                    links:
+                      statusUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890?token=...
+                      streamUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stream?token=...
+                      wsUrl: wss://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/ws?token=...
+                      resultsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/results?token=...
+                      rowsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rows?token=...
+                      errorsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/errors?token=...
+                      eventsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events?token=...
+                      eventsExportUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events/export?token=...
+                      logsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/logs?token=...
+                      downloadUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/download?token=...
+                      progressUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/progress?token=...
+                      token: prt_abc123...
+                      exp: 1752259200
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /bulk/jobs/{jobId}/review:
     post:
       summary: Review Bulk Job (Cancel or Approve)
-      description: "Cancel a queued or processing bulk job by submitting {\"action\": \"reject\"}, or resume a paused job with {\"action\": \"approve\"}. Completed or failed jobs cannot be reviewed."
+      description: 'Cancel a queued or processing bulk job by submitting {"action": "reject"}, or resume a paused job with {"action": "approve"}. Completed or failed jobs cannot be reviewed.'
       operationId: bulk-job-review
       tags:
         - Bulk Jobs
@@ -7184,7 +7734,9 @@ paths:
           schema:
             type: string
             format: uuid
-          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+          examples:
+            default:
+              value: a1b2c3d4-e5f6-7890-abcd-ef1234567890
       requestBody:
         required: true
         content:
@@ -7199,23 +7751,25 @@ paths:
                   enum:
                     - approve
                     - reject
-            example:
-              action: reject
+            examples:
+              default:
+                value:
+                  action: reject
       responses:
         "200":
           description: Review action confirmed.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ReviewResponse'
+                $ref: "#/components/schemas/ReviewResponse"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /bulk/jobs/{jobId}/results:
     get:
       summary: Get Bulk Job Results
@@ -7257,15 +7811,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobRowsResponse'
+                $ref: "#/components/schemas/JobRowsResponse"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /bulk/jobs/{jobId}/download:
     get:
       summary: Download Bulk Job Results as CSV
@@ -7289,13 +7843,13 @@ paths:
               schema:
                 type: string
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /bulk/capabilities:
     get:
       summary: Get Bulk API Capabilities
@@ -7312,7 +7866,7 @@ paths:
                 type: object
                 additionalProperties: true
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /bulk/validate:
     post:
       summary: Validate a Bulk Submission
@@ -7325,7 +7879,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BulkSubmissionRequest'
+              $ref: "#/components/schemas/BulkSubmissionRequest"
       responses:
         "200":
           description: Validation result.
@@ -7335,9 +7889,9 @@ paths:
                 type: object
                 additionalProperties: true
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /bulk/local-leads:
     post:
       summary: Submit a Local Leads Search
@@ -7360,29 +7914,30 @@ paths:
                   description: Search terms. Expanded against every city — one search row per keyword × city pair.
                   items:
                     type: string
-                  example:
-                    - "plumber"
-                    - "hvac contractor"
+                  examples:
+                    - - plumber
+                      - hvac contractor
                 cities:
                   type: array
                   description: Cities to search. Expanded against every keyword.
                   items:
                     type: string
-                  example:
-                    - "Austin"
-                    - "Dallas"
+                  examples:
+                    - - Austin
+                      - Dallas
                 countryCodes:
                   type: array
                   description: Two-letter country code per city, aligned by index. Defaults to `US` when omitted.
                   items:
                     type: string
-                  example:
-                    - "US"
-                    - "US"
+                  examples:
+                    - - US
+                      - US
                 fileName:
                   type: string
                   description: Label for the resulting job, shown in the dashboard.
-                  example: "texas-trades"
+                  examples:
+                    - texas-trades
                 magicKey:
                   type: string
                   description: Promotional key that waives credit charges when valid.
@@ -7392,11 +7947,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BulkSubmissionResponse'
+                $ref: "#/components/schemas/BulkSubmissionResponse"
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /bulk/progress:
     get:
       summary: Get Lightweight Bulk Job Progress
@@ -7426,16 +7981,18 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                status: processing
-                processed_items: 2125
-                total_rows: 5000
-                succeeded_items: 2080
-                failed_items: 45
+              examples:
+                default:
+                  value:
+                    status: processing
+                    processed_items: 2125
+                    total_rows: 5000
+                    succeeded_items: 2080
+                    failed_items: 45
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /bulk/jobs/{jobId}/errors:
     get:
       summary: Get Failed Bulk Job Rows
@@ -7444,7 +8001,7 @@ paths:
       tags:
         - Bulk Jobs
       parameters:
-        - $ref: '#/components/parameters/BulkJobId'
+        - $ref: "#/components/parameters/BulkJobId"
         - name: limit
           in: query
           required: false
@@ -7477,24 +8034,26 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                rows:
-                  - id: b2c3d4e5-f6a7-8901-bcde-f12345678901
-                    row_index: 42
-                    status: failed
-                    lm_input:
-                      email: invalid-format
-                    lm_output: null
-                    error_message: "Invalid email format: invalid-format"
-                    http_status_code: 422
-                    response_time_ms: 45
-                    completed_at: 2026-07-09T14:30:06.000Z
-                limit: 100
-                offset: 0
+              examples:
+                default:
+                  value:
+                    rows:
+                      - id: b2c3d4e5-f6a7-8901-bcde-f12345678901
+                        row_index: 42
+                        status: failed
+                        lm_input:
+                          email: invalid-format
+                        lm_output: null
+                        error_message: "Invalid email format: invalid-format"
+                        http_status_code: 422
+                        response_time_ms: 45
+                        completed_at: 2026-07-09T14:30:06.000Z
+                    limit: 100
+                    offset: 0
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /bulk/jobs/{jobId}/events:
     get:
       summary: Get Bulk Job Events
@@ -7503,7 +8062,7 @@ paths:
       tags:
         - Bulk Jobs
       parameters:
-        - $ref: '#/components/parameters/BulkJobId'
+        - $ref: "#/components/parameters/BulkJobId"
         - name: limit
           in: query
           required: false
@@ -7521,26 +8080,28 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                events:
-                  - event_id: e1f2g3h4-i5j6-7890-k1mn-opqrstuvwxyz
-                    job_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-                    event_type: row.failed
-                    source: queue-consumer
-                    level: error
-                    message: "Row 42 failed: Invalid email format"
-                    stage: enrichment
-                    status: processing
-                    details:
-                      row_index: 42
-                      error: Invalid email format
-                      http_status_code: 422
-                    created_at: 2026-07-09T14:30:06.000Z
-                limit: 50
+              examples:
+                default:
+                  value:
+                    events:
+                      - event_id: e1f2g3h4-i5j6-7890-k1mn-opqrstuvwxyz
+                        job_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                        event_type: row.failed
+                        source: queue-consumer
+                        level: error
+                        message: "Row 42 failed: Invalid email format"
+                        stage: enrichment
+                        status: processing
+                        details:
+                          row_index: 42
+                          error: Invalid email format
+                          http_status_code: 422
+                        created_at: 2026-07-09T14:30:06.000Z
+                    limit: 50
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /bulk/jobs/{jobId}/stream:
     get:
       summary: Stream Bulk Job Progress
@@ -7549,7 +8110,7 @@ paths:
       tags:
         - Bulk Jobs
       parameters:
-        - $ref: '#/components/parameters/BulkJobId'
+        - $ref: "#/components/parameters/BulkJobId"
         - name: token
           in: query
           required: false
@@ -7563,9 +8124,9 @@ paths:
               schema:
                 type: string
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /bulk/jobs/{jobId}/pause:
     post:
       summary: Pause a Bulk Job
@@ -7574,14 +8135,14 @@ paths:
       tags:
         - Bulk Jobs
       parameters:
-        - $ref: '#/components/parameters/BulkJobId'
+        - $ref: "#/components/parameters/BulkJobId"
       responses:
         "200":
           description: Job paused.
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /bulk/jobs/{jobId}/resume:
     post:
       summary: Resume a Bulk Job
@@ -7590,14 +8151,14 @@ paths:
       tags:
         - Bulk Jobs
       parameters:
-        - $ref: '#/components/parameters/BulkJobId'
+        - $ref: "#/components/parameters/BulkJobId"
       responses:
         "200":
           description: Job resumed.
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /bulk/jobs/{jobId}/restart:
     post:
       summary: Restart a Bulk Job
@@ -7606,7 +8167,7 @@ paths:
       tags:
         - Bulk Jobs
       parameters:
-        - $ref: '#/components/parameters/BulkJobId'
+        - $ref: "#/components/parameters/BulkJobId"
       requestBody:
         required: false
         content:
@@ -7639,19 +8200,21 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                jobId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-                restarted: true
-                newJobId: null
-                mode: failed_only
-                started: false
-                position: 1
+              examples:
+                default:
+                  value:
+                    jobId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                    restarted: true
+                    newJobId: null
+                    mode: failed_only
+                    started: false
+                    position: 1
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /bulk/jobs/{jobId}/priority:
     patch:
       summary: Update Bulk Job Priority
@@ -7660,7 +8223,7 @@ paths:
       tags:
         - Bulk Jobs
       parameters:
-        - $ref: '#/components/parameters/BulkJobId'
+        - $ref: "#/components/parameters/BulkJobId"
       requestBody:
         required: true
         content:
@@ -7684,18 +8247,17 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                jobId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-                priority: 100
+              examples:
+                default:
+                  value:
+                    jobId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                    priority: 100
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
-  # ============================================================
-  # Batch and Cost Control Endpoints ( /v1/batch/* )
-  # ============================================================
+          $ref: "#/components/responses/NotFound"
   /v1/batch:
     get:
       summary: List Batches
@@ -7743,7 +8305,7 @@ paths:
                 type: object
                 additionalProperties: true
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
     post:
       summary: Submit a Mixed-Product Batch
       description: Submit a batch containing items for one or more enrichment products.
@@ -7812,14 +8374,16 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
-              example:
-                batchId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-                status: accepted
-                items_count: 2
+              examples:
+                default:
+                  value:
+                    batchId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                    status: accepted
+                    items_count: 2
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/batch/{batchId}:
     get:
       summary: Get Batch Status
@@ -7834,7 +8398,9 @@ paths:
           description: Identifier of the batch returned when it was submitted.
           schema:
             type: string
-          example: "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+          examples:
+            default:
+              value: b1c2d3e4-f5a6-7890-bcde-f12345678901
       responses:
         "200":
           description: Batch status.
@@ -7844,9 +8410,9 @@ paths:
                 type: object
                 additionalProperties: true
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /v1/{product}/batch/{batchId}:
     patch:
       summary: Update Batch Metadata
@@ -7861,14 +8427,18 @@ paths:
           description: Enrichment product slug, e.g. `email-finder`. Hyphens and underscores are both accepted.
           schema:
             type: string
-          example: "email-finder"
+          examples:
+            default:
+              value: email-finder
         - name: batchId
           in: path
           required: true
           description: Identifier of the batch returned when it was submitted.
           schema:
             type: string
-          example: "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+          examples:
+            default:
+              value: b1c2d3e4-f5a6-7890-bcde-f12345678901
       requestBody:
         required: true
         content:
@@ -7885,11 +8455,11 @@ paths:
         "200":
           description: Updated batch.
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /v1/batch/campaign/{campaignId}/metrics:
     get:
       summary: Get Campaign Metrics
@@ -7904,7 +8474,9 @@ paths:
           description: Campaign identifier used to group related batches.
           schema:
             type: string
-          example: "c1d2e3f4-a5b6-7890-cdef-123456789012"
+          examples:
+            default:
+              value: c1d2e3f4-a5b6-7890-cdef-123456789012
       responses:
         "200":
           description: Campaign metrics.
@@ -7914,9 +8486,9 @@ paths:
                 type: object
                 additionalProperties: true
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /v1/batch/clients:
     get:
       summary: List Batch Clients
@@ -7933,7 +8505,7 @@ paths:
                 type: object
                 additionalProperties: true
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
     post:
       summary: Create a Batch Client
       description: Create an organization-scoped client for segmenting downstream batch work.
@@ -7952,11 +8524,13 @@ paths:
                 name:
                   type: string
                   description: Unique client identifier (slug). Lowercase, alphanumeric with hyphens.
-                  example: "acme-corp"
+                  examples:
+                    - acme-corp
                 display_name:
                   type: string
                   description: Human-readable display name.
-                  example: "Acme Corporation"
+                  examples:
+                    - Acme Corporation
                 contact_email:
                   type: string
                   format: email
@@ -7991,9 +8565,9 @@ paths:
                 type: object
                 additionalProperties: true
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/batch/clients/{clientId}/metrics:
     get:
       summary: Get Batch Client Metrics
@@ -8009,7 +8583,9 @@ paths:
           schema:
             type: string
             format: uuid
-          example: "d1e2f3a4-b5c6-7890-def1-234567890123"
+          examples:
+            default:
+              value: d1e2f3a4-b5c6-7890-def1-234567890123
       responses:
         "200":
           description: Client metrics.
@@ -8019,9 +8595,9 @@ paths:
                 type: object
                 additionalProperties: true
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /v1/batch/clients/{clientId}/webhooks:
     get:
       summary: List Batch Client Webhooks
@@ -8037,12 +8613,14 @@ paths:
           schema:
             type: string
             format: uuid
-          example: "d1e2f3a4-b5c6-7890-def1-234567890123"
+          examples:
+            default:
+              value: d1e2f3a4-b5c6-7890-def1-234567890123
       responses:
         "200":
           description: Client webhook list.
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
     post:
       summary: Create a Batch Client Webhook
       description: Register a webhook for client batch lifecycle events.
@@ -8057,7 +8635,9 @@ paths:
           schema:
             type: string
             format: uuid
-          example: "d1e2f3a4-b5c6-7890-def1-234567890123"
+          examples:
+            default:
+              value: d1e2f3a4-b5c6-7890-def1-234567890123
       requestBody:
         required: true
         content:
@@ -8069,9 +8649,9 @@ paths:
         "201":
           description: Webhook created.
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/batch/providers:
     get:
       summary: List External Batch Providers
@@ -8083,7 +8663,7 @@ paths:
         "200":
           description: Provider list with credentials redacted.
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
     post:
       summary: Create an External Batch Provider
       description: Register an HTTPS external enrichment provider.
@@ -8106,12 +8686,14 @@ paths:
                 name:
                   type: string
                   description: Display name for the provider.
-                  example: "acme-enrichment"
+                  examples:
+                    - acme-enrichment
                 baseUrl:
                   type: string
                   format: uri
                   description: HTTPS endpoint to call. Private IP addresses are rejected.
-                  example: "https://api.acme.com/enrich"
+                  examples:
+                    - https://api.acme.com/enrich
                 authType:
                   type: string
                   description: How the credential is presented to the provider.
@@ -8122,7 +8704,8 @@ paths:
                 authCredentialName:
                   type: string
                   description: Header or parameter name carrying the credential.
-                  example: "X-API-Key"
+                  examples:
+                    - X-API-Key
                 authCredentialValue:
                   type: string
                   description: Credential value. Redacted in every response.
@@ -8148,14 +8731,15 @@ paths:
                 healthCheckExpectedStatus:
                   type: integer
                   description: HTTP status treated as healthy.
-                  example: 200
+                  examples:
+                    - 200
       responses:
         "201":
           description: Provider created with credentials redacted.
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/batch/preview-cost:
     post:
       summary: Preview Batch Cost
@@ -8168,28 +8752,30 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PreviewCostRequest'
-            example:
-              items:
-                - product: email_finder
-                  input:
-                    profile_url: https://example.com/in/jane-doe
-              budget_user_id: user_abc123
+              $ref: "#/components/schemas/PreviewCostRequest"
+            examples:
+              default:
+                value:
+                  items:
+                    - product: email_finder
+                      input:
+                        profile_url: https://example.com/in/jane-doe
+                  budget_user_id: user_abc123
       responses:
         "200":
           description: Cost estimate returned (no credits consumed).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PreviewCostResponse'
+                $ref: "#/components/schemas/PreviewCostResponse"
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
         "500":
-          $ref: '#/components/responses/InternalServerError'
+          $ref: "#/components/responses/InternalServerError"
   /v1/batch/budgets:
     post:
       summary: Create Credit Budget
@@ -8225,26 +8811,28 @@ paths:
                 alert_email:
                   type: string
                   format: email
-            example:
-              scope: user
-              scope_value: user_abc123
-              max_credits: 10000
-              period: monthly
-              alert_threshold_pct: 0.8
-              alert_email: ops@example.com
+            examples:
+              default:
+                value:
+                  scope: user
+                  scope_value: user_abc123
+                  max_credits: 10000
+                  period: monthly
+                  alert_threshold_pct: 0.8
+                  alert_email: ops@example.com
       responses:
         "201":
           description: Budget created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Budget'
+                $ref: "#/components/schemas/Budget"
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "429":
-          $ref: '#/components/responses/RateLimitExceeded'
+          $ref: "#/components/responses/RateLimitExceeded"
     get:
       summary: List Credit Budgets
       description: List all credit budgets for the authenticated account.
@@ -8259,9 +8847,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Budget'
+                  $ref: "#/components/schemas/Budget"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/batch/budgets/status:
     get:
       summary: Get Budget Status
@@ -8277,9 +8865,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/BudgetStatus'
+                  $ref: "#/components/schemas/BudgetStatus"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/batch/budgets/{id}:
     patch:
       summary: Update Credit Budget
@@ -8294,7 +8882,9 @@ paths:
           description: Identifier of the credit budget.
           schema:
             type: string
-          example: "bg_4a7d2e9c1f60"
+          examples:
+            default:
+              value: bg_4a7d2e9c1f60
       requestBody:
         required: true
         content:
@@ -8316,11 +8906,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Budget'
+                $ref: "#/components/schemas/Budget"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
     delete:
       summary: Delete Credit Budget
       description: Hard-delete a credit budget.
@@ -8334,14 +8924,16 @@ paths:
           description: Identifier of the credit budget.
           schema:
             type: string
-          example: "bg_4a7d2e9c1f60"
+          examples:
+            default:
+              value: bg_4a7d2e9c1f60
       responses:
         "200":
           description: Budget deleted.
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          $ref: '#/components/responses/NotFound'
+          $ref: "#/components/responses/NotFound"
   /v1/batch/suppression-lists:
     post:
       summary: Create Suppression List
@@ -8365,21 +8957,23 @@ paths:
                   type: array
                   items:
                     type: string
-            example:
-              list_id: bounced-2026-q3
-              emails:
-                - bounced1@example.com
+            examples:
+              default:
+                value:
+                  list_id: bounced-2026-q3
+                  emails:
+                    - bounced1@example.com
       responses:
         "201":
           description: Suppression list created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuppressionList'
+                $ref: "#/components/schemas/SuppressionList"
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
     get:
       summary: List Suppression Lists
       description: List all suppression lists for the authenticated account.
@@ -8394,9 +8988,9 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/SuppressionList'
+                  $ref: "#/components/schemas/SuppressionList"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/batch/suppression-lists/{listId}:
     get:
       summary: Get Suppression List
@@ -8411,7 +9005,9 @@ paths:
           description: Identifier of the suppression list.
           schema:
             type: string
-          example: "sl_9f2c1d7e4b8a"
+          examples:
+            default:
+              value: sl_9f2c1d7e4b8a
         - name: limit
           in: query
           schema:
@@ -8429,9 +9025,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuppressionList'
+                $ref: "#/components/schemas/SuppressionList"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
     delete:
       summary: Delete Suppression List
       description: Delete an entire suppression list.
@@ -8445,12 +9041,14 @@ paths:
           description: Identifier of the suppression list.
           schema:
             type: string
-          example: "sl_9f2c1d7e4b8a"
+          examples:
+            default:
+              value: sl_9f2c1d7e4b8a
       responses:
         "200":
           description: List deleted.
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
   /v1/batch/suppression-lists/{listId}/emails:
     post:
       summary: Add Emails to Suppression List
@@ -8465,7 +9063,9 @@ paths:
           description: Identifier of the suppression list.
           schema:
             type: string
-          example: "sl_9f2c1d7e4b8a"
+          examples:
+            default:
+              value: sl_9f2c1d7e4b8a
       requestBody:
         required: true
         content:
@@ -8483,9 +9083,9 @@ paths:
         "200":
           description: Emails added.
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"
     delete:
       summary: Remove Emails from Suppression List
       description: Remove emails from a suppression list.
@@ -8499,7 +9099,9 @@ paths:
           description: Identifier of the suppression list.
           schema:
             type: string
-          example: "sl_9f2c1d7e4b8a"
+          examples:
+            default:
+              value: sl_9f2c1d7e4b8a
       requestBody:
         required: true
         content:
@@ -8517,6 +9119,6 @@ paths:
         "200":
           description: Emails removed.
         "400":
-          $ref: '#/components/responses/BadRequest'
+          $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: '#/components/responses/Unauthorized'
+          $ref: "#/components/responses/Unauthorized"

--- a/leadmagic-openapi-3.1.yaml
+++ b/leadmagic-openapi-3.1.yaml
@@ -1,542 +1,1321 @@
 openapi: 3.1.0
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 info:
   title: LeadMagic API
-  version: 1.5.0
-  description: 'A clean, consistent, and well-documented API to access LeadMagic''s
-    services, including email finding, validation, company and professional profile
-    enrichment, and advertisement searching.
+  version: "1.4.35"
+  description: |
+    # LeadMagic API Documentation
 
+    The LeadMagic API provides comprehensive B2B data enrichment services including email validation, email finding, profile search, company intelligence, and more.
 
-    **Important**: Current public docs are not fully uniform on field naming. Some
-    endpoints use snake_case while others show mixed or camelCase response fields.
+    ## Quick Start
 
-    '
+    1. Get your API key from the [LeadMagic Dashboard](https://app.leadmagic.io)
+    2. Add the `X-API-Key` header to all requests
+    3. Start enriching your data!
+
+    ## Base URL
+
+    All API requests should be made to: `https://api.leadmagic.io`
+
+    ## Rate Limits
+
+    Each endpoint has specific rate limits (requests per minute). Exceeding limits returns a `429 Too Many Requests` response.
+
+    ## Fair Use
+
+    All API use is subject to LeadMagic [Fair Use](https://leadmagic.io/legal/terms#fair-use). For Email Finder and similar enrichment endpoints, a sustained find rate below **10%** may result in throttling, reduced limits, suspension, or termination — including when you still have prepaid credits. Email Finder and Email Validation may have different published rate limits and plan tiers. LeadMagic reserves the right to modify Fair Use thresholds, rate limits, product tiering, and enforcement policies as described in our Terms.
+
+    ## Credits and rollover
+
+    API calls consume credits based on the endpoint used. On eligible **monthly** plans (Essential and above), unused subscription credits may roll over, but your workspace may never hold more than **two months** of your plan's included monthly allocation (2× monthly credits). Credits above that cap expire at each billing reset. **Basic**, **annual billing**, and **custom (negotiated) deals** do not roll over unless your written agreement explicitly includes rollover. See [Terms — Credit Expiration and Rollover](https://leadmagic.io/legal/terms#subscription) and check your balance with `/v1/credits`.
+
+    ## Support
+
+    Contact us at support@leadmagic.io for assistance.
   contact:
-    name: LeadMagic API Support
-    url: https://leadmagic.io
+    name: LeadMagic Support
     email: support@leadmagic.io
-  license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
-  summary: Complete API for LeadMagic data enrichment services
+    url: https://leadmagic.io
+  termsOfService: https://leadmagic.io/legal/terms
 servers:
-- url: https://api.leadmagic.io
-  description: Production API Server
+  - url: https://api.leadmagic.io
+    description: Production API Server
 components:
   securitySchemes:
-    apiKey:
+    ApiKeyAuth:
       type: apiKey
       in: header
       name: X-API-Key
-      description: API key for authentication. Get your API key from your LeadMagic
-        dashboard.
+      description: "Your LeadMagic API key. Header name is case-insensitive (X-API-Key, X-API-KEY, x-api-key all work)."
+  parameters:
+    BulkJobId:
+      name: jobId
+      in: path
+      required: true
+      description: UUID identifier of the bulk job.
+      schema:
+        type: string
+        format: uuid
+      example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  headers:
+    RateLimitLimit:
+      description: Effective organization request ceiling for the current minute.
+      schema:
+        type: integer
+    RateLimitRemaining:
+      description: Requests remaining in the effective organization minute window.
+      schema:
+        type: integer
+    RateLimitReset:
+      description: Unix epoch second when the current minute window resets.
+      schema:
+        type: integer
+    SearchRpsLimit:
+      description: Effective organization sustained Search RPS ceiling.
+      schema:
+        type: integer
+    SearchRpsRemaining:
+      description: Tokens remaining in the current sustained Search RPS window.
+      schema:
+        type: integer
+    SearchRpsReset:
+      description: Unix epoch second when the sustained Search RPS window refills.
+      schema:
+        type: integer
   schemas:
-    Location:
+    # ============================================================
+    # RFC 9457 Problem Details Error Response Format
+    # https://www.rfc-editor.org/rfc/rfc9457
+    # ============================================================
+    ErrorResponse:
       type: object
-      description: Geographic location information
+      description: RFC 9457 Problem Details error response
+      required:
+        - success
+        - errors
       properties:
-        name:
-          type: string
-          examples:
-          - boston, massachusetts, united states
-        locality:
-          type: string
-          examples:
-          - boston
-        region:
-          type: string
-          examples:
-          - massachusetts
-        metro:
-          type: string
-          examples:
-          - boston, massachusetts
-        country:
-          type: string
-          examples:
-          - united states
-        continent:
-          type: string
-          examples:
-          - north america
-        street_address:
-          type: string
-          examples:
-          - 1 Seaport Lane
-        address_line_2:
-          type:
-          - string
-          - 'null'
-        postal_code:
-          type: string
-          examples:
-          - '02210'
-        geo:
-          type: string
-          examples:
-          - 42.35,-71.06
-    DetailedCompany:
-      type: object
-      description: Detailed company information from company search
-      properties:
-        company_name:
-          type: string
-          examples:
-          - LeadMagic
-        company_id:
-          type: integer
-          examples:
-          - 75153174
-        locations:
+        success:
+          type: boolean
+          example: false
+          description: Always false for error responses
+        errors:
           type: array
+          description: Array of error details (typically one, but can be multiple)
+          items:
+            $ref: '#/components/schemas/ErrorDetail'
+        meta:
+          $ref: '#/components/schemas/ResponseMeta'
+    ErrorDetail:
+      type: object
+      description: RFC 9457 compliant error detail
+      required:
+        - type
+        - title
+        - status
+      properties:
+        type:
+          type: string
+          format: uri
+          description: RFC 9457 - URI reference identifying the error type
+          example: "https://api.leadmagic.io/errors/validation_error"
+        title:
+          type: string
+          description: RFC 9457 - Short human-readable summary
+          example: "Request validation failed. Check your input parameters."
+        status:
+          type: integer
+          description: RFC 9457 - HTTP status code
+          example: 400
+        detail:
+          type: string
+          description: RFC 9457 - Human-readable explanation specific to this occurrence
+          example: "The email field is required but was not provided."
+        instance:
+          type: string
+          format: uri-reference
+          description: RFC 9457 - URI reference for this specific occurrence
+          example: "/v1/people/email-validation#req_abc123"
+        code:
+          type: string
+          description: Machine-readable error code for programmatic handling
+          example: "validation_error"
+        param:
+          type: array
+          description: Parameters that caused the error
+          items:
+            type: string
+          example: ["email"]
+        action:
+          type: string
+          description: Suggested action to resolve the error
+          example: "Provide a valid email address in the 'email' field."
+        docs:
+          type: string
+          format: uri
+          description: Link to relevant documentation
+          example: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        context:
+          type: object
+          description: Additional context specific to this error type
+          additionalProperties: true
+    ResponseMeta:
+      type: object
+      description: Metadata included in all responses
+      properties:
+        request_id:
+          type: string
+          format: uuid
+          description: Unique identifier for this request (use for debugging/support)
+          example: "ea6e3248-f4d2-437d-bca3-20881b529129"
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the response was generated
+          example: "2024-02-01T12:00:00.000Z"
+        environment:
+          type: string
+          description: API environment (production, staging)
+          example: "production"
+    # ============================================================
+    # Specific Error Types
+    # ============================================================
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/validation_error"
+            title: "Request validation failed. Check your input parameters."
+            status: 400
+            code: "validation_error"
+            param: ["email"]
+            detail: "Email format is invalid. Expected format: user@domain.com"
+            action: "Provide a valid email address in the 'email' field."
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    MissingFieldError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/missing_required_field"
+            title: "Missing required field: email. Add this field to your request."
+            status: 400
+            code: "missing_required_field"
+            param: ["email"]
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    InvalidJsonError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/invalid_json"
+            title: "Invalid JSON in request body. Check your JSON syntax."
+            status: 400
+            code: "invalid_json"
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    InvalidParameterError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/invalid_parameter"
+            title: "Invalid parameter: experience_level. Valid options: entry, mid, senior, executive."
+            status: 400
+            code: "invalid_parameter"
+            param: ["experience_level"]
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    MissingAuthenticationError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/missing_authentication"
+            title: "Authentication required. Provide a valid API key in the X-API-Key header (case-insensitive)."
+            status: 401
+            code: "missing_authentication"
+            docs: "https://leadmagic.io/docs/v1/authentication"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    InvalidApiKeyError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/invalid_api_key"
+            title: "Invalid API key. The key does not exist or is incorrect."
+            status: 401
+            code: "invalid_api_key"
+            docs: "https://leadmagic.io/docs/v1/authentication"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    InsufficientPermissionsError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/insufficient_permissions"
+            title: "Access denied to this resource. Upgrade your plan or contact support."
+            status: 403
+            code: "insufficient_permissions"
+            docs: "https://leadmagic.io/docs/v1/authentication"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    InsufficientCreditsError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/insufficient_credits"
+            title: "Insufficient credits: need 5, have 2.50. Add credits to continue."
+            status: 402
+            code: "insufficient_credits"
+            detail: "This request requires 5 credit(s) but your account only has 2.50 credits remaining."
+            action: "Add credits to your account at https://app.leadmagic.io/settings/billing or contact support@leadmagic.io for enterprise plans."
+            docs: "https://leadmagic.io/docs/v1/credits"
+            context:
+              credits_required: 5
+              credits_available: 2.50
+              credits_needed: 2.50
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    ResourceNotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/resource_not_found"
+            title: "Resource not found."
+            status: 404
+            code: "resource_not_found"
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    ProfileNotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/profile_not_found"
+            title: "Profile not found or not accessible"
+            status: 404
+            code: "profile_not_found"
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    RateLimitExceededError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/rate_limit_exceeded"
+            title: "Rate limit exceeded: 600 requests per 1 minute. Wait and try again."
+            status: 429
+            code: "rate_limit_exceeded"
+            detail: "You have exceeded the maximum allowed request rate. Please wait before making additional requests."
+            action: "Wait 42 seconds before retrying. Consider implementing exponential backoff."
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#rate-limits"
+            context:
+              limit: 600
+              window: "1 minute"
+              remaining: 0
+              reset_at: 1706745642
+              retry_after_seconds: 42
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    InternalServerError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/INTERNAL_ERROR"
+            title: "Something went wrong on our end. Our team has been notified and is investigating."
+            status: 500
+            code: "INTERNAL_ERROR"
+            detail: "This is a temporary server error. The issue has been automatically reported to our team."
+            action: "Wait 30 seconds and retry your request. If the problem persists, contact support@leadmagic.io"
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    ExternalServiceError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/external_service_error"
+            title: "Error communicating with external service. Please try again."
+            status: 502
+            code: "external_service_error"
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    ServiceUnavailableError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/service_unavailable"
+            title: "Service temporarily unavailable. Please try again later."
+            status: 503
+            code: "service_unavailable"
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    ConflictError:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+      example:
+        success: false
+        errors:
+          - type: "https://api.leadmagic.io/errors/conflict"
+            title: "Resource conflict detected."
+            status: 409
+            code: "conflict"
+            docs: "https://leadmagic.io/docs/v1/making-api-calls#error-handling"
+        meta:
+          request_id: "ea6e3248-f4d2-437d-bca3-20881b529129"
+          timestamp: "2024-02-01T12:00:00.000Z"
+    # ============================================================
+    # Success Message Types (for endpoint responses)
+    # ============================================================
+    EmailValidationMessages:
+      type: string
+      description: Possible success messages for email validation
+      enum:
+        - "Email is valid."
+        - "Email is invalid."
+        - "Unable to determine email validity."
+    EmailFinderMessages:
+      type: string
+      description: Possible success messages for email finder
+      enum:
+        - "Valid email found."
+        - "No email found for this person at this company."
+    MobileFinderMessages:
+      type: string
+      description: Possible success messages for mobile finder
+      enum:
+        - "Mobile number found."
+        - "No mobile number found for this contact."
+    ProfileSearchMessages:
+      type: string
+      description: Possible success messages for profile search
+      enum:
+        - "Profile found."
+        - "Profile not found or not accessible."
+    CompanySearchMessages:
+      type: string
+      description: Possible success messages for company search
+      enum:
+        - "Company found."
+        - "Company not found"
+    RoleFinderMessages:
+      type: string
+      description: Possible success messages for role finder
+      enum:
+        - "Role found."
+        - "No matching role found at this company."
+    EmployeeFinderMessages:
+      type: string
+      description: Possible success messages for employee finder
+      enum:
+        - "Employees found."
+        - "No employees found for this company."
+    JobChangeDetectorMessages:
+      type: string
+      description: Possible success messages for job change detector
+      enum:
+        - "No job change detected. Still employed at expected company."
+        - "Job change detected. Person has moved to a new company."
+        - "Never worked at the expected company."
+    CompetitorsSearchMessages:
+      type: string
+      description: Possible success messages for competitors search
+      enum:
+        - "Competitors found."
+        - "No competitors found for this company."
+    CompanyFundingMessages:
+      type: string
+      description: Possible success messages for company funding
+      enum:
+        - "Funding data found."
+        - "Company funding data not found"
+    TechnographicsMessages:
+      type: string
+      description: Possible success messages for technographics
+      enum:
+        - "Technologies found."
+        - "No technology data found for this domain."
+    AdsSearchMessages:
+      type: string
+      description: Possible success messages for ads search endpoints
+      enum:
+        - "Ads found."
+        - "No ads found for this company."
+    PersonalEmailFinderMessages:
+      type: string
+      description: Possible success messages for personal email finder
+      enum:
+        - "Personal email found."
+        - "No personal email found for this contact."
+    B2BProfileToEmailMessages:
+      type: string
+      description: Possible success messages for B2B profile to email
+      enum:
+        - "Email found for this profile."
+        - "No email found for this profile."
+    EmailToB2BProfileMessages:
+      type: string
+      description: Possible success messages for email to B2B profile
+      enum:
+        - "Profile URL found."
+        - "No profile found for this email."
+    # ============================================================
+    # Response Headers Documentation
+    # ============================================================
+    RateLimitHeaders:
+      type: object
+      description: Rate limit headers returned with every response
+      properties:
+        RateLimit-Limit:
+          type: integer
+          description: "IETF Standard - Maximum requests per minute"
+          example: 600
+        RateLimit-Remaining:
+          type: integer
+          description: "IETF Standard - Requests remaining this minute"
+          example: 587
+        RateLimit-Reset:
+          type: integer
+          description: "IETF Standard - Seconds until limit resets"
+          example: 42
+        X-RateLimit-Limit:
+          type: integer
+          description: "Legacy - Maximum requests per minute"
+          example: 600
+        X-RateLimit-Remaining:
+          type: integer
+          description: "Legacy - Requests remaining this minute"
+          example: 587
+        X-RateLimit-Reset:
+          type: integer
+          description: "Legacy - Unix timestamp when limit resets"
+          example: 1706745600
+        X-RateLimit-Limit-Daily:
+          type: integer
+          description: "Daily request limit"
+          example: 500000
+        X-RateLimit-Remaining-Daily:
+          type: integer
+          description: "Requests remaining today"
+          example: 485000
+        X-RateLimit-Reset-Daily:
+          type: integer
+          description: "Unix timestamp when daily limit resets"
+          example: 1706832000
+        X-Credits-Remaining:
+          type: number
+          description: "Wallet credits remaining after this request"
+          example: 15432.50
+        X-Credits-Cost:
+          type: number
+          description: "Credits reserved for this route before finalization (may exceed credits actually charged)"
+          example: 1
+        X-Credits-Consumed:
+          type: number
+          description: "Credits actually charged after finalization (matches body credits_consumed)"
+          example: 1
+        X-Credits-Total:
+          type: number
+          description: "Wallet credit balance at authorization"
+          example: 15433.50
+        X-Credits-Max-Cost:
+          type: number
+          description: "Maximum credits that could be charged for this request"
+          example: 1
+        X-Request-Id:
+          type: string
+          description: "Correlation id for support troubleshooting"
+        X-RateLimit-Soft-Mode:
+          type: string
+          description: "Whether soft mode is enabled (warn but don't block)"
+          example: "true"
+        X-RateLimit-Daily-Usage-Percent:
+          type: integer
+          description: "Daily usage as percentage"
+          example: 15
+        X-RateLimit-RPM-Usage-Percent:
+          type: integer
+          description: "Current minute usage as percentage"
+          example: 5
+        Retry-After:
+          type: integer
+          description: "Seconds to wait before retrying (only on 429 responses)"
+          example: 42
+    # ============================================================
+    # Bulk Jobs Schemas
+    # ============================================================
+    # Bulk Jobs Schemas (real /bulk/* surface)
+    # ============================================================
+    BulkSubmissionRequest:
+      type: object
+      description: Request body for submitting a bulk enrichment job via POST /bulk/submit. Provide exactly one of rows, csv, fileUrl, or scrape.
+      required:
+        - product
+      properties:
+        product:
+          type: string
+          description: The enrichment product to run on each row (e.g. email_finder, email_validation, mobile_finder, profile_search, company_search).
+          example: email_finder
+        rows:
+          type: array
+          description: JSON array of row objects for /bulk/json (or /bulk/submit auto-detect). Each row is an object whose keys match the input fields the selected product expects.
           items:
             type: object
+            additionalProperties: true
+        csv:
+          type: string
+          description: Inline CSV string for /bulk/csv (or /bulk/submit).
+        fileUrl:
+          type: string
+          description: Public HTTPS URL to a remote file (CSV, JSON, JSONL). SSRF-validated server-side.
+          format: uri
+        format:
+          type: string
+          description: File format for fileUrl submissions.
+          enum:
+            - csv
+            - json
+            - jsonl
+        scrape:
+          type: object
+          description: Browser-rendering config for /bulk/scrape (or /bulk/submit).
+          properties:
+            url:
+              type: string
+              format: uri
+            mode:
+              type: string
+              enum:
+                - scrape
+                - crawl
+                - content
+                - markdown
+                - links
+                - json
+                - snapshot
+            extractPrompt:
+              type: string
+            render:
+              type: boolean
+            maxPages:
+              type: integer
+              minimum: 1
+              maximum: 50
+            maxDepth:
+              type: integer
+              minimum: 1
+              maximum: 10
+        inputMapping:
+          type: object
+          description: Optional column mapping from CSV/JSON columns to product input fields.
+          additionalProperties:
+            type: object
             properties:
-              country:
+              source:
                 type: string
-                examples:
-                - US
-              city:
+              column:
                 type: string
-                examples:
-                - Boston
-              geographic_area:
+              value: {}
+        callback:
+          type: object
+          description: Webhook configuration.
+          properties:
+            url:
+              type: string
+              format: uri
+              description: HTTPS URL to receive a POST on completion/failure. SSRF-validated.
+            events:
+              type: array
+              items:
                 type: string
-                examples:
-                - Massachusetts
-              postal_code:
-                type: string
-                examples:
-                - '02210'
-              line1:
-                type: string
-                examples:
-                - 1 Seaport Ln
-              line2:
-                type:
-                - string
-                - 'null'
-              description:
-                type: string
-                examples:
-                - Headquarters
-              headquarter:
-                type: boolean
-              localized_name:
-                type: string
-                examples:
-                - Boston
-              latitude:
-                type: number
-                examples:
-                - 42.36041
-              longitude:
-                type: number
-                examples:
-                - -71.05798
-        employee_count:
+                enum:
+                  - completed
+                  - failed
+                  - canceled
+                  - any
+                  - job.completed
+                  - job.failed
+                  - job.canceled
+              default:
+                - completed
+            inlineResults:
+              type: boolean
+            secret:
+              type: string
+            metadata:
+              type: object
+              additionalProperties: true
+        idempotencyKey:
+          type: string
+          description: Optional idempotency key for safe retries.
+        metadata:
+          type: object
+          additionalProperties: true
+        presetId:
+          type: string
+        outputTransform:
+          type: object
+          properties:
+            model:
+              type: string
+              example: "llama-3.1-8b-instruct"
+            prompt:
+              type: string
+            jsonSchema: {}
+        priority:
           type: integer
-          examples:
-          - 9
-        specialities:
+          minimum: -1000
+          maximum: 1000
+        fileName:
+          type: string
+    BulkSubmissionResponse:
+      type: object
+      description: Response for a successful bulk job submission. HTTP 202 Accepted.
+      required:
+        - jobId
+        - product
+        - totalRows
+        - status
+        - queue
+      properties:
+        jobId:
+          type: string
+          format: uuid
+          description: UUID identifier for the bulk job.
+          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        product:
+          type: string
+          description: The enrichment product this job is running.
+        endpoint:
+          type: string
+          nullable: true
+        totalRows:
+          type: integer
+          description: Total number of rows in the submission.
+        status:
+          type: string
+          description: Always 'uploaded' for a freshly submitted job.
+          example: uploaded
+        queue:
+          type: object
+          properties:
+            position:
+              type: integer
+            started:
+              type: boolean
+            queuedAt:
+              type: string
+              format: date-time
+        statusUrl:
+          type: string
+          format: uri
+        streamUrl:
+          type: string
+          format: uri
+        wsUrl:
+          type: string
+        resultsUrl:
+          type: string
+          format: uri
+        rowsUrl:
+          type: string
+          format: uri
+        errorsUrl:
+          type: string
+          format: uri
+        eventsUrl:
+          type: string
+          format: uri
+        eventsExportUrl:
+          type: string
+          format: uri
+        logsUrl:
+          type: string
+          format: uri
+        downloadUrl:
+          type: string
+          format: uri
+        progressUrl:
+          type: string
+          format: uri
+        token:
+          type: string
+          description: Progress token for follow-up reads without the API key.
+        exp:
+          type: integer
+          description: Unix timestamp when the progress token expires.
+    JobSummary:
+      type: object
+      required:
+        - job_id
+        - status
+        - total_rows
+        - processed_items
+        - succeeded_items
+        - failed_items
+        - created_at
+      properties:
+        job_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+        products:
           type: array
           items:
             type: string
-          examples:
-          - - Sales
-            - Marketing
-            - ABM
-            - RevOps
-        employee_count_range:
-          type: object
-          properties:
-            start:
-              type: integer
-              examples:
-              - 11
-            end:
-              type: integer
-              examples:
-              - 50
-        tagline:
+          nullable: true
+        submission_product:
           type: string
-          examples:
-          - LeadMagic tells you who is interested in your products or services. Engage
-            them and build more pipeline, win more deals
-        follower_count:
+          nullable: true
+        submission_endpoint:
+          type: string
+          nullable: true
+        total_rows:
           type: integer
-          examples:
-          - 6096
-        industry:
-          type: string
-          examples:
-          - Internet
-        description:
-          type: string
-          examples:
-          - LeadMagic tells you exactly what businesses are on your website and helps
-            you enrich your contact and company data.
-        website_url:
-          type: string
-          examples:
-          - https://leadmagic.io
-        founded_on:
-          type: object
-          properties:
-            month:
-              type:
-              - integer
-              - 'null'
-            year:
-              type: integer
-              examples:
-              - 2022
-            day:
-              type:
-              - integer
-              - 'null'
-        universal_name:
-          type: string
-          examples:
-          - leadmagichq
-        hashtag:
-          type: string
-          examples:
-          - '#abm'
-        industry_v2_taxonomy:
-          type: string
-          examples:
-          - Internet Publishing
-        url:
-          type: string
-          examples:
-          - https://profiles.example.com/company/leadmagichq/
-        credits_consumed:
+        processed_items:
           type: integer
-          examples:
-          - 1
-    PersonProfile:
-      type: object
-      description: Personal profile information
-      properties:
-        profile_url:
-          type: string
-          examples:
-          - https://profiles.example.com/williamhgates/
-        first_name:
-          type: string
-          examples:
-          - Bill
-        last_name:
-          type: string
-          examples:
-          - Gates
-        full_name:
-          type: string
-          examples:
-          - Bill Gates
-        public_identifier:
-          type: string
-          examples:
-          - williamhgates
-        headline:
-          type: string
-          examples:
-          - Chair, Gates Foundation and Founder, Breakthrough Energy
-        company_name:
-          type: string
-          examples:
-          - Gates Foundation
-        company_size:
-          type: string
-          examples:
-          - 1001-5000
-        company_industry:
-          type: string
-          examples:
-          - investment management
-        company_linkedin_url:
-          type: string
-          examples:
-          - profiles.example.com/company/bill-and-melinda-gates-foundation
-        company_website:
-          type: string
-          examples:
-          - gatesfoundation.org
-        total_tenure_months:
-          type: string
-          examples:
-          - '305'
-        total_tenure_days:
-          type: string
-          examples:
-          - '9150'
-        total_tenure_years:
-          type: string
-          examples:
-          - '25.42'
-        connections:
+        succeeded_items:
           type: integer
-          examples:
-          - 8
-        followers:
+        failed_items:
           type: integer
-          examples:
-          - 37841613
-        country:
+        total_credits_consumed:
           type: string
-          examples:
-          - United States
-        location:
-          type: string
-          examples:
-          - Seattle, Washington, United States
-        about:
-          type: string
-          examples:
-          - Chair of the Gates Foundation. Founder of Breakthrough Energy. Co-founder
-            of Microsoft. Voracious reader. Avid traveler. Active blogger.
-        experiences:
-          type: array
-          items:
-            type: object
-            properties:
-              company_id:
-                type: string
-                examples:
-                - '8736'
-              title:
-                type: string
-                examples:
-                - Co-chair
-              subtitle:
-                type: string
-                examples:
-                - Gates Foundation
-              caption:
-                type: string
-                examples:
-                - "2000 - Present \xB7 25 yrs 5 mos"
-        educations:
-          type: array
-          items:
-            type: object
-            properties:
-              title:
-                type: string
-                examples:
-                - Harvard University
-              caption:
-                type: string
-                examples:
-                - 1973 - 1975
-    GoogleAd:
-      type: object
-      description: Google advertisement information
-      properties:
-        advertiser_id:
-          type: string
-          examples:
-          - AR14106062795078369281
-        creative_id:
-          type: string
-          examples:
-          - CR14003695067076755457
-        advertiser_name:
-          type: string
-          examples:
-          - Gong.io Inc
-        format:
-          type: string
-          examples:
-          - Text
-        start:
-          type: string
-          format: date
-          examples:
-          - '2025-03-06'
-        last_seen:
-          type: string
-          format: date
-          examples:
-          - '2025-06-27'
-        original_url:
-          type: string
-          examples:
-          - https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR14003695067076755457?region=anywhere
-        variants:
-          type: array
-          items:
-            type: object
-            properties:
-              content:
-                type: string
-                description: HTML content or JavaScript URL for the ad
-              height:
-                type:
-                - integer
-                - 'null'
-              width:
-                type:
-                - integer
-                - 'null'
-    JobResult:
-      type: object
-      description: Job search result
-      properties:
-        company:
-          type: object
-          properties:
-            name:
-              type: string
-              examples:
-              - Microsoft
-            website_url:
-              type: string
-              examples:
-              - https://www.microsoft.com/
-            linkedin_url:
-              type: string
-              examples:
-              - https://profiles.example.com/company/microsoft/
-            twitter_handle:
-              type: string
-              examples:
-              - Microsoft
-            github_url:
-              type: string
-              examples:
-              - https://github.com/microsoft
-            is_agency:
-              type: boolean
-              examples:
-              - false
-        title:
-          type: string
-          examples:
-          - Technical Program Manager - Developer (AI)
-        location:
-          type: string
-          examples:
-          - Redmond, Washington, United States
-        types:
-          type: array
-          items:
-            type: object
-            properties:
-              id:
-                type: integer
-                examples:
-                - 1
-              name:
-                type: string
-                examples:
-                - Full Time
-        cities:
-          type: array
-          items:
-            type: object
-            properties:
-              geonameid:
-                type: integer
-                examples:
-                - 5808079
-              asciiname:
-                type: string
-                examples:
-                - Redmond
-              name:
-                type: string
-                examples:
-                - Redmond
-              country:
-                type: object
-                properties:
-                  id:
-                    type: integer
-                    examples:
-                    - 238
-                  code:
-                    type: string
-                    examples:
-                    - US
-                  name:
-                    type: string
-                    examples:
-                    - United States
-        has_remote:
-          type: boolean
-          examples:
-          - false
-        published:
+          nullable: true
+        created_at:
           type: string
           format: date-time
-          examples:
-          - '2025-06-25T20:36:00Z'
-        expired:
-          type:
-          - string
-          - 'null'
+        started_at:
+          type: string
           format: date-time
-        application_url:
+          nullable: true
+        completed_at:
           type: string
-          examples:
-          - https://jobs.careers.microsoft.com/global/en/job/1833754/
-        language:
+          format: date-time
+          nullable: true
+        last_progress_at:
           type: string
-          examples:
-          - en
-        salary_min:
+          format: date-time
+          nullable: true
+        file_name:
           type: string
-          examples:
-          - '100600'
-        salary_max:
-          type: string
-          examples:
-          - '215400'
-        salary_currency:
-          type: string
-          examples:
-          - USD
-        experience_level:
-          type: string
-          examples:
-          - Mid Level
-        description:
-          type: string
-          description: Full job description text
-    Error:
+          nullable: true
+    JobsListResponse:
       type: object
+      required:
+        - jobs
+        - limit
+        - offset
       properties:
-        error:
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/JobSummary'
+        limit:
+          type: integer
+        offset:
+          type: integer
+    JobSnapshot:
+      type: object
+      required:
+        - job_id
+        - status
+        - total_rows
+        - processed_items
+        - succeeded_items
+        - failed_items
+        - skipped_items
+        - created_at
+      properties:
+        job_id:
           type: string
-          examples:
-          - Bad Request
-        message:
+          format: uuid
+        status:
           type: string
-          examples:
-          - API key is missing or invalid.
-security:
-- apiKey: []
-paths:
-  /credits:
-    post:
-      summary: Check Credits
-      description: Check the number of available credits for the authenticated user.
-      operationId: getCredits
-      tags:
-      - Credits
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
+        products:
+          type: array
+          items:
+            type: string
+          nullable: true
+        submission_product:
+          type: string
+          nullable: true
+        submission_endpoint:
+          type: string
+          nullable: true
+        execution_mode:
+          type: string
+          nullable: true
+        total_rows:
+          type: integer
+        processed_items:
+          type: integer
+        succeeded_items:
+          type: integer
+        failed_items:
+          type: integer
+        skipped_items:
+          type: integer
+        total_credits_consumed:
+          type: string
+          nullable: true
+        total_duration_ms:
+          type: integer
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_progress_at:
+          type: string
+          format: date-time
+          nullable: true
+        file_name:
+          type: string
+          nullable: true
+        callback_url:
+          type: string
+          nullable: true
+        callback_event:
+          type: string
+          nullable: true
+        priority:
+          type: integer
+          nullable: true
+        output_transform:
+          type: [object, "null"]
+          description: Optional output transform applied to result rows.
+    JobDetailResponse:
+      allOf:
+        - $ref: '#/components/schemas/JobSnapshot'
+        - type: object
+          properties:
+            links:
               type: object
-              properties: {}
+              properties:
+                statusUrl:
+                  type: string
+                streamUrl:
+                  type: string
+                wsUrl:
+                  type: string
+                resultsUrl:
+                  type: string
+                rowsUrl:
+                  type: string
+                errorsUrl:
+                  type: string
+                eventsUrl:
+                  type: string
+                eventsExportUrl:
+                  type: string
+                logsUrl:
+                  type: string
+                downloadUrl:
+                  type: string
+                progressUrl:
+                  type: string
+                token:
+                  type: string
+                exp:
+                  type: integer
+    ReviewResponse:
+      type: object
+      required:
+        - jobId
+        - status
+      properties:
+        jobId:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum:
+            - running
+            - canceled
+    JobRow:
+      type: object
+      required:
+        - id
+        - row_index
+        - status
+      properties:
+        id:
+          type: string
+          format: uuid
+        row_index:
+          type: integer
+        status:
+          type: string
+        lm_input:
+          type: object
+          nullable: true
+        lm_output:
+          type: object
+          nullable: true
+        credits_consumed:
+          type: string
+          nullable: true
+        error_message:
+          type: string
+          nullable: true
+        http_status_code:
+          type: integer
+          nullable: true
+        response_time_ms:
+          type: integer
+          nullable: true
+        completed_at:
+          type: string
+          nullable: true
+    JobRowsResponse:
+      type: object
+      required:
+        - rows
+        - limit
+        - offset
+      properties:
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/JobRow'
+        limit:
+          type: integer
+        offset:
+          type: integer
+    # ============================================================
+    # Cost Control Schemas ( /v1/batch/* )
+    # ============================================================
+    PreviewCostRequest:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          minItems: 1
+          maxItems: 10000
+          items:
+            type: object
+            properties:
+              product:
+                type: string
+                description: Required for mixed-product mode. Omitted for per-product mode.
+              input:
+                type: object
+                additionalProperties: true
+              client_id:
+                type: string
+              client_name:
+                type: string
+              metadata:
+                type: object
+                additionalProperties: true
+        budget_user_id:
+          type: string
+          description: User ID to check against configured Credit Budgets.
+        client_id:
+          type: string
+        client_name:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: true
+    PreviewCostResponse:
+      type: object
+      required:
+        - totalItems
+        - totalCredits
+        - estimatedCostUsd
+        - perProduct
+        - willExceedBudget
+      properties:
+        totalItems:
+          type: integer
+        creditsPerItem:
+          type: number
+          nullable: true
+        totalCredits:
+          type: number
+        estimatedCostUsd:
+          type: number
+        perProduct:
+          type: array
+          items:
+            type: object
+            properties:
+              product:
+                type: string
+              items:
+                type: integer
+              creditsPerItem:
+                type: number
+              credits:
+                type: number
+        clientCreditRemaining:
+          type: string
+          nullable: true
+        willExceedBudget:
+          type: boolean
+    Budget:
+      type: object
+      properties:
+        id:
+          type: string
+        scope:
+          type: string
+        scope_value:
+          type: string
+        max_credits:
+          type: number
+        period:
+          type: string
+        alert_threshold_pct:
+          type: number
+        alert_email:
+          type: string
+    BudgetStatus:
+      type: object
+      properties:
+        scope:
+          type: string
+        scopeValue:
+          type: string
+        maxCredits:
+          type: number
+        remainingCredits:
+          type: number
+        isExceeded:
+          type: boolean
+    SuppressionList:
+      type: object
+      properties:
+        list_id:
+          type: string
+        count:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+  # ============================================================
+  # Reusable Response Definitions
+  # ============================================================
+  responses:
+    BadRequest:
+      description: |
+        Bad Request - The request was malformed or contains invalid parameters.
+
+        **Common causes:**
+        - Missing required fields
+        - Invalid field format (e.g., malformed email)
+        - Invalid JSON syntax
+        - Invalid parameter values
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationError'
+    Unauthorized:
+      description: |
+        Unauthorized - Authentication failed.
+
+        **Common causes:**
+        - Missing X-API-Key header
+        - Invalid or expired API key
+        - Malformed API key
+      content:
+        application/problem+json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/MissingAuthenticationError'
+              - $ref: '#/components/schemas/InvalidApiKeyError'
+    Forbidden:
+      description: |
+        Forbidden - You don't have permission to access this resource.
+
+        **Common causes:**
+        - API key doesn't have access to this endpoint
+        - Plan limitations
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/InsufficientPermissionsError'
+    PaymentRequired:
+      description: |
+        Payment Required - Insufficient credits for this request.
+
+        **Action required:** Add credits to your account at https://app.leadmagic.io/settings/billing
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/InsufficientCreditsError'
+    NotFound:
+      description: |
+        Not Found - The requested resource could not be found.
+
+        **Common causes:**
+        - Profile doesn't exist or is not accessible
+        - Company not found in our database
+        - Invalid URL or identifier
+      content:
+        application/problem+json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/ResourceNotFoundError'
+              - $ref: '#/components/schemas/ProfileNotFoundError'
+    Conflict:
+      description: |
+        Conflict - The request conflicts with the current state of the resource.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictError'
+    RateLimitExceeded:
+      description: |
+        Too Many Requests - Rate limit exceeded.
+
+        **Action required:** Check the `Retry-After` header for when to retry.
+
+        **Headers returned:**
+        - `Retry-After`: Seconds until you can retry
+        - `RateLimit-Limit`: Your limit per minute
+        - `RateLimit-Remaining`: Remaining requests this minute
+        - `RateLimit-Reset`: Seconds until limit resets
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds to wait before retrying
+        RateLimit-Limit:
+          schema:
+            type: integer
+          description: Maximum requests per minute
+        RateLimit-Remaining:
+          schema:
+            type: integer
+          description: Remaining requests this minute
+        RateLimit-Reset:
+          schema:
+            type: integer
+          description: Seconds until limit resets
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/RateLimitExceededError'
+    InternalServerError:
+      description: |
+        Internal Server Error - Something went wrong on our end.
+
+        **Action required:** Wait 30 seconds and retry. If the problem persists, contact support@leadmagic.io
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/InternalServerError'
+    BadGateway:
+      description: |
+        Bad Gateway - Error communicating with an upstream service.
+
+        **Action required:** Retry after a brief delay.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ExternalServiceError'
+    ServiceUnavailable:
+      description: |
+        Service Unavailable - The service is temporarily unavailable.
+
+        **Action required:** Retry after a brief delay.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ServiceUnavailableError'
+security:
+  - ApiKeyAuth: []
+tags:
+  - name: Credits
+    description: Manage and check your credit balance
+  - name: Analytics
+    description: Monitor your API usage with comprehensive analytics endpoints (FREE - no credits consumed)
+  - name: People Enrichment
+    description: Find and validate contact information for individuals
+  - name: Company Data
+    description: Discover company information and intelligence
+  - name: Jobs Data
+    description: Search job listings and detect career changes
+  - name: Ads Data
+    description: Search advertising data across platforms
+  - name: Bulk Jobs
+    description: Submit and manage bulk enrichment jobs for processing CSV files at scale
+  - name: Batch
+    description: Campaign-oriented batch enrichment with budgets, clients, suppression lists, and webhooks
+  - name: Cost Control
+    description: Preview costs, manage credit budgets, and maintain suppression lists to control spend
+paths:
+  # ============================================================
+  # Account Endpoints
+  # ============================================================
+  /v1/credits:
+    get:
+      summary: Check Credits
+      description: Check your current credit balance.
+      operationId: check-credits
+      tags:
+        - Credits
       responses:
-        '200':
-          description: Successful credits retrieval.
+        "200":
+          description: Successful credits retrieval
           content:
             application/json:
               schema:
@@ -544,809 +1323,876 @@ paths:
                 properties:
                   credits:
                     type: number
-                    description: Available credits balance
-                    examples:
-                    - 7333.8
-                  is_frozen:
-                    type: boolean
-                    description: Whether the account's credits are currently frozen.
-                    examples:
-                    - false
-                  credits_frozen:
-                    type: number
-                    description: Portion of credits currently frozen.
-                    examples:
-                    - 0
-                  credits_liquid:
-                    type: number
-                    description: Portion of credits currently available for use.
-                    examples:
-                    - 7333.8
-                  credit_freeze_message:
-                    type:
-                    - string
-                    - 'null'
-                    description: Optional message describing the freeze state.
-                    examples:
-                    - null
-                  credit_freeze_plan_hint:
-                    type:
-                    - string
-                    - 'null'
-                    description: Optional plan or upgrade hint related to a credit freeze.
-                    examples:
-                    - null
-                required:
-                - credits
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /email-validate:
-    post:
-      summary: Email Validation
-      description: Validate an email address for deliverability and retrieve associated
-        company information.
-      operationId: validateEmail
+                    example: 2200
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/analytics/dashboard:
+    get:
+      summary: Dashboard Overview
+      description: Get a real-time snapshot of your account including credits, rate limits, and usage statistics.
+      operationId: analytics-dashboard
       tags:
-      - Email
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - email
-              properties:
-                email:
-                  type: string
-                  description: Email address to validate.
-                  examples:
-                  - jesse@leadmagic.io
-                first_name:
-                  type: string
-                  description: First name of the person (optional).
-                  examples:
-                  - Jesse
-                last_name:
-                  type: string
-                  description: Last name of the person (optional).
-                  examples:
-                  - Ouellette
+        - Analytics
       responses:
-        '200':
-          description: Successful validation.
+        "200":
+          description: Dashboard data retrieved successfully
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  email:
-                    type: string
-                    examples:
-                    - jesse@leadmagic.io
-                  email_status:
-                    type: string
-                    enum:
-                    - valid
-                    - valid_catch_all
-                    - invalid
-                    - unknown
-                    - catch_all
-                    examples:
-                    - valid
-                  credits_consumed:
-                    type: number
-                    examples:
-                    - 0.05
-                  message:
-                    type: string
-                    examples:
-                    - Email is valid.
-                  is_domain_catch_all:
-                    type: boolean
-                    examples:
-                    - false
-                  mx_record:
-                    type: string
-                    examples:
-                    - aspmx.l.google.com
-                  mx_provider:
-                    type: string
-                    examples:
-                    - Google Workspace
-                  mx_security_gateway:
-                    type: boolean
-                    examples:
-                    - false
-                  company_name:
-                    type: string
-                    examples:
-                    - Leadmagic
-                  company_industry:
-                    type: string
-                    examples:
-                    - Internet
-                  company_size:
-                    type: string
-                    examples:
-                    - 11-50
-                  company_founded:
-                    type: integer
-                    examples:
-                    - 2022
-                  company_type:
-                    type: string
-                    examples:
-                    - private
-                  company_linkedin_url:
-                    type: string
-                    examples:
-                    - profiles.example.com/company/leadmagichq
-                  company_linkedin_id:
-                    type: string
-                    examples:
-                    - '75153174'
-                  company_facebook_url:
-                    type:
-                    - string
-                    - 'null'
-                  company_twitter_url:
-                    type:
-                    - string
-                    - 'null'
-                  company_location:
-                    $ref: '#/components/schemas/Location'
-                required:
-                - email
-                - email_status
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /email-finder:
-    post:
-      summary: Email Finder
-      description: Finds a verified email address based on a person's name and company.
-      operationId: findEmail
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        example: "user_abc123"
+                      email:
+                        type: string
+                        example: "developer@leadmagic.io"
+                  credits:
+                    type: object
+                    properties:
+                      current:
+                        type: number
+                        example: 15432.50
+                      formatted:
+                        type: string
+                        example: "$154.33"
+                  rate_limit:
+                    type: object
+                    properties:
+                      minute:
+                        type: object
+                        properties:
+                          limit:
+                            type: integer
+                            example: 600
+                          used:
+                            type: integer
+                            example: 45
+                          remaining:
+                            type: integer
+                            example: 555
+                          utilization:
+                            type: number
+                            example: 15.0
+                      daily:
+                        type: object
+                        properties:
+                          limit:
+                            type: integer
+                            example: 500000
+                          used:
+                            type: integer
+                            example: 12500
+                          remaining:
+                            type: integer
+                            example: 487500
+                          utilization:
+                            type: number
+                            example: 2.5
+                  concurrency:
+                    type: object
+                    properties:
+                      current:
+                        type: integer
+                        example: 0
+                      peak:
+                        type: integer
+                        example: 23
+                      active_reservations:
+                        type: integer
+                        example: 0
+                  stats:
+                    type: object
+                    properties:
+                      today:
+                        type: object
+                        properties:
+                          requests:
+                            type: integer
+                            example: 1250
+                          credits:
+                            type: number
+                            example: 875.50
+                          chargeable_requests:
+                            type: integer
+                            example: 1100
+                          chargeable_rate:
+                            type: number
+                            example: 88.0
+                          unique_products:
+                            type: integer
+                            example: 5
+                      this_week:
+                        type: object
+                        properties:
+                          requests:
+                            type: integer
+                            example: 8500
+                          credits:
+                            type: number
+                            example: 5200.25
+                          chargeable_requests:
+                            type: integer
+                            example: 7200
+                          chargeable_rate:
+                            type: number
+                            example: 84.7
+                          unique_products:
+                            type: integer
+                            example: 8
+                      this_month:
+                        type: object
+                        properties:
+                          requests:
+                            type: integer
+                            example: 45000
+                          credits:
+                            type: number
+                            example: 28500.00
+                          chargeable_requests:
+                            type: integer
+                            example: 38000
+                          chargeable_rate:
+                            type: number
+                            example: 84.4
+                          unique_products:
+                            type: integer
+                            example: 12
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/analytics/usage:
+    get:
+      summary: Usage Summary
+      description: Get daily usage summary with requests, credits consumed, and chargeable rates.
+      operationId: analytics-usage
       tags:
-      - Email
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - first_name
-              - last_name
-              properties:
-                first_name:
-                  type: string
-                  description: The person's first name.
-                  examples:
-                  - Bill
-                last_name:
-                  type: string
-                  description: The person's last name.
-                  examples:
-                  - Gates
-                domain:
-                  type: string
-                  description: The company's domain name.
-                  examples:
-                  - microsoft.com
-                company_name:
-                  type: string
-                  description: The company's name (used if domain is unknown).
-                  examples:
-                  - Microsoft
+        - Analytics
+      parameters:
+        - name: days
+          in: query
+          description: Number of days to include (1-90)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 90
+            default: 30
       responses:
-        '200':
-          description: Successful email discovery.
+        "200":
+          description: Usage summary retrieved successfully
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  email:
-                    type: string
-                    examples:
-                    - billg@microsoft.com
-                  status:
-                    type: string
-                    enum:
-                    - valid
-                    - valid_catch_all
-                    - not_found
-                    examples:
-                    - valid
-                  credits_consumed:
-                    type: integer
-                    examples:
-                    - 1
-                  message:
-                    type: string
-                    examples:
-                    - Valid email found.
-                  first_name:
-                    type: string
-                    examples:
-                    - Bill
-                  last_name:
-                    type: string
-                    examples:
-                    - Gates
-                  domain:
-                    type: string
-                    examples:
-                    - microsoft.com
-                  is_domain_catch_all:
-                    type: boolean
-                    examples:
-                    - false
-                  mx_record:
-                    type: string
-                    examples:
-                    - microsoft-com.mail.protection.outlook.com
-                  mx_provider:
-                    type: string
-                    examples:
-                    - Microsoft 365
-                  mx_security_gateway:
-                    type: boolean
-                    examples:
-                    - false
-                  company_name:
-                    type: string
-                    examples:
-                    - Microsoft
-                  company_industry:
-                    type: string
-                    examples:
-                    - Computer Software
-                  company_size:
-                    type: string
-                    examples:
-                    - 10001+
-                  company_founded:
-                    type: integer
-                    examples:
-                    - 1975
-                  company_type:
-                    type: string
-                    examples:
-                    - public
-                  company_linkedin_url:
-                    type: string
-                    examples:
-                    - profiles.example.com/company/microsoft
-                  company_linkedin_id:
-                    type: string
-                    examples:
-                    - '1035'
-                  company_facebook_url:
-                    type: string
-                    examples:
-                    - facebook.com/microsoft
-                  company_twitter_url:
-                    type: string
-                    examples:
-                    - twitter.com/microsoft
-                  company_location:
-                    $ref: '#/components/schemas/Location'
-                required:
-                - email
-                - status
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /profile-search:
-    post:
-      summary: Profile Search
-      description: "Provide a B2B profile URL (for example, a professional social profile) to get full profile\
-        \ details. \nRate limit: 300 requests/minute.\n"
-      operationId: searchProfile
-      tags:
-      - Profiles
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - profile_url
-              properties:
-                profile_url:
-                  type: string
-                  description: Full URL of the B2B profile.
-                  examples:
-                  - https://profiles.example.com/williamhgates/
-      responses:
-        '200':
-          description: Successful retrieval of profile information.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  credits_consumed:
-                    type: number
-                    examples:
-                    - 1
-                required:
-                - credits_consumed
-                allOf:
-                - $ref: '#/components/schemas/PersonProfile'
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '429':
-          description: Rate limit exceeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /company-search:
-    post:
-      summary: Company Search
-      description: Search for company details using its domain, name, or profile URL.
-      operationId: searchCompany
-      tags:
-      - Companies
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              description: Provide at least one of the following to find company details.
-              properties:
-                company_domain:
-                  type: string
-                  examples:
-                  - leadmagic.io
-                company_name:
-                  type: string
-                  examples:
-                  - Leadmagic
-                profile_url:
-                  type: string
-                  examples:
-                  - https://profiles.example.com/company/leadmagichq
-      responses:
-        '200':
-          description: Successful retrieval of company details.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  credits_consumed:
-                    type: integer
-                    examples:
-                    - 1
-                required:
-                - credits_consumed
-                allOf:
-                - $ref: '#/components/schemas/DetailedCompany'
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /jobs-finder:
-    post:
-      summary: Jobs Finder
-      description: Searches for job postings based on various criteria.
-      operationId: findJobs
-      tags:
-      - Jobs
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                company_name:
-                  type: string
-                  description: Filter by company name.
-                  examples:
-                  - Microsoft
-                company_website:
-                  type: string
-                  description: Filter by company website.
-                  examples:
-                  - microsoft.com
-                job_title:
-                  type: string
-                  description: Filter by job title.
-                  examples:
-                  - Developer
-                location:
-                  type: string
-                  description: Filter by job location.
-                  examples:
-                  - New York
-                experience_level:
-                  type: string
-                  description: Required experience level.
-                  enum:
-                  - entry
-                  - mid
-                  - senior
-                  - executive
-                  examples:
-                  - senior
-                job_description:
-                  type: string
-                  description: Keywords from the job description.
-                  examples:
-                  - python "software engineer"
-                country_id:
-                  type: string
-                  description: Filter jobs by country ID.
-                  examples:
-                  - US
-                page:
-                  type: integer
-                  default: 1
-                  minimum: 1
-                  examples:
-                  - 1
-                per_page:
-                  type: integer
-                  default: 20
-                  minimum: 1
-                  maximum: 50
-                  description: Number of results per page. Maximum of 50.
-                  examples:
-                  - 5
-      responses:
-        '200':
-          description: Successful job search.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  total_count:
-                    type: integer
-                    examples:
-                    - 105
-                  page:
-                    type: integer
-                    examples:
-                    - 1
-                  per_page:
-                    type: integer
-                    examples:
-                    - 5
-                  total_pages:
-                    type: integer
-                    examples:
-                    - 21
-                  credits_consumed:
-                    type: integer
-                    examples:
-                    - 5
-                  results:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/JobResult'
-                required:
-                - total_count
-                - page
-                - per_page
-                - total_pages
-                - credits_consumed
-                - results
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /google/searchads:
-    post:
-      summary: Google Ads Search
-      description: Search for Google Ads based on a company's domain or name.
-      operationId: searchGoogleAds
-      tags:
-      - Advertisements
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              description: Provide a company name or domain to search for ads.
-              properties:
-                company_domain:
-                  type: string
-                  examples:
-                  - gong.io
-                company_name:
-                  type: string
-                  examples:
-                  - gong
-      responses:
-        '200':
-          description: Successful retrieval of Google Ads.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  credits_consumed:
-                    type: number
-                    examples:
-                    - 8
-                  ads:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/GoogleAd'
-                required:
-                - credits_consumed
-                - ads
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /meta/searchads:
-    post:
-      summary: Meta (Facebook/Instagram) Ads Search
-      description: Search for Meta Ads based on a company's domain or name.
-      operationId: searchMetaAds
-      tags:
-      - Advertisements
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              description: Provide a company name or domain to search for ads.
-              properties:
-                company_domain:
-                  type: string
-                  examples:
-                  - gong.io
-                company_name:
-                  type: string
-                  examples:
-                  - gong
-      responses:
-        '200':
-          description: Successful retrieval of Meta Ads.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  credits_consumed:
-                    type: number
-                    examples:
-                    - 2.6
-                  ads:
+                  period:
+                    type: object
+                    properties:
+                      start:
+                        type: string
+                        format: date
+                        example: "2024-01-02"
+                      end:
+                        type: string
+                        format: date
+                        example: "2024-02-01"
+                      days:
+                        type: integer
+                        example: 30
+                  summary:
+                    type: object
+                    properties:
+                      total_requests:
+                        type: integer
+                        example: 45000
+                      chargeable_requests:
+                        type: integer
+                        example: 38000
+                      total_credits:
+                        type: number
+                        example: 28500.00
+                      avg_credits_per_request:
+                        type: number
+                        example: 0.63
+                      chargeable_rate:
+                        type: number
+                        example: 84.4
+                      unique_products:
+                        type: integer
+                        example: 12
+                  daily:
                     type: array
                     items:
                       type: object
                       properties:
-                        ad_archive_id:
+                        date:
                           type: string
-                          examples:
-                          - '618153827656899'
-                        page_id:
-                          type: string
-                          examples:
-                          - '105549201674375'
-                        page_name:
-                          type: string
-                          examples:
-                          - Lykkedal Retreat
-                        is_active:
-                          type: boolean
-                        publisher_platform:
-                          type: array
-                          items:
-                            type: string
-                          examples:
-                          - - facebook
-                            - instagram
-                        snapshot:
-                          type: object
-                          properties:
-                            body:
-                              type: object
-                              properties:
-                                markup:
-                                  type: string
-                            title:
-                              type: string
-                            cta_text:
-                              type: string
-                            images:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  original_image_url:
-                                    type: string
-                                    format: uri
-                            videos:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  video_hd_url:
-                                    type: string
-                                    format: uri
-                required:
-                - credits_consumed
-                - ads
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /mobile-finder:
-    post:
-      summary: Mobile Finder
-      description: Find mobile phone numbers using profile URL, work email, or personal
-        email.
-      operationId: findMobile
+                          format: date
+                          example: "2024-02-01"
+                        total_requests:
+                          type: integer
+                          example: 1250
+                        chargeable_requests:
+                          type: integer
+                          example: 1100
+                        total_credits:
+                          type: number
+                          example: 875.50
+                        unique_products_used:
+                          type: integer
+                          example: 5
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/analytics/products:
+    get:
+      summary: Products Breakdown
+      description: Get per-product usage with requests, credits, and success rates.
+      operationId: analytics-products
       tags:
-      - Mobile
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              description: Provide at least one of the following parameters.
-              properties:
-                profile_url:
-                  type: string
-                  examples:
-                  - https://profiles.example.com/williamhgates/
-                work_email:
-                  type: string
-                  examples:
-                  - jesse@leadmagic.io
-                personal_email:
-                  type: string
-                  examples:
-                  - jesse.ouellette@gmail.com
+        - Analytics
+      parameters:
+        - name: days
+          in: query
+          description: Number of days to include (1-90)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 90
+            default: 30
       responses:
-        '200':
-          description: Mobile search response.
+        "200":
+          description: Products breakdown retrieved successfully
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  message:
-                    type: string
-                    examples:
-                    - mobile not found
-                    - Mobile found
-                  credits_consumed:
-                    type: number
-                    examples:
-                    - 0
-                    - 1
-                  mobile_number:
-                    type:
-                    - string
-                    - 'null'
-                    examples:
-                    - '+1234567890'
-                required:
-                - message
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /b2b-profile:
-    post:
-      summary: Email Address to B2B Profile
-      description: Find B2B profile URL using work email address.
-      operationId: emailToProfile
+                  period:
+                    type: object
+                    properties:
+                      start:
+                        type: string
+                        format: date
+                      end:
+                        type: string
+                        format: date
+                      days:
+                        type: integer
+                  products:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      properties:
+                        total_requests:
+                          type: integer
+                          example: 20000
+                        total_credits:
+                          type: number
+                          example: 1000.00
+                        successful_requests:
+                          type: integer
+                          example: 19500
+                        failed_requests:
+                          type: integer
+                          example: 500
+                        success_rate:
+                          type: number
+                          example: 97.5
+                        avg_credits_per_request:
+                          type: number
+                          example: 0.25
+                  daily:
+                    type: array
+                    items:
+                      type: object
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/analytics/credits:
+    get:
+      summary: Credit History
+      description: Get credit consumption history with daily breakdown.
+      operationId: analytics-credits
       tags:
-      - Profiles
+        - Analytics
+      parameters:
+        - name: days
+          in: query
+          description: Number of days to include (1-90)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 90
+            default: 30
+      responses:
+        "200":
+          description: Credit history retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  period:
+                    type: object
+                    properties:
+                      start:
+                        type: string
+                        format: date
+                      end:
+                        type: string
+                        format: date
+                      days:
+                        type: integer
+                  summary:
+                    type: object
+                    properties:
+                      total_credits:
+                        type: number
+                        example: 28500.00
+                      total_requests:
+                        type: integer
+                        example: 45000
+                      chargeable_requests:
+                        type: integer
+                        example: 38000
+                      avg_credits_per_request:
+                        type: number
+                        example: 0.63
+                      chargeable_rate:
+                        type: number
+                        example: 84.4
+                  daily:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        date:
+                          type: string
+                          format: date
+                        total_credits:
+                          type: number
+                        total_requests:
+                          type: integer
+                        chargeable_requests:
+                          type: integer
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/analytics/summary:
+    get:
+      summary: All-Time Summary
+      description: Get lifetime statistics for your account.
+      operationId: analytics-summary
+      tags:
+        - Analytics
+      parameters:
+        - name: start_date
+          in: query
+          description: Start date (YYYY-MM-DD)
+          schema:
+            type: string
+            format: date
+        - name: end_date
+          in: query
+          description: End date (YYYY-MM-DD)
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          description: Summary statistics retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_api_requests:
+                    type: integer
+                    example: 1250000
+                  total_credits_consumed:
+                    type: number
+                    example: 425000.50
+                  unique_products_used:
+                    type: integer
+                    example: 15
+                  successful_requests:
+                    type: integer
+                    example: 1150000
+                  failed_requests:
+                    type: integer
+                    example: 100000
+                  success_rate:
+                    type: number
+                    example: 92.0
+                  avg_response_time_ms:
+                    type: number
+                    example: 245
+                  first_request:
+                    type: string
+                    format: date-time
+                    nullable: true
+                    example: "2023-06-15T10:30:00.000Z"
+                  last_request:
+                    type: string
+                    format: date-time
+                    nullable: true
+                    example: "2024-02-01T14:22:00.000Z"
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/analytics/daily:
+    get:
+      summary: Daily Metrics
+      description: Get detailed daily metrics with performance data.
+      operationId: analytics-daily
+      tags:
+        - Analytics
+      parameters:
+        - name: days
+          in: query
+          description: Number of days to include (1-90)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 90
+            default: 30
+      responses:
+        "200":
+          description: Daily metrics retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  period:
+                    type: object
+                    properties:
+                      start:
+                        type: string
+                        format: date
+                      end:
+                        type: string
+                        format: date
+                      days:
+                        type: integer
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        date:
+                          type: string
+                          format: date
+                        total_requests:
+                          type: integer
+                        successful_requests:
+                          type: integer
+                        failed_requests:
+                          type: integer
+                        total_credits:
+                          type: number
+                        p50_latency_ms:
+                          type: number
+                        p95_latency_ms:
+                          type: number
+                        p99_latency_ms:
+                          type: number
+                        error_rate:
+                          type: number
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/analytics/day/{date}:
+    get:
+      summary: Day Breakdown
+      description: Get per-product breakdown for a specific day.
+      operationId: analytics-day
+      tags:
+        - Analytics
+      parameters:
+        - name: date
+          in: path
+          required: true
+          description: Date in YYYY-MM-DD format
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          description: Day breakdown retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  date:
+                    type: string
+                    format: date
+                    example: "2024-02-01"
+                  summary:
+                    type: object
+                    properties:
+                      total_credits:
+                        type: number
+                        example: 875.50
+                      total_requests:
+                        type: integer
+                        example: 1250
+                      products_count:
+                        type: integer
+                        example: 8
+                  products:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        product_id:
+                          type: string
+                          example: "email_validation"
+                        requests:
+                          type: integer
+                          example: 500
+                        credits:
+                          type: number
+                          example: 25.00
+                        credits_percentage:
+                          type: number
+                          example: 2.86
+                        avg_credits_per_request:
+                          type: number
+                          example: 0.25
+                        max_credits:
+                          type: number
+                          example: 0.25
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  # ============================================================
+  # Email Endpoints
+  # ============================================================
+  /v1/people/email-validation:
+    post:
+      summary: Email Validation
+      description: Validate an email address for deliverability and get company enrichment data.
+      operationId: email-validation
+      tags:
+        - People Enrichment
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required:
-              - work_email
               properties:
-                work_email:
+                email:
                   type: string
-                  examples:
-                  - jesse@leadmagic.io
+                  format: email
+                  description: Email address to validate
+                  example: alex.rivera@example.com
+              required:
+                - email
       responses:
-        '200':
-          description: Profile URL found.
+        "200":
+          description: Successful validation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  email:
+                    type: string
+                    example: alex.rivera@example.com
+                  email_status:
+                    type: string
+                    example: valid
+                  credits_consumed:
+                    type: number
+                    example: 0.25
+                  message:
+                    type: string
+                    example: Email is valid.
+                  mx_record:
+                    type: string
+                    example: mx1.example.com
+                  mx_provider:
+                    type: string
+                    example: Example Mail
+                  mx_gateway:
+                    type: string
+                    nullable: true
+                    description: Security gateway vendor name
+                    example: null
+                  mx_gateway_type:
+                    type: string
+                    nullable: true
+                    description: Security gateway type
+                    example: null
+                  mx_security_gateway:
+                    type: boolean
+                    example: false
+                  company_name:
+                    type: string
+                    example: Leadmagic
+                  company_industry:
+                    type: string
+                    example: Internet
+                  company_size:
+                    type: string
+                    example: 11-50
+                  company_founded:
+                    type: integer
+                    example: 2022
+                  company_type:
+                    type: string
+                    example: Private
+                  company_location:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        example: Boston, Massachusetts, United States
+                      locality:
+                        type: string
+                        example: Boston
+                      region:
+                        type: string
+                        example: Massachusetts
+                      metro:
+                        type: string
+                        example: Boston
+                      country:
+                        type: string
+                        example: United States
+                      continent:
+                        type: string
+                        example: North America
+                      street_address:
+                        type: string
+                        example: 1 Seaport Lane
+                      address_line_2:
+                        type: string
+                        nullable: true
+                        example: null
+                      postal_code:
+                        type: string
+                        example: "02210"
+                      geo:
+                        type: string
+                        nullable: true
+                        example: null
+                  company_linkedin_url:
+                    type: string
+                    description: Legacy field name for the B2B company profile.
+                    example: example.com/company/acme
+                  company_linkedin_id:
+                    type: string
+                    example: "75153174"
+                  company_facebook_url:
+                    type: string
+                    nullable: true
+                    example: null
+                  company_twitter_url:
+                    type: string
+                    nullable: true
+                    example: null
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/people/email-finder:
+    post:
+      summary: Email Finder
+      description: Find a person's work email address using their name and company information.
+      operationId: email-finder
+      tags:
+        - People Enrichment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                first_name:
+                  type: string
+                  description: First name of the person (optional if full_name provided)
+                  default: Alex
+                last_name:
+                  type: string
+                  nullable: true
+                  description: Last name of the person (optional)
+                  default: Rivera
+                full_name:
+                  type: string
+                  nullable: true
+                  description: Full name of the person (alternative to first_name + last_name)
+                  default: Alex Rivera
+                domain:
+                  type: string
+                  description: Company domain name (required if company_name not provided)
+                  default: leadmagic.io
+                company_name:
+                  type: string
+                  description: Company name (required if domain not provided)
+                  default: LeadMagic
+      responses:
+        "200":
+          description: Successful response with email details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  email:
+                    type: string
+                    example: alex.rivera@example.com
+                  status:
+                    type: string
+                    example: valid
+                  credits_consumed:
+                    type: integer
+                    example: 1
+                  message:
+                    type: string
+                    example: Valid email found.
+                  first_name:
+                    type: string
+                    example: Alex
+                  last_name:
+                    type: string
+                    example: Rivera
+                  domain:
+                    type: string
+                    example: leadmagic.io
+                  mx_record:
+                    type: string
+                    example: alt3.mx1.example.com
+                  mx_provider:
+                    type: string
+                    example: Example Mail
+                  mx_security_gateway:
+                    type: boolean
+                    example: false
+                  has_mx:
+                    type: boolean
+                    description: Whether the domain has MX records
+                    example: true
+                  mx_records_full:
+                    type: array
+                    description: Complete list of MX records with priorities
+                    items:
+                      type: object
+                      properties:
+                        priority:
+                          type: integer
+                          example: 10
+                        exchange:
+                          type: string
+                          example: mx1.example.com
+                  company_name:
+                    type: string
+                    example: Leadmagic
+                  company_industry:
+                    type: string
+                    example: ""
+                  company_size:
+                    type: string
+                    example: 11-50
+                  company_founded:
+                    type: integer
+                    example: 2022
+                  company_location:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        example: boston, massachusetts, united states
+                      locality:
+                        type: string
+                        example: boston
+                      region:
+                        type: string
+                        example: massachusetts
+                      metro:
+                        type: string
+                        example: boston, massachusetts
+                      country:
+                        type: string
+                        example: united states
+                      continent:
+                        type: string
+                        example: north america
+                      street_address:
+                        type: string
+                        example: 1 seaport lane
+                      address_line_2:
+                        type: string
+                      postal_code:
+                        type: string
+                        example: "02210"
+                      geo:
+                        type: string
+                        example: 42.35,-71.06
+                  company_profile_url:
+                    type: string
+                    example: leadmagichq
+                  company_profile_id:
+                    type: string
+                    example: "75153174"
+                  company_facebook_url:
+                    type: string
+                    example: ""
+                  company_twitter_url:
+                    type: string
+                    example: ""
+                  company_type:
+                    type: string
+                    example: private
+                  employment_verified:
+                    type: boolean
+                    nullable: true
+                    description: Whether the employment at the domain was verified
+                    example: true
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/people/personal-email-finder:
+    post:
+      summary: Personal Email Finder
+      description: Provide a B2B Profile URL and get back the personal emails of the person.
+      operationId: personal-email-finder
+      tags:
+        - People Enrichment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile_url:
+                  type: string
+                  description: Professional profile URL or identifier
+                  default: alex-rivera
+              required:
+                - profile_url
+      responses:
+        "200":
+          description: Successful response with personal email details
           content:
             application/json:
               schema:
@@ -1354,209 +2200,557 @@ paths:
                 properties:
                   profile_url:
                     type: string
-                    examples:
-                    - https://profiles.example.com/jesseouehwx
-                  message:
-                    type: string
-                    examples:
-                    - Profile URL found
+                    example: alex-rivera
                   credits_consumed:
                     type: integer
-                    examples:
-                    - 10
-                required:
-                - message
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /role-finder:
+                    example: 2
+                  message:
+                    type: string
+                    example: Personal Email Found.
+                  name:
+                    type: string
+                    example: Alex Rivera
+                  first_personal_email:
+                    type: string
+                    example: alex-riveral@gmail.com
+                  personal_emails:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - alex-riveral@gmail.com
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/people/b2b-profile-email:
     post:
-      summary: Role Finder
-      description: Find specific roles/positions within a company.
-      operationId: findRole
+      summary: B2B Person Profile to Email
+      description: Provide a B2B person profile and get back the work email of the person.
+      operationId: b2b-profile-email
       tags:
-      - People
+        - People Enrichment
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required:
-              - job_title
               properties:
-                job_title:
+                profile_url:
                   type: string
-                  examples:
-                  - Developer
-                company_name:
-                  type: string
-                  examples:
-                  - Microsoft
-                company_domain:
-                  type: string
-                  examples:
-                  - microsoft.com
-                company_profile_url:
-                  type: string
-                  examples:
-                  - https://profiles.example.com/company/microsoft
+                  description: B2B person profile URL or slug
+                  default: alex-rivera
+              required:
+                - profile_url
       responses:
-        '200':
-          description: Role search response.
+        "200":
+          description: Successful response with profile and email details
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  message:
+                  profile_url:
                     type: string
-                    examples:
-                    - Role not found.
-                    - Role found.
+                    example: alex-rivera
                   credits_consumed:
                     type: integer
-                    examples:
-                    - 0
-                    - 1
+                    example: 5
+                  message:
+                    type: string
+                    example: Email Found.
+                  email:
+                    type: string
+                    example: alex.rivera@example.com
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  # ============================================================
+  # Contact Endpoints
+  # ============================================================
+  /v1/people/profile-search:
+    post:
+      summary: B2B Person Profile
+      description: Retrieve comprehensive B2B person profile information including work history, education, certifications, and more.
+      operationId: profile-search
+      tags:
+        - People Enrichment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile_url:
+                  type: string
+                  description: B2B person profile URL or slug
+                  example: alex-rivera
+              required:
+                - profile_url
+      responses:
+        "200":
+          description: Successful response with profile information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  profile_url:
+                    type: string
+                    example: alex-rivera
+                  credits_consumed:
+                    type: integer
+                    example: 1
+                  first_name:
+                    type: string
+                    nullable: true
+                    example: Alex
+                  last_name:
+                    type: string
+                    nullable: true
+                    example: Rivera
+                  full_name:
+                    type: string
+                    nullable: true
+                    example: Alex Rivera
+                  professional_title:
+                    type: string
+                    nullable: true
+                    example: Growth & AI Expert | Founder LeadMagic
+                  bio:
+                    type: string
+                    nullable: true
+                    example: SaaS Founder
                   company_name:
                     type: string
-                    examples:
-                    - Microsoft
+                    nullable: true
+                    example: LeadMagic
+                  company_industry:
+                    type: string
+                    nullable: true
+                    example: Internet
                   company_website:
                     type: string
-                    examples:
-                    - microsoft.com
-                required:
-                - message
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /employee-finder:
+                    nullable: true
+                    example: leadmagic.io
+                  total_tenure_months:
+                    type: string
+                    nullable: true
+                    example: "205"
+                  total_tenure_days:
+                    type: string
+                    nullable: true
+                    example: "6240"
+                  total_tenure_years:
+                    type: string
+                    nullable: true
+                    example: "17"
+                  followers_range:
+                    type: string
+                    nullable: true
+                    example: 45K-50K
+                    description: Follower count range for privacy (e.g. "45K-50K", "1M+")
+                  personal_website:
+                    type: object
+                    nullable: true
+                    properties:
+                      name:
+                        type: string
+                        example: https://leadmagic.io
+                      link:
+                        type: string
+                        example: https://leadmagic.io
+                  country:
+                    type: string
+                    nullable: true
+                    example: United States
+                  location:
+                    type: string
+                    nullable: true
+                    example: Greater Boston
+                  work_experience:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      properties:
+                        position_title:
+                          type: string
+                          example: Founder
+                        company_name:
+                          type: string
+                          example: LeadMagic
+                        employment_period:
+                          type: string
+                          example: Sep 2022 - Present · 3 yrs 2 mos
+                        company_website:
+                          type: string
+                          nullable: true
+                          example: leadmagic.io
+                          description: Only included when domain is available
+                        company_logo_url:
+                          type: string
+                          nullable: true
+                          example: https://logo.leadmagic.io/leadmagic.io
+                          description: Only included when domain is available
+                  education:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      properties:
+                        institution_name:
+                          type: string
+                          example: University of Maine
+                        degree:
+                          type: string
+                          example: University of Maine
+                        attendance_period:
+                          type: string
+                          example: ""
+                  certifications:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      properties:
+                        certification_name:
+                          type: string
+                          example: Revenue Architect
+                        issuing_organization:
+                          type: string
+                          example: Winning by Design
+                        issue_date:
+                          type: string
+                          example: Issued Nov 2020
+                  honors:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                          example: Hortonworks - MVP NorthEast - Region - 2016
+                        description:
+                          type: string
+                          example: Issued by Hortonworks · Jan 2016
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/people/b2b-profile:
     post:
-      summary: Employee Finder
-      description: Find employees of a specific company.
-      operationId: findEmployees
+      summary: Email Address to B2B Person Profile
+      description: Use this endpoint to find a B2B person profile based on the provided email.
+      operationId: email-to-b2b-profile
       tags:
-      - People
+        - People Enrichment
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required:
-              - company_name
               properties:
-                company_name:
+                work_email:
                   type: string
-                  examples:
-                  - Microsoft
-                page:
-                  type: integer
-                  default: 1
-                  minimum: 1
-                  examples:
-                  - 1
-                per_page:
-                  type: integer
-                  default: 20
-                  minimum: 1
-                  maximum: 50
-                  examples:
-                  - 5
+                  description: Provide the Work Email of the person
+                  default: alex.rivera@example.com
+                personal_email:
+                  type: string
+                  description: Provide the Personal Email of the person
+                  default: alex-riveral@gmail.com
       responses:
-        '200':
-          description: Employee search results.
+        "200":
+          description: Successful response with B2B profile details
           content:
             application/json:
               schema:
                 type: object
                 properties:
+                  profile_url:
+                    type: string
+                    example: jouellette
                   message:
                     type: string
-                    examples:
-                    - Data found for the given company.
-                  total_count:
-                    type: integer
-                    examples:
-                    - 5000
-                  returned_count:
-                    type: integer
-                    examples:
-                    - 20
+                    example: Profile URL found
                   credits_consumed:
                     type: integer
-                    examples:
-                    - 1
-                  data:
+                    example: 10
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/people/mobile-finder:
+    post:
+      summary: Mobile Finder
+      description: Find a person's mobile phone number using their profile URL or email address.
+      operationId: mobile-finder
+      tags:
+        - People Enrichment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile_url:
+                  type: string
+                  description: Provide their Social Media URL
+                  default: alex-rivera
+                work_email:
+                  type: string
+                  description: Provide the Work Email of the person
+                  default: alex.rivera@example.com
+                personal_email:
+                  type: string
+                  description: Provide the Personal Email of the person
+                  default: alex-riveral@gmail.com
+      responses:
+        "200":
+          description: Successful response with mobile details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  profile_url:
+                    type: string
+                    nullable: true
+                    example: alex-rivera
+                  email:
+                    type: string
+                    nullable: true
+                    description: Email address used in lookup (if provided)
+                    example: alex.rivera@example.com
+                  mobile_number:
+                    type: string
+                    nullable: true
+                    description: Mobile phone number if found
+                    example: "12077523358"
+                  credits_consumed:
+                    type: number
+                    example: 5
+                  message:
+                    type: string
+                    description: Status message about the result
+                    example: Mobile number found.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/people/job-change-detector:
+    post:
+      summary: Job Change Detector
+      description: Monitor employee transitions and detect when someone has changed jobs.
+      operationId: job-change-detector
+      tags:
+        - Jobs Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                profile_url:
+                  type: string
+                  description: Professional profile URL or identifier
+                  example: alex-rivera
+                company_name:
+                  type: string
+                  description: Expected company name (either company_name or company_domain is required)
+                  example: Example Robotics
+                company_domain:
+                  type: string
+                  description: Expected company domain (either company_name or company_domain is required)
+                  example: smartlead.ai
+              required:
+                - profile_url
+      responses:
+        "200":
+          description: Successful job change detection
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job_change_detected:
+                    type: boolean
+                    example: false
+                  status:
+                    type: string
+                    enum: [NO_CHANGE, JOB_CHANGE_DETECTED, NEVER_WORKED_THERE]
+                    example: NEVER_WORKED_THERE
+                  summary:
+                    type: string
+                    example: Alex Rivera has never worked at Example Robotics according to their comprehensive employment history. They are currently working at Leadmagic as Founder for 3 years. Their complete employment history shows experience at Leadmagic, Atlas Guild, Northstar Labs, and 7 other companies. The expected company does not appear in any current or past positions, confirming they have never been employed there.
+                  employee_name:
+                    type: string
+                    example: Alex Rivera
+                  expected_company:
+                    type: string
+                    example: Example Robotics
+                  current_company:
+                    type: string
+                    example: Leadmagic
+                  current_position:
+                    type: object
+                    properties:
+                      title:
+                        type: string
+                        example: Founder
+                      company:
+                        type: string
+                        example: Leadmagic
+                      start_date:
+                        type: string
+                        example: Sep 2022
+                      days_at_job:
+                        type: integer
+                        example: 1111
+                      tenure_formatted:
+                        type: string
+                        example: 3 years
+                      is_current_position:
+                        type: boolean
+                        example: true
+                  tenure_stats:
+                    type: object
+                    properties:
+                      average_tenure_months:
+                        type: integer
+                        example: 26
+                      average_tenure_formatted:
+                        type: string
+                        example: 2 years 2 months
+                      total_positions:
+                        type: integer
+                        example: 10
+                      longest_tenure_months:
+                        type: integer
+                        example: 73
+                      longest_tenure_formatted:
+                        type: string
+                        example: 6 years 1 month
+                      shortest_tenure_months:
+                        type: integer
+                        example: 1
+                      shortest_tenure_formatted:
+                        type: string
+                        example: 1 month
+                  work_history:
                     type: array
                     items:
                       type: object
                       properties:
-                        first_name:
-                          type: string
-                          examples:
-                          - John
-                        last_name:
-                          type: string
-                          examples:
-                          - Doe
                         title:
                           type: string
-                          examples:
-                          - Senior Software Engineer
-                        website:
+                          example: Founder
+                        company:
                           type: string
-                          examples:
-                          - http://www.microsoft.com
-                        company_name:
+                          example: LeadMagic
+                        duration:
                           type: string
-                          examples:
-                          - Microsoft
-                required:
-                - message
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /company-funding:
+                          example: Sep 2022 - Present
+                        is_present:
+                          type: boolean
+                          example: true
+                    example:
+                      - title: Founder
+                        company: Leadmagic
+                        duration: Sep 2022 - Present
+                        is_present: true
+                      - title: Executive Member
+                        company: Atlas Guild
+                        duration: Aug 2019 - Present
+                        is_present: true
+                      - title: Advisor
+                        company: Northstar Labs
+                        duration: Feb 2023 - Jan 2024
+                        is_present: false
+                      - title: Advisor
+                        company: Sales Community
+                        duration: May 2020 - Dec 2023
+                        is_present: false
+                      - title: Advisor
+                        company: Astronomer
+                        duration: Jul 2020 - Sep 2023
+                        is_present: false
+                  profile_found:
+                    type: boolean
+                    example: true
+                  profile_url:
+                    type: string
+                    example: alex-rivera
+                  credits_consumed:
+                    type: integer
+                    example: 2
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  # ============================================================
+  # Company Data Endpoints
+  # ============================================================
+  /v1/companies/company-search:
     post:
-      summary: Company Funding
-      description: Get comprehensive funding information, financials, competitors,
-        and company insights.
-      operationId: getCompanyFunding
+      summary: Company Search
+      description: Search for companies and retrieve comprehensive company intelligence including funding, employees, industry, and more.
+      operationId: company-search
       tags:
-      - Companies
+        - Company Data
       requestBody:
         required: true
         content:
@@ -1564,17 +2758,292 @@ paths:
             schema:
               type: object
               properties:
+                profile_url:
+                  type: string
+                  description: Business company profile URL or identifier
+                  default: leadmagichq
                 company_domain:
                   type: string
-                  examples:
-                  - microsoft.com
+                  description: Provide Company Domain
+                  default: leadmagic.io
                 company_name:
                   type: string
-                  examples:
-                  - Microsoft
+                  description: Provide Company Name
+                  default: Leadmagic
       responses:
-        '200':
-          description: Comprehensive company funding and business information.
+        "200":
+          description: Successful response with company details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Status message
+                    example: Company found
+                  credits_consumed:
+                    type: number
+                    description: Number of credits consumed for this request
+                    example: 1
+                  companyName:
+                    type: string
+                    example: LeadMagic
+                  companyId:
+                    type: integer
+                    example: 75153174
+                  locations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        country:
+                          type: string
+                          example: US
+                        city:
+                          type: string
+                          example: Boston
+                        geographicArea:
+                          type: string
+                          example: Massachusetts
+                        postalCode:
+                          type: string
+                          example: "02210"
+                        line1:
+                          type: string
+                          example: 1 Seaport Ln
+                        line2:
+                          type: string
+                          nullable: true
+                          example: null
+                        description:
+                          type: string
+                          example: Headquarters
+                        headquarter:
+                          type: boolean
+                          example: true
+                        localizedName:
+                          type: string
+                          example: Boston
+                        latitude:
+                          type: number
+                          example: 42.36041
+                        longitude:
+                          type: number
+                          example: -71.05798
+                  employeeCount:
+                    type: integer
+                    example: 9
+                  specialities:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - Sales
+                      - Marketing
+                      - ABM
+                      - RevOps
+                  employeeCountRange:
+                    type: object
+                    properties:
+                      start:
+                        type: integer
+                        example: 11
+                      end:
+                        type: integer
+                        example: 50
+                  tagline:
+                    type: string
+                    example: Example Robotics provides enterprise software solutions for B2B companies. Their platform helps teams streamline operations and drive growth.
+                  followerCount:
+                    type: integer
+                    example: 4663
+                  industry:
+                    type: string
+                    example: Internet
+                  description:
+                    type: string
+                    example: LeadMagic tells you exactly what businesses are on your website and helps you enrich your contact and company data.
+                  websiteUrl:
+                    type: string
+                    example: https://leadmagic.io
+                  headquarter:
+                    type: object
+                    properties:
+                      country:
+                        type: string
+                        example: US
+                      city:
+                        type: string
+                        example: Boston
+                      geographicArea:
+                        type: string
+                        example: Massachusetts
+                      postalCode:
+                        type: string
+                        example: "02210"
+                      line1:
+                        type: string
+                        example: 1 Seaport Ln
+                      line2:
+                        type: string
+                        nullable: true
+                        example: null
+                      description:
+                        type: string
+                        example: Headquarters
+                  foundedOn:
+                    type: object
+                    properties:
+                      month:
+                        type: integer
+                        nullable: true
+                        example: null
+                      year:
+                        type: integer
+                        example: 2022
+                      day:
+                        type: integer
+                        nullable: true
+                        example: null
+                  universalName:
+                    type: string
+                    example: leadmagichq
+                  hashtag:
+                    type: string
+                    example: "#abm"
+                  url:
+                    type: string
+                    example: leadmagichq
+                  logo_url:
+                    type: string
+                    nullable: true
+                    description: Company logo URL from logo.leadmagic.io (generated from company domain)
+                    example: "https://logo.leadmagic.io/leadmagic.io"
+                  founded_year:
+                    type: string
+                    nullable: true
+                    description: Year the company was founded
+                    example: "2009"
+                  ownership_status:
+                    type: string
+                    nullable: true
+                    description: Ownership type (Public, Private, or Acquired)
+                    example: "Private"
+                  revenue:
+                    type: number
+                    nullable: true
+                    description: Estimated annual revenue
+                    example: 5100000000
+                  revenue_formatted:
+                    type: string
+                    nullable: true
+                    description: Human-readable revenue format
+                    example: "5.1B"
+                  employee_range:
+                    type: string
+                    nullable: true
+                    description: Employee count range
+                    example: "5,000 - 10,000"
+                  total_funding:
+                    type: string
+                    nullable: true
+                    description: Total funding raised
+                    example: "9.8B"
+                  funding_rounds:
+                    type: integer
+                    nullable: true
+                    description: Number of funding rounds completed
+                    example: 5
+                  last_funding_round:
+                    type: string
+                    nullable: true
+                    description: Type of most recent funding round
+                    example: "Equity"
+                  last_funding_amount:
+                    type: number
+                    nullable: true
+                    description: Amount raised in most recent funding round
+                    example: 694159778
+                  last_funding_date:
+                    type: string
+                    nullable: true
+                    description: Date of most recent funding round
+                    example: "Apr 2024"
+                  competitors:
+                    type: array
+                    nullable: true
+                    description: List of competitor company names
+                    items:
+                      type: string
+                    example:
+                      - "Rapyd"
+                      - "Square"
+                      - "PayPal"
+                      - "Clover"
+                      - "Payment Depot"
+                  acquisitions_count:
+                    type: integer
+                    nullable: true
+                    description: Number of acquisitions made by the company
+                    example: 3
+                  twitter_url:
+                    type: string
+                    nullable: true
+                    description: Twitter/X profile URL
+                    example: "https://twitter.com/leadmagichq"
+                  b2b_profile_url:
+                    type: string
+                    nullable: true
+                    description: B2B company profile URL
+                    example: "leadmagichq"
+                  facebook_url:
+                    type: string
+                    nullable: true
+                    description: Facebook page URL
+                    example: ""
+                  stock_ticker:
+                    type: string
+                    nullable: true
+                    description: Stock ticker symbol (if publicly traded)
+                    example: "STRP"
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/companies/company-funding:
+    post:
+      summary: Company Funding
+      description: Provide the Company Domain or Company Name and get back the complete funding details of the company.
+      operationId: company-funding
+      tags:
+        - Company Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                company_name:
+                  type: string
+                  description: Provide Company Name
+                  default: leadmagic
+                company_domain:
+                  type: string
+                  description: Provide Company Domain
+                  default: leadmagic.io
+      responses:
+        "200":
+          description: Successful response with company funding details
           content:
             application/json:
               schema:
@@ -1585,68 +3054,183 @@ paths:
                     properties:
                       companyName:
                         type: string
-                        examples:
-                        - Microsoft Corp.
+                        example: LeadMagic Inc
                       description:
                         type: string
+                        example: Example Robotics provides enterprise software solutions for B2B companies.
                       shortName:
                         type: string
-                        examples:
-                        - Microsoft
+                        example: LeadMagic
                       founded:
                         type: string
-                        examples:
-                        - '1975'
+                        example: "2015"
+                      headquarters:
+                        type: object
+                        properties:
+                          city:
+                            type: string
+                            example: Palo Alto
+                          state:
+                            type: string
+                            example: California
+                          country:
+                            type: string
+                            example: USA
+                          fullAddress:
+                            type: string
+                            example: Palo Alto, California, USA
                       primaryDomain:
                         type: string
-                        examples:
-                        - microsoft.com
+                        example: leadmagic.io
                       phone:
                         type: string
-                        examples:
-                        - 1-124-415-8000
+                        example: 1-650-276-3068
                       status:
                         type: string
-                        examples:
-                        - NEW
+                        example: NEW
                       followers:
                         type: integer
-                        examples:
-                        - 181691
+                        example: 2422
                       ownership:
                         type: string
-                        examples:
-                        - Public
+                        example: Private
                   financialInfo:
                     type: object
                     properties:
                       revenue:
                         type: integer
-                        examples:
-                        - 270010000000
+                        example: 178000000
                       formattedRevenue:
                         type: string
-                        examples:
-                        - 270B
+                        example: 178M
                       totalFunding:
                         type: integer
-                        examples:
-                        - 61000000
+                        example: 584000000
                       formattedFunding:
                         type: string
-                        examples:
-                        - 61M
+                        example: 584M
+                      lastFundingRound:
+                        type: object
+                        properties:
+                          round:
+                            type: string
+                            example: Series E
+                          date:
+                            type: string
+                            format: date-time
+                            example: "2021-05-01T00:00:00.000Z"
+                          amount:
+                            type: integer
+                            example: 250000000
+                  fundingHistory:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        round:
+                          type: string
+                          example: Series E
+                        date:
+                          type: string
+                          format: date-time
+                          example: "2021-05-01T00:00:00.000Z"
+                        amount:
+                          type: string
+                          example: $250,000,000
+                        investors:
+                          type: array
+                          items:
+                            type: string
+                          example:
+                            - Franklin Templeton
+                            - Coatue
+                            - Sequoia
+                            - Thrive Capital
+                            - Tiger Global
+                    example:
+                      - round: Series E
+                        date: "2021-05-01T00:00:00.000Z"
+                        amount: $250,000,000
+                        investors:
+                          - Franklin Templeton
+                          - Coatue
+                          - Sequoia
+                          - Thrive Capital
+                          - Tiger Global
+                      - round: Series D
+                        date: "2020-08-01T00:00:00.000Z"
+                        amount: $200,000,000
+                        investors:
+                          - Coatue
+                          - Index Ventures
+                          - Thrive Capital
+                          - Battery Ventures
+                          - NextWorld Capital
+                          - Norwest Venture Partners
+                          - Sequoia Capital
+                          - Wing Venture Capital
+                      - round: Series C
+                        date: "2019-12-01T00:00:00.000Z"
+                        amount: $65,000,000
+                        investors:
+                          - Sequoia Capital
+                          - Battery Ventures
+                          - Norwest Venture Partners
+                          - Wing Venture Capital
+                          - NextWorld Capital
+                          - Cisco Investments
                   companySize:
                     type: object
                     properties:
                       employees:
                         type: integer
-                        examples:
-                        - 221000
+                        example: 1100
                       employeeRange:
                         type: string
-                        examples:
-                        - 100,000 - 9,999,999
+                        example: 1,000 - 5,000
+                      employeeGrowth:
+                        type: string
+                        example: N/A
+                  leadership:
+                    type: object
+                    properties:
+                      ceo:
+                        type: object
+                        properties:
+                          firstName:
+                            type: string
+                            example: Amit
+                          lastName:
+                            type: string
+                            example: Bendov
+                          designation:
+                            type: string
+                            example: Co-Founder & CEO
+                          b2b_profile:
+                            type: string
+                            example: amitbendov
+                          twitter:
+                            type: string
+                            example: https://twitter.com/banditmove
+                  industryAndSectors:
+                    type: object
+                    properties:
+                      industrySectors:
+                        type: array
+                        items:
+                          type: string
+                        example:
+                          - Sales Enablement Software
+                          - Business Intelligence (BI)
+                      industries:
+                        type: array
+                        items:
+                          type: string
+                        example:
+                          - Software, Internet & Computer Services
+                      technologyStack:
+                        type: string
+                        example: N/A
                   topCompetitors:
                     type: array
                     items:
@@ -1654,48 +3238,2974 @@ paths:
                       properties:
                         name:
                           type: string
-                          examples:
-                          - IBM
+                          example: Chorus
                         revenue:
                           type: string
-                          examples:
-                          - ''
+                          example: $21
                         employees:
                           type: string
-                          examples:
-                          - 311,300
+                          example: "200"
+                        totalFunding:
+                          type: string
+                          example: $1,003
+                        headquarters:
+                          type: object
+                          properties:
+                            city:
+                              type: string
+                              example: San Francisco
+                            state:
+                              type: string
+                              example: US-CA
+                            country:
+                              type: string
+                              example: USA
+                            fullAddress:
+                              type: string
+                              example: San Francisco, US-CA, USA
+                        founded:
+                          type: string
+                          format: date-time
+                          example: "2015-01-01T00:00:00.000Z"
+                        ownership:
+                          type: string
+                          example: Private
                         website:
                           type: string
-                          examples:
-                          - https://www.ibm.com
+                          example: https://www.chorus.ai
+                    example:
+                      - name: BoostUp
+                        revenue: $6
+                        employees: "85"
+                        totalFunding: $425
+                        headquarters:
+                          city: Santa Clara
+                          state: US-CA
+                          country: USA
+                          fullAddress: Santa Clara, US-CA, USA
+                        founded: "2018-01-01T00:00:00.000Z"
+                        ownership: Private
+                        website: https://www.boostup.ai
+                      - name: ExecVision
+                        revenue: $43
+                        employees: "31"
+                        totalFunding: $81
+                        headquarters:
+                          city: Arlington
+                          state: US-VA
+                          country: USA
+                          fullAddress: Arlington, US-VA, USA
+                        founded: "2015-01-01T00:00:00.000Z"
+                        ownership: Private
+                        website: https://www.execvision.io
+                      - name: Seismic
+                        revenue: $375
+                        employees: 1,000
+                        totalFunding: $940
+                        headquarters:
+                          city: San Diego
+                          state: US-CA
+                          country: USA
+                          fullAddress: San Diego, US-CA, USA
+                        founded: "2010-01-01T00:00:00.000Z"
+                        ownership: Private
+                        website: https://seismic.com
+                  acquisitions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        companyName:
+                          type: string
+                          example: Vayo
+                        acquisitionDate:
+                          type: string
+                          format: date-time
+                          example: "2020-09-01T00:00:00.000Z"
+                        description:
+                          type: string
+                          example: Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business
+                        source:
+                          type: string
+                          example: https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo
+                    example:
+                      - companyName: Vayo
+                        acquisitionDate: "2020-09-01T00:00:00.000Z"
+                        description: Vayo is a SaaS-based firm that analyzes, integrates and converts customer data into actionable insights for business
+                        source: https://techcrunch.com/2020/09/01/fresh-off-200m-series-d-leadmagic-acquires-early-stage-startup-vayo
+                      - companyName: ONDiGO
+                        acquisitionDate: "2018-04-01T00:00:00.000Z"
+                        description: ONDiGO is a CRM platform that offers customer retention and management services to professionals and micro-businesses.
+                        source: https://www.prnewswire.com/news-releases/leadmagic-acquires-ondigo-to-extend-its-conversation-intelligence-platform-300630168.html
+                  socialMedia:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        platform:
+                          type: string
+                          example: twitter
+                        url:
+                          type: string
+                          example: https://twitter.com/leadmagic
+                    example:
+                      - platform: twitter
+                        url: https://twitter.com/leadmagic
+                      - platform: facebook
+                        url: https://www.facebook.com/To.LeadMagicHQ
+                      - platform: b2b_profile
+                        url: leadmagichq
+                  news:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                          example: "Example Robotics: Example Robotics Launches New Enterprise Platform"
+                        source:
+                          type: string
+                          example: Martech Cube
+                        date:
+                          type: string
+                          format: date-time
+                          example: "2024-08-07T08:40:00.000Z"
+                    example:
+                      - title: "Example Robotics: Example Robotics Launches New Enterprise Platform"
+                        source: TechCrunch
+                        date: "2024-08-07T08:40:00.000Z"
+                      - title: "Example Robotics: Example Robotics Partners with Example CRM"
+                        source: Business Wire
+                        date: "2024-06-26T22:15:00.000Z"
+                      - title: "Example Robotics Named Best SaaS Solution in 2024 Industry Awards"
+                        source: Forbes
+                        date: "2024-06-26T00:00:00.000Z"
+                  pressReleases:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        title:
+                          type: string
+                          example: "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
+                        source:
+                          type: string
+                          example: PR Newswire
+                        date:
+                          type: string
+                          format: date-time
+                          example: "2024-10-17T22:21:00.000Z"
+                    example:
+                      - title: "Press Release: Example Robotics Announces Strategic Partnership with Example Robotics"
+                        source: PR Newswire
+                        date: "2024-10-17T22:21:00.000Z"
+                      - title: "Press Release: Example Robotics Named a Winner in The Cloud Awards"
+                        source: PR Newswire
+                        date: "2024-10-09T18:28:00.000Z"
+                      - title: "Press Release: Example Robotics Recognized as Industry Leader by Example Research"
+                        source: Business Wire
+                        date: "2024-09-04T18:50:00.000Z"
+                  keyHighlights:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          example: partnership
+                        text:
+                          type: string
+                          example: Example Robotics Announces Strategic Partnership with Example Robotics
+                        date:
+                          type: string
+                          format: date-time
+                          example: "2024-10-17T22:21:00.000Z"
+                        src:
+                          type: string
+                          example: https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html
+                        source:
+                          type: string
+                          example: PR Newswire
+                    example:
+                      - type: partnership
+                        text: Example Robotics Announces Strategic Partnership with Example Robotics
+                        date: "2024-10-17T22:21:00.000Z"
+                        src: https://www.prnewswire.com/news-releases/acme-corp-announces-partnership-302271451.html
+                        source: PR Newswire
+                      - type: award
+                        text: Example Robotics Named a Winner in The Cloud Awards
+                        date: "2024-10-09T18:28:00.000Z"
+                        src: https://www.prnewswire.com/news-releases/acme-corp-cloud-awards-302271452.html
+                        source: PR Newswire
+                  summarySection:
+                    type: string
+                    example: Example Robotics provides enterprise software solutions for B2B companies. Example Robotics was founded in 2018. Example Robotics's headquarters is located in San Francisco, California, USA.
                   credits_consumed:
                     type: integer
-                    examples:
-                    - 4
-                required:
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /job-country:
-    get:
-      summary: Get Job Countries
-      description: Retrieve list of available countries for job filtering.
-      operationId: getJobCountries
+                    example: 4
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/companies/competitors-search:
+    post:
+      summary: Competitors Search
+      description: Find competitors of a company by analyzing market position and industry data.
+      operationId: competitors-search
       tags:
-      - Jobs
+        - Company Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                company_domain:
+                  type: string
+                  description: Company website domain
+                  example: leadmagic.io
+                company_url:
+                  type: string
+                  description: Company profile URL or identifier (optional)
+                  example: leadmagichq
+                company_name:
+                  type: string
+                  description: Company name
+                  example: LeadMagic
       responses:
-        '200':
-          description: List of available countries.
+        "200":
+          description: Successful response with competitors details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  competitors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          example: LeadMagic
+                        shortDescription:
+                          type: string
+                          example: "LeadMagic is a company that develops a conversation intelligence platform for B2B sales teams. "
+                        founded_year:
+                          type: string
+                          example: "2015"
+                        companyType:
+                          type: string
+                          example: private
+                        hq:
+                          type: string
+                          example: San Francisco, US
+                        employeesCount:
+                          type: integer
+                          example: 1504
+                        valuation:
+                          type: integer
+                          example: 7250000000
+                        tags:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                example: Technology
+                              slug:
+                                type: string
+                                example: technology
+                              primary:
+                                type: boolean
+                                example: true
+                        twitter_followers:
+                          type: integer
+                          example: 7611
+                        growth:
+                          type: integer
+                          example: 1
+                        non_hq_locations:
+                          type: array
+                          items:
+                            type: string
+                          example:
+                            - Dublin, IE
+                            - Ramat Gan, IL
+                            - Atlanta, US
+                            - Chicago, US
+                        more_locations:
+                          type: boolean
+                          example: false
+                        financial_metrics:
+                          type: object
+                          properties:
+                            currency_code:
+                              type: string
+                              example: USD
+                            period:
+                              type: string
+                              example: Y, 2020
+                            revenue:
+                              type: integer
+                              example: 37500000
+                            cost_of_goods_sold:
+                              type: integer
+                              nullable: true
+                              example: null
+                            gross_profit:
+                              type: integer
+                              nullable: true
+                              example: null
+                            net_income:
+                              type: integer
+                              nullable: true
+                              example: null
+                        operating_metrics:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              period:
+                                type: string
+                                example: Dec, 2019
+                              value:
+                                type: string
+                                example: "700.0"
+                              definition:
+                                type: string
+                                example: Enterprise Customers
+                              operating_metric_group:
+                                type: string
+                                example: Customers
+                              currency_code:
+                                type: string
+                                nullable: true
+                                example: null
+                        funding_metrics:
+                          type: object
+                          properties:
+                            date:
+                              type: string
+                              example: about 3 years
+                            latest:
+                              type: integer
+                              example: 250000000
+                            currency_code:
+                              type: string
+                              example: USD
+                            total:
+                              type: integer
+                              example: 581000000
+                        twitterEngagement:
+                          type: object
+                          properties:
+                            handle:
+                              type: string
+                              example: leadmagichq
+                            analytics:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  collectedAt:
+                                    type: string
+                                    example: "2023-07-12T00:00:00"
+                                  tweets:
+                                    type: integer
+                                    example: 6384
+                                  following:
+                                    type: integer
+                                    example: 1854
+                                  followers:
+                                    type: integer
+                                    example: 7611
+                                  tweetsForPeriod:
+                                    type: integer
+                                    example: 0
+                                  avgTweetsPerDay:
+                                    type: number
+                                    example: 0
+                                  avgRetweetsPerTweet:
+                                    type: number
+                                    example: 0
+                                  avgLikesPerTweet:
+                                    type: number
+                                    example: 0
+                                  tweetsPercentageEngagementForPeriod:
+                                    type: number
+                                    example: 0
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/companies/technographics:
+    post:
+      summary: Company Technographics
+      description: Get detailed technology stack information for any company by providing their domain.
+      operationId: technographics
+      tags:
+        - Company Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - company_domain
+              properties:
+                company_domain:
+                  type: string
+                  description: The domain of the company to analyze
+                  example: leadmagic.io
+      responses:
+        "200":
+          description: Successful response with technology stack information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  credits_consumed:
+                    type: integer
+                    example: 1
+                  message:
+                    type: string
+                    example: Technology stack information retrieved successfully
+                  data:
+                    type: array
+                    description: Array of technologies found. Omitted or empty when no data is available.
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: The name of the technology
+                          example: Google Analytics
+                        description:
+                          type: string
+                          description: Description of the technology
+                          example: Google Analytics is a web analytics service offered by Google that tracks and reports website traffic.
+                        categories:
+                          type: array
+                          description: Categories this technology belongs to
+                          items:
+                            type: string
+                          example:
+                            - Analytics
+                            - Marketing
+                        sub_technologies:
+                          type: array
+                          description: Sub-technologies or related tools
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: Name of the sub-technology
+                                example: Google Analytics 4
+                              description:
+                                type: string
+                                description: Description of the sub-technology
+                                example: The latest version of Google Analytics with enhanced privacy features
+                              categories:
+                                type: array
+                                items:
+                                  type: string
+                                description: Categories for the sub-technology
+                                example:
+                                  - Analytics
+                                  - Privacy-focused
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  # ============================================================
+  # People Enrichment Endpoints
+  # ============================================================
+  /v1/people/role-finder:
+    post:
+      summary: Role Finder
+      description: Provide the company name or domain and the required job title, and retrieve the corresponding person.
+      operationId: role-finder
+      tags:
+        - People Enrichment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                company_name:
+                  type: string
+                  description: Business Profile URL (with url or public_identifier)
+                  default: leadmagic
+                company_domain:
+                  type: string
+                  description: Company domain
+                  default: leadmagic.io
+                job_title:
+                  type: string
+                  description: Enter the job title you want to find in the company.
+                  default: ceo
+      responses:
+        "200":
+          description: Successful response with role details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    example: Alex Rivera
+                  profile_url:
+                    type: string
+                    example: alex-rivera
+                  first_name:
+                    type: string
+                    example: Alex
+                  last_name:
+                    type: string
+                    example: Rivera
+                  message:
+                    type: string
+                    example: Role found.
+                  credits_consumed:
+                    type: integer
+                    example: 2
+                  company_name:
+                    type: string
+                    example: Leadmagic
+                  company_website:
+                    type: string
+                    example: leadmagic.io
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/people/employee-finder:
+    post:
+      summary: Employee Finder
+      description: Find employees at a company. Returns a list of employees with their profiles, titles, and locations. Costs 0.05 credits per employee returned — free when no employees are found.
+      operationId: employee-finder
+      tags:
+        - People Enrichment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                company_domain:
+                  type: string
+                  description: Company website domain (preferred — more accurate than company_name)
+                  default: leadmagic.io
+                company_name:
+                  type: string
+                  description: Company name. Use if domain is not available.
+                  default: leadmagic
+                limit:
+                  type: integer
+                  description: Maximum number of employees to return
+                  default: 10
+      responses:
+        "200":
+          description: Successful response with employee list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  employees:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        first_name:
+                          type: string
+                          example: Alex
+                        last_name:
+                          type: string
+                          example: Rivera
+                        full_name:
+                          type: string
+                          example: Alex Rivera
+                        profile_url:
+                          type: string
+                          example: example.com/in/alex-rivera
+                        job_title:
+                          type: string
+                          example: VP of Sales
+                        location:
+                          type: string
+                          example: San Francisco, CA
+                  total_count:
+                    type: integer
+                    description: Total employees found (may exceed returned count when limit is set)
+                    example: 150
+                  credits_consumed:
+                    type: number
+                    description: Credits used (0.05 per employee returned)
+                    example: 0.5
+                  message:
+                    $ref: '#/components/schemas/EmployeeFinderMessages'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v3/people/search:
+    post:
+      summary: People Search
+      description: Canonical V3 people lookup with all company, title, role, people, channel, and contact-detail filters.
+      operationId: people-search
+      tags:
+        - People Enrichment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              properties:
+                company_domain:
+                  type: string
+                  example: leadmagic.io
+                company_name:
+                  type: string
+                  example: LeadMagic
+                linkedin_url:
+                  type: string
+                  description: B2B company profile URL or slug.
+                  example: https://www.example.com/company/acme/
+                company_filters:
+                  type: object
+                  additionalProperties: true
+                  description: Criteria-based company set. Supports the full Company Search filter family.
+                people_filters:
+                  type: object
+                  additionalProperties: true
+                  description: >
+                    People-level filters for names, title/function/level, geography, profile URLs,
+                    headline/about-me/industry, languages, seniority, connection count, and channel
+                    availability. Canonical keys use the contact_* prefix (e.g. contact_linkedin_about_me);
+                    bare aliases such as about_me, headline, industry, job_function, and city are accepted.
+                    contact_job_function accepts short chips (Sales, Marketing, Finance, …) or full standard
+                    labels (Sales & Business Development, …); matching is exact after chip→label expansion and
+                    response rows always return the standard label. Multiple values in one array are OR'd;
+                    different people_filters keys in one request are AND'd. Keys the search cannot honor are
+                    echoed in interpreted_search.ignored_people_filters rather than silently dropped.
+                title:
+                  type: string
+                  example: VP Sales
+                job_title:
+                  type: string
+                  example: Head of Revenue
+                titles:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 12
+                roles:
+                  type: array
+                  items:
+                    type: string
+                  maxItems: 12
+                query:
+                  type: string
+                  description: Free-text people/title query.
+                required_email:
+                  type: boolean
+                  description: Only return people with email availability.
+                required_mobile:
+                  type: boolean
+                  description: Only return people with mobile availability.
+                channels:
+                  type: array
+                  items:
+                    type: string
+                    enum: [email, phone]
+                  description: Legacy alias for contactability requirements.
+                channel_match:
+                  type: string
+                  enum: [any, all]
+                  default: any
+                include_company:
+                  type: boolean
+                  default: true
+                include_domain_intel:
+                  type: boolean
+                  default: true
+                include_contact_details:
+                  type: boolean
+                  default: false
+                  description: >
+                    Opt in to paid raw email/mobile fields (alias — full_search). Bills 1 extra credit
+                    per returned email and 5 per returned mobile; base results are 1 credit per returned person.
+                    Search RPS / unmetered people-search plans cannot unlock email or mobile (403); unlocks
+                    require a credit-metered plan.
+                include_email:
+                  type: boolean
+                  description: >
+                    When contact details are on, return and bill raw emails (+1 credit each).
+                    If neither include_email nor include_mobile is set, both default to true.
+                    If either flag is set, the omitted flag defaults to false (include_email=true alone is email-only).
+                include_mobile:
+                  type: boolean
+                  description: >
+                    When contact details are on, return and bill raw mobiles (+5 credits each).
+                    Same default rules as include_email.
+                confirm_credit_charge:
+                  type: boolean
+                  default: false
+                  description: Accepted for backwards compatibility; does not bypass RPS/unmetered unlock restrictions.
+                limit:
+                  type: integer
+                  default: 25
+                  minimum: 1
+                  maximum: 10000
+                  description: Offset requests allow up to 10000 rows; cursor-based pages are capped at 50.
+                cursor:
+                  type: string
+                  description: Opaque signed next_cursor from the previous page. Send unchanged with the same filters, a limit no greater than 50, and offset 0.
+                offset:
+                  type: integer
+                  default: 0
+                  minimum: 0
+                  deprecated: true
+                  description: >
+                    Legacy offset pagination; prefer cursor. Unstable ordering, uncached.
+                    Restart at offset 0 to obtain a cursor.
+            example:
+              company_filters:
+                company_domains:
+                  - leadmagic.io
+                crm_tech:
+                  - Salesforce
+              people_filters:
+                contact_job_level:
+                  - VP
+                  - Director
+                contact_job_function:
+                  - Sales
+                is_sales: true
+                min_contactability_score: 40
+              titles:
+                - VP Sales
+                - Head of Revenue
+              required_email: true
+              limit: 10
+      responses:
+        "200":
+          description: People search results
+          headers:
+            RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+            X-RateLimit-RPS-Limit:
+              $ref: '#/components/headers/SearchRpsLimit'
+            X-RateLimit-RPS-Remaining:
+              $ref: '#/components/headers/SearchRpsRemaining'
+            X-RateLimit-RPS-Reset:
+              $ref: '#/components/headers/SearchRpsReset'
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  message:
+                    type: string
+                  credits_consumed:
+                    type: number
+                  credit_preview:
+                    type: object
+                    additionalProperties: true
+                  people:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                      properties:
+                        contact_linkedin_url:
+                          type: string
+                          nullable: true
+                        contact_linkedin_username:
+                          type: string
+                          nullable: true
+                        contact_first_name:
+                          type: string
+                          nullable: true
+                        contact_last_name:
+                          type: string
+                          nullable: true
+                        contact_full_name:
+                          type: string
+                          nullable: true
+                        contact_email:
+                          type: string
+                          nullable: true
+                        contact_email_domain:
+                          type: string
+                          nullable: true
+                        contact_mobile_phone:
+                          type: string
+                          nullable: true
+                        contact_direct_phone:
+                          type: string
+                          nullable: true
+                        contact_linkedin_headline:
+                          type: string
+                          nullable: true
+                        contact_linkedin_industry:
+                          type: string
+                          nullable: true
+                        contact_linkedin_about_me:
+                          type: string
+                          nullable: true
+                        contact_city:
+                          type: string
+                          nullable: true
+                        contact_state:
+                          type: string
+                          nullable: true
+                        contact_state_code:
+                          type: string
+                          nullable: true
+                        contact_country:
+                          type: string
+                          nullable: true
+                        contact_country_code:
+                          type: string
+                          nullable: true
+                        contact_region:
+                          type: string
+                          nullable: true
+                        contact_continent:
+                          type: string
+                          nullable: true
+                        contact_job_title:
+                          type: string
+                          nullable: true
+                        contact_job_function:
+                          type: string
+                          nullable: true
+                          description: >
+                            Standard department label for the person's current role
+                            (e.g. Sales & Business Development). Filter requests may use
+                            short chips such as Sales; responses always return this standard label.
+                        contact_job_level:
+                          type: string
+                          nullable: true
+                        contact_job_description:
+                          type: string
+                          nullable: true
+                        contact_job_start_date:
+                          type: string
+                          nullable: true
+                        contact_job_count:
+                          type: integer
+                          nullable: true
+                        contact_persona:
+                          type: string
+                          nullable: true
+                        contact_job_city:
+                          type: string
+                          nullable: true
+                        contact_job_country:
+                          type: string
+                          nullable: true
+                        contact_job_country_code:
+                          type: string
+                          nullable: true
+                        contact_job_region:
+                          type: string
+                          nullable: true
+                        contact_job_continent:
+                          type: string
+                          nullable: true
+                        contact_job_state:
+                          type: string
+                          nullable: true
+                        contact_job_state_code:
+                          type: string
+                          nullable: true
+                        contact_company_name:
+                          type: string
+                          nullable: true
+                        company_domain:
+                          type: string
+                          nullable: true
+                        contact_education:
+                          type: string
+                          nullable: true
+                        contact_skills:
+                          type: string
+                          nullable: true
+                        contact_certifications:
+                          type: string
+                          nullable: true
+                        contact_languages:
+                          type: string
+                          nullable: true
+                        contact_websites:
+                          type: string
+                          nullable: true
+                        seniority_score:
+                          type: integer
+                          nullable: true
+                        has_email:
+                          type: boolean
+                        has_mobile_phone:
+                          type: boolean
+                        has_phone:
+                          type: boolean
+                        is_cio:
+                          type: boolean
+                          nullable: true
+                        is_it_leader:
+                          type: boolean
+                          nullable: true
+                        is_security:
+                          type: boolean
+                          nullable: true
+                        is_revops:
+                          type: boolean
+                          nullable: true
+                        is_recruiting:
+                          type: boolean
+                          nullable: true
+                        is_engineering:
+                          type: boolean
+                          nullable: true
+                        is_sales:
+                          type: boolean
+                          nullable: true
+                        is_marketing:
+                          type: boolean
+                          nullable: true
+                        is_operations:
+                          type: boolean
+                          nullable: true
+                        contactability_score:
+                          type: integer
+                          nullable: true
+                        profile_completeness_score:
+                          type: integer
+                          nullable: true
+                        job_observation_count:
+                          type: integer
+                          nullable: true
+                        distinct_company_count:
+                          type: integer
+                          nullable: true
+                        followers:
+                          type: integer
+                          nullable: true
+                        company:
+                          type: object
+                          nullable: true
+                          additionalProperties: true
+                        domain_intel:
+                          type: object
+                          nullable: true
+                          additionalProperties: true
+                        unlock:
+                          type: object
+                          nullable: true
+                          additionalProperties: true
+                  companies:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                  count:
+                    type: integer
+                  returned_count:
+                    type: integer
+                  limit_applied:
+                    type: integer
+                  offset:
+                    type: integer
+                  has_more:
+                    type: boolean
+                  next_cursor:
+                    type: string
+                    nullable: true
+                    description: Opaque signed token for the next page, or null on the last page. Send back as cursor with offset 0. Cursor pagination is stable and cached.
+                  metadata:
+                    type: object
+                    additionalProperties: true
+                    properties:
+                      pagination:
+                        type: string
+                        enum:
+                          - snapshot
+                          - cursor
+                          - offset
+                        description: snapshot/cursor for cursor/first-page responses; offset for legacy offset responses.
+              example:
+                message: People found
+                credits_consumed: 0
+                count: 120
+                returned_count: 25
+                limit_applied: 25
+                offset: 25
+                has_more: true
+                next_cursor: null
+                metadata:
+                  query_name: people_search_v3
+                  query_path: full_search
+                  pagination: offset
+                people:
+                  - contact_linkedin_url: "https://example.com/in/jane-doe"
+                    contact_linkedin_username: "jesseoue"
+                    contact_first_name: "Jesse"
+                    contact_last_name: "Ouellette"
+                    contact_full_name: "Jesse Ouellette"
+                    contact_email: "jesse@leadmagic.io"
+                    contact_email_domain: "leadmagic.io"
+                    contact_mobile_phone: "+12073561898"
+                    contact_direct_phone: null
+                    contact_linkedin_headline: "Growth & AI Expert | Founder LeadMagic"
+                    contact_linkedin_about_me: "SaaS Founder"
+                    contact_city: "Boston"
+                    contact_state: "Massachusetts"
+                    contact_state_code: "MA"
+                    contact_country: "United States"
+                    contact_country_code: "US"
+                    contact_region: "NORAM"
+                    contact_continent: "North America"
+                    contact_job_title: "Founder"
+                    contact_job_function: "General Business & Management"
+                    contact_job_level: "C-Team"
+                    contact_job_description: "LeadMagic is the Best B2B Email & Mobile Finder"
+                    contact_job_start_date: "2022-09-01"
+                    contact_job_count: 15
+                    contact_persona: "Founder/Co-Founder"
+                    contact_company_name: "Leadmagic"
+                    company_domain: "leadmagic.io"
+                    seniority_score: 5
+                    has_email: true
+                    has_mobile_phone: true
+                    has_phone: false
+                    followers: 500
+                    company:
+                      company_domain: "leadmagic.io"
+                      company_name: "Leadmagic"
+                      company_website: "https://www.leadmagic.io"
+                      company_industry_linkedin: "Internet Publishing"
+                      employee_range: "11 to 50"
+                      employee_min: 11
+                      employee_max: 50
+                      linkedin_employee_count: 10
+                      revenue_range: "$1M to <$10M"
+                      revenue_min: "4000000"
+                      revenue_max: "4000000"
+                      hq_country: "United States"
+                      hq_country_code: "US"
+                      hq_city: "Boston"
+                      hq_state: "Massachusetts"
+                      founded_year: 2022
+                      linkedin_followers: 8804
+                      growth_rate: 14
+                      linkedin_url: "https://www.example.com/company/acme"
+                      company_headline: "The data provider other data providers use. Emails, mobiles, and company data that don't bounce."
+                    domain_intel:
+                      company_domain: "leadmagic.io"
+                      company_name: "Leadmagic"
+                      company_website: "https://www.leadmagic.io"
+                      company_domain_tld: "leadmagic.io"
+                      company_website_active: true
+                      primary_email_domain: "leadmagic.io"
+                      email_pattern: "first"
+                      email_pattern_example: "soufiane@leadmagic.io"
+                      email_pattern_confidence: 100
+                      email_pattern_confidence_tier: "low"
+                      total_email_count: 4
+                      valid_email_count: 4
+                      total_contacts: 10
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+  /v3/companies/search:
+    post:
+      summary: Company Search
+      description: Canonical V3 company lookup with all company filters.
+      operationId: company-search-v3
+      tags:
+        - Company Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              properties:
+                company_domain:
+                  type: string
+                  description: Direct one-company lookup input. Returns one rich company row plus legacy-friendly aliases when no broad filters or explicit limit are supplied.
+                  example: leadmagic.io
+                domain:
+                  type: string
+                  description: Alias for company_domain.
+                website:
+                  type: string
+                  description: Company website URL or domain.
+                company_name:
+                  type: string
+                  description: Company name lookup input.
+                profile_url:
+                  type: string
+                  description: Company profile URL.
+                linkedin_url:
+                  type: string
+                  description: Company profile URL.
+                company_filters:
+                  type: object
+                  additionalProperties: true
+                  description: Full company filter object.
+                query:
+                  type: string
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 50
+                  default: 10
+                cursor:
+                  type: string
+                  description: Opaque next_cursor from the previous page. Send unchanged with the same filters and limit.
+                offset:
+                  type: integer
+                  minimum: 0
+                  default: 0
+                  deprecated: true
+                  description: >
+                    Legacy offset pagination; prefer cursor. Unstable ordering, uncached.
+                    Restart at offset 0 to obtain a cursor.
+            example:
+              limit: 10
+              company_filters:
+                company_domains:
+                  - leadmagic.io
+                country_codes:
+                  - US
+                location_country_codes:
+                  - US
+                crm_tech:
+                  - Salesforce
+                has_funding: true
+                website_active: true
+      responses:
+        "200":
+          description: Company search results
+          headers:
+            RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+            X-RateLimit-RPS-Limit:
+              $ref: '#/components/headers/SearchRpsLimit'
+            X-RateLimit-RPS-Remaining:
+              $ref: '#/components/headers/SearchRpsRemaining'
+            X-RateLimit-RPS-Reset:
+              $ref: '#/components/headers/SearchRpsReset'
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  message:
+                    type: string
+                  credits_consumed:
+                    type: number
+                  companies:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                      properties:
+                        company_domain:
+                          type: string
+                        company_name:
+                          type: string
+                        company_website:
+                          type: string
+                        company_industry_linkedin:
+                          type: string
+                        employee_range:
+                          type: string
+                        employee_min:
+                          type: integer
+                        employee_max:
+                          type: integer
+                        linkedin_employee_count:
+                          type: integer
+                        revenue_range:
+                          type: string
+                        revenue_min:
+                          type: string
+                        revenue_max:
+                          type: string
+                        hq_country:
+                          type: string
+                        hq_country_code:
+                          type: string
+                        hq_city:
+                          type: string
+                        hq_state:
+                          type: string
+                        hq_street:
+                          type: string
+                          nullable: true
+                        hq_postcode:
+                          type: string
+                          nullable: true
+                        hq_region:
+                          type: string
+                        hq_continent:
+                          type: string
+                          nullable: true
+                        location_city:
+                          type: string
+                          nullable: true
+                        location_country_code:
+                          type: string
+                          nullable: true
+                        location_region:
+                          type: string
+                          nullable: true
+                        location_state_code:
+                          type: string
+                          nullable: true
+                        founded_year:
+                          type: integer
+                          nullable: true
+                        specialties:
+                          type: string
+                          nullable: true
+                        total_funding:
+                          type: number
+                          nullable: true
+                        funding_investor_count:
+                          type: integer
+                          nullable: true
+                        last_funding_type:
+                          type: string
+                          nullable: true
+                        last_funding_date:
+                          type: string
+                          nullable: true
+                        last_funding_amount:
+                          type: number
+                          nullable: true
+                        lead_investors:
+                          type: string
+                          nullable: true
+                          description: Not returned in standard company search responses.
+                        linkedin_followers:
+                          type: integer
+                          nullable: true
+                        growth_rate:
+                          type: integer
+                          nullable: true
+                        linkedin_url:
+                          type: string
+                          nullable: true
+                        linkedin_claimed:
+                          type: boolean
+                        company_headline:
+                          type: string
+                          nullable: true
+                        company_about:
+                          type: string
+                          nullable: true
+                        company_phone:
+                          type: string
+                          nullable: true
+                        company_entity_type:
+                          type: string
+                          nullable: true
+                        company_legal_type:
+                          type: string
+                          nullable: true
+                        has_tech_stack:
+                          type: boolean
+                        profile_completeness_score:
+                          type: integer
+                          nullable: true
+                        total_contacts:
+                          type: integer
+                        contacts_with_email:
+                          type: integer
+                        contacts_with_phone:
+                          type: integer
+                        valid_email_count:
+                          type: integer
+                        website_active:
+                          type: boolean
+                        website_for_sale:
+                          type: boolean
+                        sic_code:
+                          type: string
+                          nullable: true
+                        naics_code:
+                          type: string
+                          nullable: true
+                        sic_description:
+                          type: string
+                          nullable: true
+                        naics_description:
+                          type: string
+                          nullable: true
+                        predicted_naics_2022_code:
+                          type: string
+                          nullable: true
+                        domain_tld:
+                          type: string
+                        total_app_reviews:
+                          type: integer
+                        crm_tech:
+                          type: string
+                          nullable: true
+                        marketing_automation_tech:
+                          type: string
+                          nullable: true
+                        sales_automation_tech:
+                          type: string
+                          nullable: true
+                        analytics_tech:
+                          type: string
+                          nullable: true
+                        cloud_provider_tech:
+                          type: string
+                          nullable: true
+                        development_tech:
+                          type: string
+                          nullable: true
+                        ecommerce_tech:
+                          type: string
+                          nullable: true
+                        erp_tech:
+                          type: string
+                          nullable: true
+                        email_hosting_tech:
+                          type: string
+                          nullable: true
+                        email_security_tech:
+                          type: string
+                          nullable: true
+                        abm_tech:
+                          type: string
+                          nullable: true
+                        cms_tech:
+                          type: string
+                          nullable: true
+                        conversation_intelligence_tech:
+                          type: string
+                          nullable: true
+                        app_security_tech:
+                          type: string
+                          nullable: true
+                        cloud_security_tech:
+                          type: string
+                          nullable: true
+                        company_martech:
+                          type: string
+                          nullable: true
+                        category:
+                          type: array
+                          items:
+                            type: string
+                  found:
+                    type: boolean
+                    description: Present for one-company lookup requests.
+                  company:
+                    type: object
+                    nullable: true
+                    additionalProperties: true
+                    description: Present for one-company lookup requests. Contains the first returned company row.
+                  companyName:
+                    type: string
+                    nullable: true
+                    description: Present for one-company lookup requests. Alias for company.company_name.
+                  companyDomain:
+                    type: string
+                    nullable: true
+                    description: Present for one-company lookup requests. Alias for company.company_domain.
+                  websiteUrl:
+                    type: string
+                    nullable: true
+                    description: Present for one-company lookup requests. Alias for company.company_website.
+                  linkedinUrl:
+                    type: string
+                    nullable: true
+                    description: Present for one-company lookup requests. Alias for company.linkedin_url.
+                  count:
+                    type: integer
+                  returned_count:
+                    type: integer
+                  limit_applied:
+                    type: integer
+                  offset:
+                    type: integer
+                  has_more:
+                    type: boolean
+                  next_cursor:
+                    type: string
+                    nullable: true
+                    description: Opaque signed token for the next page, or null on the last page. Send back as cursor with offset 0. Cursor pagination is stable and cached.
+                  interpreted_search:
+                    type: object
+                    additionalProperties: true
+                  metadata:
+                    type: object
+                    additionalProperties: true
+                    properties:
+                      pagination:
+                        type: string
+                        enum:
+                          - snapshot
+                          - cursor
+                          - offset
+                        description: snapshot/cursor for cursor/first-page responses; offset for legacy offset responses.
+              example:
+                message: Companies found
+                credits_consumed: 0
+                count: 120
+                returned_count: 25
+                limit_applied: 25
+                offset: 25
+                has_more: true
+                next_cursor: null
+                metadata:
+                  pagination: offset
+                companies:
+                  - company_domain: "leadmagic.io"
+                    company_name: "Leadmagic"
+                    company_website: "https://www.leadmagic.io"
+                    employee_range: "11 to 50"
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+  /v3/companies/lookalike:
+    post:
+      summary: Company Lookalike
+      description: |
+        Find similar companies from a seed domain or description with full company output.
+        Costs **5 credits** when one or more lookalikes are returned; **free** when empty.
+        Common aliases (`domain`, `website`, `company_website`, `name`) and misspellings
+        (`companny_domain`, `limmit`, …) are accepted and remapped. `preview: true` is
+        chatbot-UI only — API keys receive 400.
+      operationId: company-lookalike-v3
+      tags:
+        - Company Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              properties:
+                company_domain:
+                  type: string
+                  description: Seed company domain. Aliases include domain, website, company_website, seed.domain. Typos like companny_domain are remapped.
+                  example: leadmagic.io
+                domain:
+                  type: string
+                  description: Alias for company_domain.
+                website:
+                  type: string
+                  description: Seed website URL or domain.
+                company_website:
+                  type: string
+                  description: Alias for website.
+                company_name:
+                  type: string
+                  description: Seed company name used as text intent when no domain is supplied.
+                name:
+                  type: string
+                  description: Alias for company_name.
+                description:
+                  type: string
+                  description: Free-text seed description.
+                company_description:
+                  type: string
+                  description: Alias for description.
+                seed:
+                  type: object
+                  additionalProperties: true
+                  description: Optional seed object. Prefer seed.domain.
+                company_filters:
+                  type: object
+                  additionalProperties: true
+                  description: Same full company filter family as Company Search. Alias filters.
+                filters:
+                  type: object
+                  additionalProperties: true
+                  description: Alias for company_filters.
+                preview:
+                  type: boolean
+                  default: false
+                  description: Free preview — chatbot UI only. API/MCP clients receive 400.
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 2000
+                  default: 25
+                  description: Page size. Typos like limmit are remapped.
+                offset:
+                  type: integer
+                  minimum: 0
+                  default: 0
+            example:
+              company_domain: leadmagic.io
+              company_filters:
+                country_codes:
+                  - US
+                location_country_codes:
+                  - US
+                employee_ranges:
+                  - 51 to 200
+                  - 201 to 500
+                crm_tech:
+                  - Salesforce
+                has_tech_stack: true
+                website_active: true
+              limit: 25
+      responses:
+        "200":
+          description: Company lookalike results (flat JSON body — not wrapped in data)
+          headers:
+            X-Credits-Cost:
+              schema:
+                type: number
+              description: Credits reserved before finalization (5)
+            X-Credits-Consumed:
+              schema:
+                type: number
+              description: Credits actually charged (0 or 5)
+            X-Credits-Remaining:
+              schema:
+                type: number
+              description: Wallet credits remaining after this request
+            X-Credits-Total:
+              schema:
+                type: number
+            X-Request-Id:
+              schema:
+                type: string
+            RateLimit-Remaining:
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                required:
+                  - message
+                  - credits_consumed
+                  - companies
+                  - count
+                  - returned_count
+                properties:
+                  message:
+                    type: string
+                    example: Lookalike companies found
+                  credits_consumed:
+                    type: number
+                    description: Flat 5 when results returned; 0 when empty
+                    example: 5
+                  companies:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                      properties:
+                        company_domain:
+                          type: string
+                        company_name:
+                          type: string
+                        company_website:
+                          type: string
+                        company_industry_linkedin:
+                          type: string
+                        employee_range:
+                          type: string
+                        employee_min:
+                          type: integer
+                        employee_max:
+                          type: integer
+                        linkedin_employee_count:
+                          type: integer
+                        revenue_range:
+                          type: string
+                        revenue_min:
+                          type: string
+                        revenue_max:
+                          type: string
+                        hq_country:
+                          type: string
+                        hq_country_code:
+                          type: string
+                        hq_city:
+                          type: string
+                        hq_state:
+                          type: string
+                        similarity:
+                          type: number
+                          description: Lookalike similarity score when available
+                        source_seed_domain:
+                          type: string
+                        match_context:
+                          type: string
+                  count:
+                    type: integer
+                    example: 5
+                  returned_count:
+                    type: integer
+                    example: 5
+                  limit_applied:
+                    type: integer
+                    example: 25
+                  offset:
+                    type: integer
+                    example: 0
+                  interpreted_search:
+                    type: object
+                    additionalProperties: true
+                    description: Normalized seed and company_filters used for the query
+                  metadata:
+                    type: object
+                    additionalProperties: true
+                    properties:
+                      query_name:
+                        type: string
+                        example: company_lookalike_v3
+                      query_path:
+                        type: string
+                        example: lookalike
+                      preview:
+                        type: boolean
+                      degraded:
+                        type: boolean
+                        description: True when upstream was briefly unavailable and an empty free response was returned
+              example:
+                message: Lookalike companies found
+                credits_consumed: 5
+                companies:
+                  - company_domain: tomba.io
+                    company_name: Tomba.Io
+                    similarity: 0.88
+                count: 1
+                returned_count: 1
+                limit_applied: 25
+                offset: 0
+                interpreted_search:
+                  seed:
+                    domain: leadmagic.io
+                  company_filters: {}
+                metadata:
+                  query_name: company_lookalike_v3
+                  query_path: lookalike
+                  preview: false
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+
+  # ============================================================
+  # Jobs Endpoints
+  # ============================================================
+  /v1/jobs/jobs-finder:
+    post:
+      summary: Jobs Finder
+      description: LeadMagic's Jobs Finder
+      operationId: jobs-finder
+      tags:
+        - Jobs Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                company_name:
+                  type: string
+                  description: Provide the Company Name. (Optional)
+                  example: Clay
+                company_website:
+                  type: string
+                  description: Provide the Company Website. (Optional)
+                  example: clay.com
+                job_title:
+                  type: string
+                  description: Provide the Job Title.
+                  example: RevOps Engineer
+                location:
+                  type: string
+                  description: Location of the job
+                  example: United States
+                experience_level:
+                  type: string
+                  description: Indicates the required experience level for the job. Choose "entry" for Entry Level, "mid" for Mid Level, "senior" for Senior Level, or "executive" for Executive Level. If not specified, jobs from all experience levels will be included.
+                  example: senior
+                job_description:
+                  type: string
+                  description: Filters jobs based on specific keywords or phrases found in the job description.
+                  example: leadmagic
+                city_name:
+                  type: string
+                  description: Filter jobs by city name. Pair with `country_id` to disambiguate cities that share a name.
+                  example: Austin
+                country_id:
+                  type: string
+                  description: Filter jobs by country code, such as US or GB. Use the country helper for supported values.
+                  example: US
+                region_id:
+                  type: integer
+                  description: Filter jobs by region ID.
+                  example: 5
+                job_type_id:
+                  type: integer
+                  description: Filter jobs by job type ID.
+                  example: 1
+                company_type_id:
+                  type: integer
+                  description: Filter jobs by company type ID.
+                  example: 1
+                company_industry_id:
+                  type: integer
+                  description: Filter jobs by company industry ID.
+                  example: 7
+                min_employees:
+                  type: integer
+                  description: Minimum number of employees
+                  example: 51
+                max_employees:
+                  type: integer
+                  description: Maximum number of employees
+                  example: 10000
+                has_remote:
+                  type: boolean
+                  description: Determines whether the jobs offer remote work options. Set to true to include remote-only listings, or false to include non-remote listings.
+                  example: true
+                posted_within:
+                  type: integer
+                  description: Specify the number of days within which the job was posted.
+                  example: 30
+                posted_after:
+                  type: string
+                  format: date
+                  description: Filters jobs posted on or after a specific date. Use the format YYYY-MM-DD.
+                  example: "2026-05-01"
+                posted_before:
+                  type: string
+                  format: date
+                  description: Filters jobs posted on or before a specific date. Use the format YYYY-MM-DD.
+                  example: "2026-05-15"
+                page:
+                  type: integer
+                  description: Page number
+                  default: 1
+                per_page:
+                  type: integer
+                  description: Provide number of results needed per page. (Maximum per_page can be 50)
+                  default: 20
+            example:
+              company_website: clay.com
+              job_title: RevOps Engineer
+              country_id: US
+              has_remote: true
+              posted_within: 30
+              page: 1
+              per_page: 20
+      responses:
+        "200":
+          description: Successful response with job listings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_count:
+                    type: integer
+                    default: 0
+                  page:
+                    type: integer
+                    default: 0
+                  per_page:
+                    type: integer
+                    default: 0
+                  total_pages:
+                    type: integer
+                    default: 0
+                  credits_consumed:
+                    type: integer
+                    default: 0
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        company:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              example: LeadMagic
+                            website_url:
+                              type: string
+                              example: https://leadmagic.io
+                            b2b_profile_url:
+                              type: string
+                              nullable: true
+                              example: leadmagichq
+                            twitter_handle:
+                              type: string
+                              nullable: true
+                              example: leadmagichq
+                            github_url:
+                              type: string
+                              nullable: true
+                              example: https://github.com/leadmagic
+                        title:
+                          type: string
+                        location:
+                          type: string
+                        types:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                default: 0
+                              name:
+                                type: string
+                        cities:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              geonameid:
+                                type: integer
+                                default: 0
+                              asciiname:
+                                type: string
+                              name:
+                                type: string
+                        country:
+                          type: object
+                        timezone:
+                          type: string
+                        latitude:
+                          type: string
+                        longitude:
+                          type: string
+                        countries:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              code:
+                                type: string
+                              name:
+                                type: string
+                        region:
+                          type: object
+                        regions:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                                default: 0
+                              name:
+                                type: string
+                        has_remote:
+                          type: boolean
+                          default: true
+                        published:
+                          type: string
+                        description:
+                          type: string
+                        application_url:
+                          type: string
+                        language:
+                          type: string
+                          nullable: true
+                        clearance_required:
+                          type: boolean
+                          default: true
+                        salary_min:
+                          type: string
+                          nullable: true
+                        salary_max:
+                          type: string
+                          nullable: true
+                        salary_currency:
+                          type: string
+                          nullable: true
+                        experience_level:
+                          type: string
+                example:
+                  total_count: 50
+                  page: 1
+                  per_page: 20
+                  total_pages: 3
+                  credits_consumed: 20
+                  results:
+                    - company:
+                        name: LeadMagic
+                        website_url: https://leadmagic.io
+                        b2b_profile_url: leadmagichq
+                        twitter_handle: leadmagichq
+                        github_url: https://github.com/leadmagic
+                      title: Senior Software Engineer
+                      location: San Jose, San José, Costa Rica
+                      types:
+                        - id: 1
+                          name: Full Time
+                      cities:
+                        - geonameid: 3621849
+                          asciiname: San Jose
+                          name: San José
+                          country:
+                            code: CR
+                            name: Costa Rica
+                            region:
+                              id: 5
+                              name: North America
+                          timezone: America/Costa_Rica
+                          latitude: "9.93333"
+                          longitude: "-84.08333"
+                      countries:
+                        - code: CR
+                          name: Costa Rica
+                          region:
+                            id: 5
+                            name: North America
+                      regions:
+                        - id: 5
+                          name: North America
+                      has_remote: false
+                      published: "2024-07-23T15:25:00Z"
+                      description: ""
+                      application_url: https://leadmagic.io/careers
+                      language: en
+                      clearance_required: false
+                      salary_min: null
+                      salary_max: null
+                      salary_currency: null
+                      experience_level: Senior Level
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v3/jobs/search:
+    post:
+      summary: Job Search
+      description: Search jobs with title, occupation taxonomy, company, location, tag, salary, seniority, and date filters. The endpoint resolves friendly values into normalized filter IDs before searching. Company objects do not include logo fields.
+      operationId: job-search
+      tags:
+        - Jobs Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                titles:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        type: string
+                    exclude:
+                      type: array
+                      items:
+                        type: string
+                    vector:
+                      type: boolean
+                      default: false
+                occupationTaxonomy:
+                  type: object
+                  properties:
+                    level1:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    level2:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    level3:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                companies:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        type: string
+                    exclude:
+                      type: array
+                      items:
+                        type: string
+                    ids:
+                      type: array
+                      items:
+                        type: integer
+                location:
+                  type: object
+                  properties:
+                    countries:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    regions:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    states:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    cities:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                tags:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    exclude:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                salary:
+                  type: object
+                  properties:
+                    min_usd:
+                      type: integer
+                    max_usd:
+                      type: integer
+                seniority:
+                  type: array
+                  items:
+                    type: string
+                postedAfter:
+                  type: string
+                  format: date
+                postedBefore:
+                  type: string
+                  format: date
+                postedWithin:
+                  type: integer
+                  description: Include jobs posted within the last N days.
+                languages:
+                  type: array
+                  items:
+                    type: string
+                hasRemote:
+                  type: boolean
+                jobTypeIds:
+                  type: array
+                  items:
+                    type: integer
+                industryIds:
+                  type: array
+                  items:
+                    type: integer
+                companyTypeIds:
+                  type: array
+                  items:
+                    type: integer
+                companySizeCodes:
+                  type: array
+                  items:
+                    type: integer
+                limit:
+                  type: integer
+                  default: 25
+                  maximum: 50
+                cursor:
+                  type: string
+                  description: Opaque cursor from pagination.next_cursor. Send unchanged with the same filters and limit.
+                includeDescription:
+                  type: boolean
+                  default: false
+                  description: Include job description text. Enabling descriptions may increase response time.
+                includeFacets:
+                  type: boolean
+                  default: false
+                  description: Include facet metadata. Enabling facets may increase response time.
+                totalMode:
+                  type: string
+                  default: capped
+                  enum: [none, capped, exact]
+                mode:
+                  type: string
+                  default: fast
+                  enum: [fast, deep]
+                  description: fast returns paginated browsing results when descriptions and facets are omitted; deep enables broader text matching.
+                autoResolve:
+                  type: boolean
+                  default: true
+            example:
+              titles:
+                include:
+                  - Engineer
+                vector: false
+              occupationTaxonomy:
+                level2:
+                  - DevOps
+              location:
+                countries:
+                  - US
+              postedWithin: 30
+              limit: 5
+              totalMode: none
+              mode: fast
+              autoResolve: true
+      responses:
+        "200":
+          description: Job search results
+          headers:
+            RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+            X-RateLimit-RPS-Limit:
+              $ref: '#/components/headers/SearchRpsLimit'
+            X-RateLimit-RPS-Remaining:
+              $ref: '#/components/headers/SearchRpsRemaining'
+            X-RateLimit-RPS-Reset:
+              $ref: '#/components/headers/SearchRpsReset'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  signals:
+                    type: array
+                    items:
+                      type: object
+                  total:
+                    type: integer
+                  totalMode:
+                    type: string
+                  pagination:
+                    type: object
+                    properties:
+                      limit:
+                        type: integer
+                      returned:
+                        type: integer
+                      has_more:
+                        type: boolean
+                      next_cursor:
+                        type: string
+                        nullable: true
+                  has_more:
+                    type: boolean
+                  next_cursor:
+                    type: string
+                    nullable: true
+                  resolved:
+                    type: object
+                  credits_consumed:
+                    type: integer
+              example:
+                signals:
+                  - title: Full-Stack Software Engineer
+                    company:
+                      id: 102413
+                      name: Example Company
+                      website_url: https://example.com
+                    occupation_taxonomy:
+                      level1:
+                        id: 1
+                        name: Developer
+                      level2:
+                        id: 20
+                        name: Full-Stack Development
+                      level3:
+                        id: 774
+                        name: Full-stack software engineer
+                total: 3
+                totalMode: capped
+                credits_consumed: 1
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+  /v3/search/stats:
+    post:
+      summary: Search Stats
+      description: Free helper endpoint that returns cached high-level coverage, capabilities, and top dimensions for Jobs, Company, and People Search.
+      operationId: search-stats-v3
+      tags:
+        - Jobs Data
+        - Company Data
+        - People Enrichment
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              properties:
+                products:
+                  type: array
+                  description: Search products to include — jobs, company, and/or people stats.
+                  items:
+                    type: string
+                    enum: [jobs, company, people]
+                  default: [jobs, company, people]
+                sections:
+                  type: array
+                  description: Stat sections to return — coverage counts, top dimensions, and/or filter capabilities.
+                  items:
+                    type: string
+                    enum: [coverage, top, capabilities]
+                  default: [coverage, top, capabilities]
+                limit:
+                  type: integer
+                  description: Max top values per dimension. Defaults to 3.
+                  minimum: 1
+                  maximum: 25
+                  default: 3
+            example:
+              products: [jobs, company, people]
+              sections: [coverage, top]
+              limit: 10
+      responses:
+        "200":
+          description: Search stats results
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+  /v3/jobs-search:
+    post:
+      summary: Job Search Alias
+      description: Alias for POST /v3/jobs/search.
+      operationId: job-search-alias
+      tags:
+        - Jobs Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                titles:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        type: string
+                    vector:
+                      type: boolean
+                      default: false
+                location:
+                  type: object
+                  properties:
+                    countries:
+                      type: array
+                      items:
+                        type: string
+                tags:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        type: string
+                limit:
+                  type: integer
+                  default: 25
+                  maximum: 50
+                totalMode:
+                  type: string
+                  default: capped
+                  enum: [none, capped, exact]
+                mode:
+                  type: string
+                  default: fast
+                  enum: [fast, deep]
+            example:
+              titles:
+                include:
+                  - Software Engineer
+                vector: false
+              location:
+                countries:
+                  - US
+              limit: 5
+              totalMode: none
+              mode: fast
+      responses:
+        "200":
+          description: Job search results
+  /v3/jobs/search/resolve:
+    post:
+      summary: Resolve Job Search filters
+      description: Resolve friendly companies, countries, tags, occupation taxonomy values, and titles into canonical filter IDs. This endpoint does not return job rows and is free.
+      operationId: job-search-resolve
+      tags:
+        - Jobs Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                companies:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        type: string
+                    exclude:
+                      type: array
+                      items:
+                        type: string
+                    ids:
+                      type: array
+                      items:
+                        type: integer
+                tags:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    exclude:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                occupationTaxonomy:
+                  type: object
+                  properties:
+                    level1:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    level2:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    level3:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                location:
+                  type: object
+                  properties:
+                    countries:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    regions:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    states:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                    cities:
+                      type: array
+                      items:
+                        oneOf:
+                          - type: string
+                          - type: integer
+                titles:
+                  type: object
+                  properties:
+                    include:
+                      type: array
+                      items:
+                        type: string
+                    exclude:
+                      type: array
+                      items:
+                        type: string
+              example:
+                companies:
+                  include:
+                    - leadmagic.io
+                tags:
+                  include:
+                    - kubernetes
+                occupationTaxonomy:
+                  level2:
+                    - DevOps
+                location:
+                  countries:
+                    - US
+                titles:
+                  include:
+                    - Site Reliability Engineer
+      responses:
+        "200":
+          description: Resolved filters
+  /v3/jobs/search/companies:
+    get:
+      summary: Job Search Companies Helper
+      description: Company autocomplete and cards for Job Search.
+      operationId: job-search-companies
+      tags:
+        - Jobs Data
+      parameters:
+        - name: q
+          in: query
+          example: leadmagic
+          schema:
+            type: string
+        - name: domain
+          in: query
+          example: leadmagic.io
+          schema:
+            type: string
+        - name: limit
+          in: query
+          example: 10
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Company helper results
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                companies:
+                  - id: 102413
+                    name: LeadMagic
+                    domain: leadmagic.io
+                    logo_domain: leadmagic.io
+  /v3/jobs/search/tags:
+    get:
+      summary: Job Search Tags Helper
+      description: Tag autocomplete with occupation taxonomy metadata.
+      operationId: job-search-tags
+      tags:
+        - Jobs Data
+      parameters:
+        - name: q
+          in: query
+          example: kuber
+          schema:
+            type: string
+        - name: tag_type
+          in: query
+          example: 2
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          example: 10
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Tag helper results
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                tags:
+                  - id: 482
+                    name: kubernetes
+                    tag_type: 2
+                    occupation_taxonomy:
+                      level1:
+                        id: 1
+                        name: Developer
+                      level2:
+                        id: 20
+                        name: DevOps
+  /v3/jobs/search/titles:
+    get:
+      summary: Job Search Titles Helper
+      description: Title autocomplete with occupation taxonomy metadata.
+      operationId: job-search-titles
+      tags:
+        - Jobs Data
+      parameters:
+        - name: q
+          in: query
+          example: devops engineer
+          schema:
+            type: string
+        - name: limit
+          in: query
+          example: 10
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Title helper results
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                titles:
+                  - id: 774
+                    name: DevOps Engineer
+                    occupation_taxonomy:
+                      level1:
+                        id: 1
+                        name: Developer
+                      level2:
+                        id: 20
+                        name: DevOps
+                      level3:
+                        id: 774
+                        name: DevOps Engineer
+  /v3/jobs/search/occupation-taxonomy:
+    get:
+      summary: Job Search Occupation Taxonomy Helper
+      description: Occupation taxonomy autocomplete with level1, level2, and level3 IDs and labels.
+      operationId: job-search-occupation-taxonomy
+      tags:
+        - Jobs Data
+      parameters:
+        - name: q
+          in: query
+          example: DevOps
+          schema:
+            type: string
+        - name: level
+          in: query
+          example: level2
+          schema:
+            type: string
+            enum: [level1, level2, level3]
+        - name: limit
+          in: query
+          example: 10
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Occupation taxonomy helper results
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                occupation_taxonomy:
+                  - id: 1700834
+                    name: .NET & DevOps
+                    type: 2
+                    level1:
+                      id: 7
+                      name: Engineer
+                    level2:
+                      id: 1700834
+                      name: .NET & DevOps
+                    level3: null
+                    path: Engineer > .NET & DevOps
+                credits_consumed: 0
+  /v3/jobs/search/locations:
+    get:
+      summary: Job Search Locations Helper
+      description: Country, region, state, and city autocomplete for exact geo filters.
+      operationId: job-search-locations
+      tags:
+        - Jobs Data
+      parameters:
+        - name: q
+          in: query
+          example: United
+          schema:
+            type: string
+        - name: type
+          in: query
+          example: country
+          schema:
+            type: string
+            enum: [country, region, state, city]
+        - name: limit
+          in: query
+          example: 10
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Location helper results
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                locations:
+                  - id: 840
+                    name: United States
+                    type: country
+                  - id: 826
+                    name: United Kingdom
+                    type: country
+  /v3/jobs/search/catalogs:
+    get:
+      summary: Job Search Catalogs
+      description: Filter catalogs for countries, regions, job types, industries, company types, seniority, and public-safe Jobs Search stats.
+      operationId: job-search-catalogs
+      tags:
+        - Jobs Data
+      responses:
+        "200":
+          description: Catalog response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                countries:
+                  - id: 840
+                    name: United States
+                  - id: 826
+                    name: United Kingdom
+                job_types:
+                  - id: 1
+                    name: Full-time
+                  - id: 2
+                    name: Part-time
+                  - id: 3
+                    name: Contract
+                industries:
+                  - id: 96
+                    name: Software
+                company_types:
+                  - id: 1
+                    name: Private
+                  - id: 2
+                    name: Public
+                seniority:
+                  - id: 1
+                    name: Entry
+                  - id: 5
+                    name: VP
+                stats:
+                  total_jobs_indexed: 12500000
+                  freshness_days: 1
+  /v3/jobs/search/roles:
+    get:
+      summary: Job Search Roles Helper
+      description: Role autocomplete for occupation-based filtering, mapped to occupation taxonomy IDs.
+      operationId: job-search-roles
+      tags:
+        - Jobs Data
+      parameters:
+        - name: q
+          in: query
+          example: revenue operations
+          schema:
+            type: string
+        - name: limit
+          in: query
+          example: 10
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Role helper results
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                roles:
+                  - id: 20
+                    name: Revenue Operations
+                    occupation_taxonomy:
+                      level1:
+                        id: 5
+                        name: Operations
+                      level2:
+                        id: 20
+                        name: Revenue Operations
+  /v3/jobs/search/stats:
+    get:
+      summary: Job Search Dataset Stats
+      description: Public-safe dataset statistics for the Jobs Search index — totals and freshness. Free.
+      operationId: job-search-stats
+      tags:
+        - Jobs Data
+      responses:
+        "200":
+          description: Dataset statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                stats:
+                  total_jobs_indexed: 12500000
+                  freshness_days: 1
+  /v3/jobs/search/job-board/stats:
+    get:
+      summary: Job Board Stats
+      description: Alias of Job Search Dataset Stats for job-board integrations. Free.
+      operationId: job-board-stats
+      tags:
+        - Jobs Data
+      responses:
+        "200":
+          description: Dataset statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                stats:
+                  total_jobs_indexed: 12500000
+                  freshness_days: 1
+  /v3/jobs/search/export:
+    post:
+      summary: Job Search Export
+      description: Bulk export of job postings using the full Job Search filter vocabulary. Returns up to 5,000 jobs per request with descriptions included by default. Credit-metered on all plans.
+      operationId: job-search-export
+      tags:
+        - Jobs Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              properties:
+                titles:
+                  type: object
+                  additionalProperties: true
+                  description: Same title filters as Job Search, including include/exclude and vector.
+                companies:
+                  type: object
+                  additionalProperties: true
+                location:
+                  type: object
+                  additionalProperties: true
+                tags:
+                  type: object
+                  additionalProperties: true
+                occupationTaxonomy:
+                  type: object
+                  additionalProperties: true
+                salary:
+                  type: object
+                  additionalProperties: true
+                workModes:
+                  type: array
+                  items:
+                    type: integer
+                postedWithin:
+                  type: integer
+                  description: Days back, max 365.
+                includeDescription:
+                  type: boolean
+                  default: true
+                includeCompany:
+                  type: boolean
+                  default: true
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 5000
+                  default: 100
+                  description: Maximum jobs to export. Cursor pagination is not supported on export; narrow filters instead.
+            example:
+              titles:
+                include: ["Software Engineer"]
+              location:
+                countries: ["US"]
+              postedWithin: 30
+              limit: 500
+      responses:
+        "200":
+          description: Exported jobs
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                jobs:
+                  - id: "j_01hxyz"
+                    title: Software Engineer
+                    company:
+                      name: Example Corp
+                      domain: example.com
+                    location: United States
+                    posted_at: "2026-08-01"
+                    description: Full posting text…
+                total_returned: 500
+                credits_consumed: 500
+  /v1/jobs/countries:
+    get:
+      summary: Job Country
+      description: Use this API to retrieve the country ID, which can then be used in the Jobs Finder API to filter jobs by country.
+      operationId: job-country
+      tags:
+        - Jobs Data
+      responses:
+        "200":
+          description: Successful response with country list
           content:
             application/json:
               schema:
@@ -1705,32 +6215,33 @@ paths:
                   properties:
                     id:
                       type: string
-                      examples:
-                      - US
-                      - CA
-                      - UK
                     name:
                       type: string
-                      examples:
-                      - United States
-                      - Canada
-                      - United Kingdom
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /job-types:
+                example:
+                  - id: AL
+                    name: Albania
+                  - id: DZ
+                    name: Algeria
+                  - id: AD
+                    name: Andorra
+                  - id: AO
+                    name: Angola
+                  - id: AG
+                    name: Antigua and Barbuda
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/jobs/regions:
     get:
-      summary: Get Job Types
-      description: Retrieve list of available job types for filtering.
-      operationId: getJobTypes
+      summary: Job Region
+      description: Use this API to retrieve the region ID, which can then be used in the Jobs Finder API to filter jobs by region.
+      operationId: job-regions
       tags:
-      - Jobs
+        - Jobs Data
       responses:
-        '200':
-          description: List of available job types.
+        "200":
+          description: Successful response with region list
           content:
             application/json:
               schema:
@@ -1740,189 +6251,525 @@ paths:
                   properties:
                     id:
                       type: integer
-                      examples:
-                      - 1
-                      - 2
-                      - 3
+                      default: 0
                     name:
                       type: string
-                      examples:
-                      - Full Time
-                      - Part Time
-                      - Contract
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /personal-email-finder:
-    post:
-      summary: Personal Email Finder
-      description: Find personal email addresses from B2B profile URLs.
-      operationId: findPersonalEmail
+                example:
+                  - id: 1
+                    name: Africa
+                  - id: 2
+                    name: Asia/Pacific
+                  - id: 3
+                    name: Europe
+                  - id: 4
+                    name: Middle East
+                  - id: 5
+                    name: North America
+                  - id: 6
+                    name: South America
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/jobs/job-types:
+    get:
+      summary: Job Type
+      description: Use this API to retrieve the Job Type ID, which can then be used in the Jobs Finder API to filter jobs by Job Type.
+      operationId: job-types
       tags:
-      - Email
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - profile_url
-              properties:
-                profile_url:
-                  type: string
-                  description: B2B profile URL (for example, a professional social profile)
-                  examples:
-                  - https://profiles.example.com/williamhgates/
+        - Jobs Data
       responses:
-        '200':
-          description: Personal email search response.
+        "200":
+          description: Successful response with job type list
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  personal_email:
-                    type:
-                    - string
-                    - 'null'
-                    examples:
-                    - bill.gates@gmail.com
-                  status:
-                    type: string
-                    enum:
-                    - found
-                    - not_found
-                    examples:
-                    - found
-                  credits_consumed:
-                    type: integer
-                    examples:
-                    - 1
-                  message:
-                    type: string
-                    examples:
-                    - Personal email found
-                    - Personal email not found
-                required:
-                - status
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /b2b-social-email:
-    post:
-      summary: B2B Social to Email
-      description: Find work email addresses from B2B profile URLs.
-      operationId: socialToWorkEmail
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      default: 0
+                    name:
+                      type: string
+                example:
+                  - id: 1
+                    name: Full Time
+                  - id: 2
+                    name: Part Time
+                  - id: 3
+                    name: Temporary
+                  - id: 4
+                    name: Internship
+                  - id: 5
+                    name: Freelance
+                  - id: 6
+                    name: Contract
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/jobs/company-types:
+    get:
+      summary: Job Company Type
+      description: Use this API to retrieve the Company Type ID, which can then be used in the Jobs Finder API to filter jobs by Company Type.
+      operationId: job-company-types
       tags:
-      - Email
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - profile_url
-              properties:
-                profile_url:
-                  type: string
-                  description: B2B profile URL (for example, a professional social profile)
-                  examples:
-                  - https://profiles.example.com/williamhgates/
+        - Jobs Data
       responses:
-        '200':
-          description: Work email search response.
+        "200":
+          description: Successful response with company type list
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  work_email:
-                    type:
-                    - string
-                    - 'null'
-                    examples:
-                    - bill.gates@microsoft.com
-                  status:
-                    type: string
-                    enum:
-                    - found
-                    - not_found
-                    examples:
-                    - found
-                  credits_consumed:
-                    type: integer
-                    examples:
-                    - 1
-                  message:
-                    type: string
-                    examples:
-                    - Work email found
-                    - Work email not found
-                required:
-                - status
-                - credits_consumed
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /b2b/searchads:
-    post:
-      summary: B2B Ads Search
-      description: Search for B2B Ads based on a company's domain or name.
-      operationId: searchB2BAds
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      default: 0
+                    name:
+                      type: string
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/jobs/industries:
+    get:
+      summary: Job Industry
+      description: Use this API to retrieve the Industry ID, which can then be used in the Jobs Finder API to filter jobs by Industry.
+      operationId: job-industry
       tags:
-      - Advertisements
+        - Jobs Data
+      responses:
+        "200":
+          description: Successful response with industry list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                      default: 0
+                    name:
+                      type: string
+                example:
+                  - id: 22
+                    name: Accounting
+                  - id: 318
+                    name: Administration of Justice
+                  - id: 297
+                    name: Administrative and Support Services
+                  - id: 8
+                    name: Advertising Services
+                  - id: 245
+                    name: Agricultural Chemical Manufacturing
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  # ============================================================
+  # Ads Data Endpoints
+  # ============================================================
+  /v1/ads/google-ads-search:
+    post:
+      summary: Google Ads Search
+      description: Search for Google Ads run by a company to understand their advertising strategy.
+      operationId: google-ads-search
+      tags:
+        - Ads Data
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              description: Provide a company name or domain to search for ads.
               properties:
                 company_domain:
                   type: string
-                  examples:
-                  - microsoft.com
+                  description: Company domain name
+                  default: leadmagic.io
+                  example: leadmagic.io
                 company_name:
                   type: string
-                  examples:
-                  - Microsoft
+                  description: Company name
+                  default: leadmagic
+                  example: leadmagic
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  description: >-
+                    Maximum number of ads to return. Because you are charged 1 credit
+                    per ad returned, this also caps the credits spent on the request.
+                    Omit to return every ad found.
+                  example: 10
       responses:
-        '200':
-          description: Successful retrieval of B2B Ads.
+        "200":
+          description: Successful response with ads details
           content:
             application/json:
               schema:
                 type: object
                 properties:
+                  message:
+                    type: string
+                    example: "Google Ads retrieved successfully"
                   credits_consumed:
                     type: number
-                    examples:
-                    - 5
+                    example: 2
+                  ads_count:
+                    type: integer
+                    example: 2
+                  ads:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        advertiser_id:
+                          type: string
+                          example: "123456"
+                        creative_id:
+                          type: string
+                          example: "789012"
+                        original_url:
+                          type: string
+                          example: https://www.example.com/ad
+                        variants:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              content:
+                                type: string
+                                example: <img src="https://tpc.googlesyndication.com/archive/simgad/6399633577457746150" height="173" width="380">
+                              height:
+                                type: integer
+                                nullable: true
+                                example: 173
+                              width:
+                                type: integer
+                                nullable: true
+                                example: 380
+                        start:
+                          type: string
+                          example: "2023-01-01"
+                        last_seen:
+                          type: string
+                          example: "2023-12-31"
+                        advertiser_name:
+                          type: string
+                          example: Example Company
+                        format:
+                          type: string
+                          example: Text
+                example:
+                  ads:
+                    - advertiser_id: AR14106062795078369281
+                      creative_id: CR14003695067076755457
+                      original_url: https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR14003695067076755457?region=anywhere
+                      variants:
+                        - content: <img src="https://tpc.googlesyndication.com/archive/simgad/6399633577457746150" height="173" width="380">
+                          height: 173
+                          width: 380
+                      start: "2024-07-03"
+                      last_seen: "2025-03-06"
+                      advertiser_name: LeadMagic Inc
+                      format: Text
+                    - advertiser_id: AR14106062795078369281
+                      creative_id: CR16065875974473908225
+                      original_url: https://adstransparency.google.com/advertiser/AR14106062795078369281/creative/CR16065875974473908225?region=anywhere
+                      variants:
+                        - content: <img src="https://tpc.googlesyndication.com/archive/simgad/14075255850026292628" height="173" width="380">
+                          height: 173
+                          width: 380
+                      start: "2025-02-04"
+                      last_seen: "2025-03-06"
+                      advertiser_name: LeadMagic Inc
+                      format: Text
+
+                  credits_consumed: 2
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/ads/meta-ads-search:
+    post:
+      summary: Meta Ads Search
+      description: Search for Meta Ads by company domain or name.
+      operationId: meta-ads-search
+      tags:
+        - Ads Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                company_domain:
+                  type: string
+                  description: Company domain name
+                  default: leadmagic.io
+                  example: leadmagic.io
+                company_name:
+                  type: string
+                  description: Company name
+                  default: leadmagic
+                  example: leadmagic
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  description: >-
+                    Maximum number of ads to return. Because you are charged 1 credit
+                    per ad returned, this also caps the credits spent on the request.
+                    Omit to return every ad found.
+                  example: 10
+      responses:
+        "200":
+          description: Successful response with ads details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Meta Ads retrieved successfully"
+                  credits_consumed:
+                    type: number
+                    example: 1
+                  ads_count:
+                    type: integer
+                    example: 1
+                  ads:
+                    type: array
+                    description: Array of ad objects (structure varies by ad type)
+                    items:
+                      type: object
+                example:
+                  message: "Meta Ads retrieved successfully"
+                  credits_consumed: 1
+                  ads_count: 1
+                  ads:
+                    - adid: "0"
+                      adArchiveID: "618153827656899"
+                      archiveTypes: []
+                      categories:
+                        - 0
+                      containsDigitallyCreatedMedia: false
+                      containsSensitiveContent: false
+                      collationCount: 1
+                      collationID: 1015196963820298
+                      currency: ""
+                      endDate: 1741248000
+                      entityType: person_profile
+                      fevInfo: null
+                      finServAdData:
+                        is_deemed_finserv: false
+                        is_limited_delivery: false
+                      gatedType: eligible
+                      hasUserReported: false
+                      hiddenSafetyData: false
+                      hideDataStatus: NONE
+                      impressionsWithIndex:
+                        impressionsText: null
+                        impressionsIndex: -1
+                      isAAAEligible: true
+                      isAdAccountActioned: false
+                      isActive: true
+                      isProfilePage: false
+                      pageID: "105549201674375"
+                      pageInfo: null
+                      pageIsDeleted: false
+                      pageName: Lykkedal Retreat
+                      politicalCountries: []
+                      reachEstimate: null
+                      regionalRegulationData:
+                        finserv:
+                          is_deemed_finserv: false
+                          is_limited_delivery: false
+                        tw_anti_scam:
+                          is_limited_delivery: false
+                      reportCount: null
+                      snapshot:
+                        ad_creative_id: 1159245568945589
+                        cards: []
+                        body_translations: {}
+                        byline: null
+                        caption: ezme.io
+                        cta_text: Buy tickets
+                        dynamic_item_flags: {}
+                        dynamic_versions: null
+                        edited_snapshots: []
+                        effective_authorization_category: NONE
+                        event:
+                          event_promoted_type: external_tickets
+                          event_start_timestamp: 1742130000
+                          event_end_timestamp: 1742137200
+                          event_location: Dalvej 5, Helsinge
+                          event_timezone: Europe/Copenhagen
+                        extra_images: []
+                        extra_links: []
+                        extra_texts: []
+                        extra_videos: []
+                        instagram_shopping_products: []
+                        display_format: event
+                        title: Yin Yoga & Yoga Nidra til LeadMagic
+                        link_description: Dalvej 5, Helsinge
+                        link_url: https://ezme.io/c/xHa/3KPb
+                        page_welcome_message: null
+                        images:
+                          - original_image_url: https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/481787314_4001422706744378_5754827939445302437_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=oLiF-cU0WxgQ7kNvgEM6GgD&_nc_oc=AdgH2C1dxKtFX8-Nb0xC8YJj9RAGxYUVx4s72-vlBMvSF8NqRSDRTgLtQ49bxn4GKvU&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYFCcwS06k5-Zs4REiVNPyDBnDiH2m3ry6__l8b-xYVnNw&oe=67D010D7
+                            resized_image_url: https://scontent-iad3-2.xx.fbcdn.net/v/t39.35426-6/482055202_1183219813458252_5286390622516633466_n.jpg?stp=dst-jpg_s600x600_tt6&_nc_cat=106&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=UpMVtSZb0FoQ7kNvgGYCYSO&_nc_oc=AdioNK9N0BC6jFliPpZBoCB7q8c6RxzPm1sjxYyWN8gW1fEzj5ort06-PEXPS9aRQtY&_nc_zt=14&_nc_ht=scontent-iad3-2.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYET5FXrho887m4dU5OxwmVKM8nNNYMDyPzbcrFDRHPNkQ&oe=67CFD900
+                            watermarked_resized_image_url: ""
+                            image_crops: {}
+                        videos: []
+                        creation_time: 1741291804
+                        page_id: 105549201674375
+                        page_name: Lykkedal Retreat
+                        page_profile_picture_url: https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482021866_1335378004273354_6611332374691484765_n.jpg?stp=dst-jpg_s60x60_tt6&_nc_cat=107&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=9OkGTrz7rR0Q7kNvgG57RTD&_nc_oc=AdhR7nxSqcwLeXf4E6zMven92LUORzNF9f6UG5HdXPkNcCJwnCvuJsEFIkd2qEkf1mc&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYHvvv7TVyYBBZbUWdFtsMMF1Zw19HFrCguT8PizFkDG-w&oe=67CFF9CB
+                        page_categories:
+                          "1215982301785137": Meditation Center
+                        page_entity_type: person_profile
+                        page_is_profile_page: false
+                        instagram_actor_name: 🔆 ET LIV I BALANCE 🔆
+                        instagram_profile_pic_url: https://scontent-iad3-1.xx.fbcdn.net/v/t39.35426-6/482221977_1473904650233662_1812261223336634635_n.jpg?_nc_cat=102&ccb=1-7&_nc_sid=c53f8f&_nc_ohc=pt8glJ939ioQ7kNvgEhv2uO&_nc_oc=Adi7fFY9dROfonTLhbM1HQhTr-sBDcj7xGQeKttehNVcjEKjKkBqWDm69xB9k8lQLk4&_nc_zt=14&_nc_ht=scontent-iad3-1.xx&_nc_gid=AxNB6smfEOXOGrm59sveePu&oh=00_AYH7uq0g9Ag0DFiPvgZdXyt_1LXYO8ZrWuCq--rMrhWQfw&oe=67CFE12C
+                        instagram_url: ""
+                        instagram_handle: ""
+                        is_reshared: false
+                        version: 3
+                        body:
+                          context: {}
+                          markup:
+                            __html: "🌿 Yin Yoga &amp; LeadMagic Meditation i jurten på Lykkedal Retreat 🌿<br /> <br /> Trænger du til en dyb pause, hvor krop og sind får lov at give slip og finde ro? ✨<br /> <br /> 🧘‍♀️ Yin Yoga er en blid, meditativ yogaform, der arbejder med kroppens bindevæv, led og energibaner gennem lange, rolige stræk. Stillingerne holdes i flere minutter, så kroppen får tid til at slippe spændinger og finde dybere afslapning. Alle kan være med – uanset erfaring.<br /> <br /> 🎶 LeadMagic Meditation fordyber din afslapning gennem dybe, vibrerende lyde, der beroliger nervesystemet og inviterer sindet til at give slip. Mange oplever en følelse af lethed, ro og fornyet energi efter en meditation.<br /> <br /> 📅 Dato: Søndag d. 16. marts<br /> ⏰ Tid: Kl. 14:00 - 16:00<br /> 📍 Sted: Lykkedal Retreat, Dalvej 5, Helsinge<br />       Pris: 275 kr.<br /> <br /> 🌿 Efter workshoppen byder vi på økologisk urtete og lækre snacks i vores hyggelige skovcafé. Her kan du nyde en stille stund og mærke effekten af din praksis. Tag en mindful gåtur i naturen og hils på dyrene – en smuk måde at afslutte dagen på.<br /> <br /> 🔔 Alle er velkomne – uanset erfaring! 🔔<br /> <br /> 💚 Tilmelding &amp; info:<br /> 📩 Send besked til Natassia på info&#064;lykkedalretreat.dk eller tlf. 2390 7473<br /> <br /> 🌾 Lykkedal Retreat – en perle i Nordsjællands natur 🌾<br /> Her finder du åbne marker med heste, høje træer og den smukke gamle Pibe Mølle. Workshoppen afholdes i den stemningsfulde jurt/rundsal, hvor du kan fordybe dig i ro og nærvær.<br /> <br /> ✨ Tidligere deltagere siger:<br /> 🌟 &quot;Lykkedal er et åndehul i naturen&quot;<br /> 🌟 &quot;Jeg kom hjem i mig selv&quot;<br /> 🌟 &quot;Jeg havde glemt, hvor meget jeg savner naturen&quot;<br /> <br /> 📩 Book din plads i dag – vi glæder os til at byde dig velkommen!<br /> <br /> #YinYoga #LeadMagicMeditation #LykkedalRetreat #IndreRo #NaturligBalance #Mindfulness #Selvforkælelse #TidTilDigSelv"
+                          callerHash: c339298372ed2a9ebf3ad02f136b05d2
+                        brazil_tax_id: null
+                        branded_content: null
+                        current_page_name: Lykkedal Retreat
+                        disclaimer_label: null
+                        page_like_count: 1198
+                        page_profile_uri: https://facebook.com/LykkedalRetreat
+                        page_is_deleted: false
+                        root_reshared_post: null
+                        cta_type: BUY_TICKETS
+                        additional_info: null
+                        ec_certificates: null
+                        country_iso_code: null
+                        instagram_branded_content: null
+                      spend: null
+                      startDate: 1741248000
+                      stateMediaRunLabel: null
+                      publisherPlatform:
+                        - facebook
+                        - instagram
+                      menuItems: []
+                      targetedOrReachedCountries: []
+                      totalActiveTime: 7915
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/ads/b2b-ads-search:
+    post:
+      summary: B2B Search Ads
+      description: Search for B2B ads by company domain or name. Charged 1 base credit plus 1 credit per ad returned (minimum 1 credit).
+      operationId: b2b-ads-search
+      tags:
+        - Ads Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                company_domain:
+                  type: string
+                  description: Company domain name
+                  default: gong.io
+                  example: gong.io
+                company_name:
+                  type: string
+                  description: Company name
+                  default: gong
+                  example: gong
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  description: >-
+                    Maximum number of ads to return. Because you are charged 1 credit
+                    per ad returned, this also caps the per-ad credits spent on the
+                    request; the 1 base credit per search still applies. Omit to return
+                    every ad found.
+                  example: 10
+      responses:
+        "200":
+          description: Successful response with ads details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "B2B ads found for the given company."
+                  credits_consumed:
+                    type: number
+                    example: 25
+                  ads_count:
+                    type: integer
+                    example: 24
+                  company:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        nullable: true
+                      domain:
+                        type: string
+                        nullable: true
+                      industry:
+                        type: string
+                        nullable: true
+                      company_size:
+                        type: string
+                        nullable: true
+                      linkedin_url:
+                        type: string
+                        nullable: true
+                        description: B2B company profile URL (/company/{slug})
+                      logo_url:
+                        type: string
+                        nullable: true
+                      city:
+                        type: string
+                        nullable: true
+                      state:
+                        type: string
+                        nullable: true
+                      country:
+                        type: string
+                        nullable: true
                   ads:
                     type: array
                     items:
@@ -1930,43 +6777,414 @@ paths:
                       properties:
                         ad_id:
                           type: string
-                          examples:
-                          - '12345'
-                        company_name:
+                        headline:
                           type: string
-                          examples:
-                          - Microsoft
-                        ad_title:
+                          nullable: true
+                        description:
                           type: string
-                          examples:
-                          - Microsoft Azure Cloud Services
-                        ad_description:
+                          nullable: true
+                        content:
+                          type: string
+                        link:
                           type: string
                         ad_url:
                           type: string
-                          format: uri
-                required:
-                - credits_consumed
-                - ads
-        '400':
-          description: Bad Request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /b2b/ad-details:
+                        image_url:
+                          type: string
+                          nullable: true
+                        carousel_images:
+                          type: array
+                          items:
+                            type: string
+                        ad_type:
+                          type: string
+                          nullable: true
+                        creative_type:
+                          type: string
+                          nullable: true
+                        advertiser:
+                          type: string
+                          nullable: true
+                        advertiser_linkedin_url:
+                          type: string
+                          nullable: true
+                          description: Advertiser B2B company profile URL (/company/{slug})
+                        cta_text:
+                          type: string
+                          nullable: true
+                        landing_page_url:
+                          type: string
+                          nullable: true
+                example:
+                  message: "B2B ads found for the given company."
+                  credits_consumed: 25
+                  ads_count: 24
+                  company:
+                    name: gong
+                    domain: gong.io
+                    industry: computer software
+                    company_size: 1001-5000
+                    linkedin_url: /company/gong-io
+                    logo_url: https://logo.leadmagic.io/gong.io
+                    city: san francisco
+                    state: california
+                    country: united states
+                  ads:
+                    - ad_id: "1436673673"
+                      headline: null
+                      description: See how revenue teams use Gong to win more deals.
+                      content: See how revenue teams use Gong to win more deals.
+                      link: "1436673673"
+                      ad_url: /ad-library/detail/1436673673
+                      ad_type: Document Ad
+                      creative_type: SPONSORED_UPDATE_NATIVE_DOCUMENT
+                      advertiser: Gong
+                      advertiser_linkedin_url: /company/gong-io
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/ads/b2b-ads-details:
     post:
       summary: B2B Ad Details
-      description: Get detailed information about a specific B2B ad.
-      operationId: getB2BAdDetails
+      description: Get detailed information about a specific B2B ad using its ad library URL, path, or numeric ID.
+      operationId: b2b-ad-details
       tags:
-      - Advertisements
+        - Ads Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ad_url:
+                  type: string
+                  description: B2B ad library URL, path (/ad-library/detail/{id}), or numeric ad ID
+                  example: "1436673673"
+              required:
+                - ad_url
+      responses:
+        "200":
+          description: Successful response with ad details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Ad details retrieved successfully"
+                  credits_consumed:
+                    type: number
+                    example: 2
+                  company:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        nullable: true
+                      domain:
+                        type: string
+                        nullable: true
+                      industry:
+                        type: string
+                        nullable: true
+                      company_size:
+                        type: string
+                        nullable: true
+                      linkedin_url:
+                        type: string
+                        nullable: true
+                      logo_url:
+                        type: string
+                        nullable: true
+                      city:
+                        type: string
+                        nullable: true
+                      state:
+                        type: string
+                        nullable: true
+                      country:
+                        type: string
+                        nullable: true
+                  ad_details:
+                    type: object
+                    description: Normalized ad object (same shape as B2B Ads Search) plus raw source payload
+                    properties:
+                      ad_id:
+                        type: string
+                      headline:
+                        type: string
+                        nullable: true
+                      description:
+                        type: string
+                        nullable: true
+                      content:
+                        type: string
+                      link:
+                        type: string
+                      ad_url:
+                        type: string
+                      ad_type:
+                        type: string
+                        nullable: true
+                      creative_type:
+                        type: string
+                        nullable: true
+                      advertiser:
+                        type: string
+                        nullable: true
+                      advertiser_linkedin_url:
+                        type: string
+                        nullable: true
+                      cta_text:
+                        type: string
+                        nullable: true
+                      landing_page_url:
+                        type: string
+                        nullable: true
+                      image_url:
+                        type: string
+                        nullable: true
+                      carousel_images:
+                        type: array
+                        items:
+                          type: string
+                      video_url:
+                        type: string
+                        nullable: true
+                      targeting:
+                        type: object
+                        nullable: true
+                      total_impressions:
+                        type: string
+                        nullable: true
+                      impressions_by_country:
+                        type: array
+                        items: {}
+                      message_ad:
+                        type: object
+                        nullable: true
+                      raw:
+                        type: object
+                        description: Original ad payload for unmapped fields
+                example:
+                  message: "Ad details retrieved successfully"
+                  credits_consumed: 2
+                  company:
+                    name: Gong
+                    linkedin_url: /company/gong-io
+                  ad_details:
+                    ad_id: "1436673673"
+                    content: See how revenue teams use Gong to win more deals.
+                    link: "1436673673"
+                    ad_url: /ad-library/detail/1436673673
+                    ad_type: Document Ad
+                    creative_type: SPONSORED_UPDATE_NATIVE_DOCUMENT
+                    advertiser: Gong
+                    advertiser_linkedin_url: /company/gong-io
+                    raw: {}
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  # ============================================================
+  # Bulk Jobs Endpoints (real /bulk/* surface)
+  # ============================================================
+  /bulk/submit:
+    post:
+      summary: Submit Bulk Job
+      description: "Submit data for bulk enrichment. Provide exactly one of rows (JSON array), csv (string), fileUrl (HTTPS URL), or scrape (browser rendering config). The job is processed asynchronously; use the returned jobId to poll status via GET /bulk/jobs/{jobId}. **Security**: fileUrl and callback.url are SSRF-validated server-side. Private/internal IP ranges, localhost, cloud metadata endpoints (169.254.169.254), and non-HTTPS protocols are rejected."
+      operationId: bulk-submit
+      tags:
+        - Bulk Jobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkSubmissionRequest'
+            example:
+              product: email_finder
+              rows:
+                - profile_url: https://example.com/in/jane-doe
+                  company_name: LeadMagic
+              callback:
+                url: https://hooks.example.com/leadmagic/bulk
+                events:
+                  - completed
+      responses:
+        "202":
+          description: Bulk job accepted and queued for processing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkSubmissionResponse'
+        "400":
+          description: "Bad request. The request body failed validation, or a provided URL failed SSRF validation (SSRF_VALIDATION_FAILED)."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "402":
+          $ref: '#/components/responses/PaymentRequired'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /bulk/jobs:
+    get:
+      summary: List Bulk Jobs
+      description: Retrieve a paginated list of bulk jobs owned by the authenticated account, newest first.
+      operationId: bulk-job-list
+      tags:
+        - Bulk Jobs
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: Filter jobs by current status.
+          schema:
+            type: string
+        - name: product
+          in: query
+          required: false
+          description: Filter jobs by enrichment product.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: Number of jobs per page.
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+        - name: offset
+          in: query
+          required: false
+          description: Number of jobs to skip.
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+            maximum: 10000
+      responses:
+        "200":
+          description: Paginated list of bulk jobs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobsListResponse'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /bulk/jobs/{jobId}:
+    get:
+      summary: Get Bulk Job Status
+      description: Retrieve the current status and progress of a specific bulk job. Accepts progress-token auth from the submit response.
+      operationId: bulk-job-status
+      tags:
+        - Bulk Jobs
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          description: UUID identifier of the bulk job.
+          schema:
+            type: string
+            format: uuid
+          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+      responses:
+        "200":
+          description: Current status of the requested bulk job.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobDetailResponse'
+              example:
+                job_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                status: processing
+                products:
+                  - email_finder
+                submission_product: email_finder
+                submission_endpoint: null
+                execution_mode: null
+                total_rows: 5000
+                processed_items: 2125
+                succeeded_items: 2080
+                failed_items: 45
+                skipped_items: 0
+                total_credits_consumed: "2080.00"
+                total_duration_ms: null
+                created_at: 2026-07-09T14:30:00.000Z
+                started_at: 2026-07-09T14:30:05.000Z
+                completed_at: null
+                last_progress_at: 2026-07-09T14:35:12.000Z
+                file_name: q3-contacts.csv
+                callback_url: https://hooks.example.com/leadmagic/bulk
+                callback_event: completed
+                priority: 0
+                output_transform: null
+                links:
+                  statusUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890?token=...
+                  streamUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stream?token=...
+                  wsUrl: wss://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/ws?token=...
+                  resultsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/results?token=...
+                  rowsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rows?token=...
+                  errorsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/errors?token=...
+                  eventsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events?token=...
+                  eventsExportUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/events/export?token=...
+                  logsUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/logs?token=...
+                  downloadUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/download?token=...
+                  progressUrl: https://api.leadmagic.io/bulk/jobs/a1b2c3d4-e5f6-7890-abcd-ef1234567890/progress?token=...
+                  token: prt_abc123...
+                  exp: 1752259200
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /bulk/jobs/{jobId}/review:
+    post:
+      summary: Review Bulk Job (Cancel or Approve)
+      description: "Cancel a queued or processing bulk job by submitting {\"action\": \"reject\"}, or resume a paused job with {\"action\": \"approve\"}. Completed or failed jobs cannot be reviewed."
+      operationId: bulk-job-review
+      tags:
+        - Bulk Jobs
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          description: UUID identifier of the bulk job.
+          schema:
+            type: string
+            format: uuid
+          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
       requestBody:
         required: true
         content:
@@ -1974,84 +7192,1331 @@ paths:
             schema:
               type: object
               required:
-              - ad_id
+                - action
               properties:
-                ad_id:
+                action:
                   type: string
-                  description: B2B ad ID
-                  examples:
-                  - '12345'
+                  enum:
+                    - approve
+                    - reject
+            example:
+              action: reject
       responses:
-        '200':
-          description: Detailed B2B ad information.
+        "200":
+          description: Review action confirmed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReviewResponse'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /bulk/jobs/{jobId}/results:
+    get:
+      summary: Get Bulk Job Results
+      description: Retrieve paginated row-level results for a bulk job as JSON.
+      operationId: bulk-job-results
+      tags:
+        - Bulk Jobs
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          description: UUID identifier of the bulk job.
+          schema:
+            type: string
+            format: uuid
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 200
+            minimum: 1
+            maximum: 1000
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+        - name: status
+          in: query
+          required: false
+          description: Filter rows by status.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Paginated row results.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobRowsResponse'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /bulk/jobs/{jobId}/download:
+    get:
+      summary: Download Bulk Job Results as CSV
+      description: Stream the full results as a CSV file. No pagination — all rows are included.
+      operationId: bulk-job-download
+      tags:
+        - Bulk Jobs
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          description: UUID identifier of the bulk job.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: CSV stream.
+          content:
+            text/csv:
+              schema:
+                type: string
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /bulk/capabilities:
+    get:
+      summary: Get Bulk API Capabilities
+      description: Return the machine-readable bulk enrichment capability and tool manifest.
+      operationId: bulk-capabilities
+      tags:
+        - Bulk Jobs
+      responses:
+        "200":
+          description: Bulk capability manifest.
           content:
             application/json:
               schema:
                 type: object
-                properties:
-                  ad_id:
+                additionalProperties: true
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /bulk/validate:
+    post:
+      summary: Validate a Bulk Submission
+      description: Validate a bulk submission payload without persisting or processing a job.
+      operationId: bulk-validate
+      tags:
+        - Bulk Jobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkSubmissionRequest'
+      responses:
+        "200":
+          description: Validation result.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /bulk/local-leads:
+    post:
+      summary: Submit a Local Leads Search
+      description: Submit long-running local-leads searches to the dedicated bulk queue.
+      operationId: bulk-local-leads
+      tags:
+        - Bulk Jobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - keywords
+                - cities
+              properties:
+                keywords:
+                  type: array
+                  description: Search terms. Expanded against every city — one search row per keyword × city pair.
+                  items:
                     type: string
-                    examples:
-                    - '12345'
-                  company_name:
+                  example:
+                    - "plumber"
+                    - "hvac contractor"
+                cities:
+                  type: array
+                  description: Cities to search. Expanded against every keyword.
+                  items:
                     type: string
-                    examples:
-                    - Microsoft
-                  ad_title:
+                  example:
+                    - "Austin"
+                    - "Dallas"
+                countryCodes:
+                  type: array
+                  description: Two-letter country code per city, aligned by index. Defaults to `US` when omitted.
+                  items:
                     type: string
-                    examples:
-                    - Microsoft Azure Cloud Services
-                  ad_description:
-                    type: string
-                  ad_url:
-                    type: string
-                    format: uri
-                  campaign_info:
+                  example:
+                    - "US"
+                    - "US"
+                fileName:
+                  type: string
+                  description: Label for the resulting job, shown in the dashboard.
+                  example: "texas-trades"
+                magicKey:
+                  type: string
+                  description: Promotional key that waives credit charges when valid.
+      responses:
+        "202":
+          description: Local-leads job accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkSubmissionResponse'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /bulk/progress:
+    get:
+      summary: Get Lightweight Bulk Job Progress
+      description: Return a compact progress snapshot for frequent polling.
+      operationId: bulk-job-progress
+      tags:
+        - Bulk Jobs
+      parameters:
+        - name: jobId
+          in: query
+          required: true
+          description: UUID identifier of the bulk job.
+          schema:
+            type: string
+            format: uuid
+        - name: token
+          in: query
+          required: false
+          description: Signed progress token returned when the job was submitted.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Lightweight progress snapshot.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                status: processing
+                processed_items: 2125
+                total_rows: 5000
+                succeeded_items: 2080
+                failed_items: 45
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /bulk/jobs/{jobId}/errors:
+    get:
+      summary: Get Failed Bulk Job Rows
+      description: Return failed rows and their error details for a bulk job.
+      operationId: bulk-job-errors
+      tags:
+        - Bulk Jobs
+      parameters:
+        - $ref: '#/components/parameters/BulkJobId'
+        - name: limit
+          in: query
+          required: false
+          description: Rows to return per page.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 200
+        - name: offset
+          in: query
+          required: false
+          description: Zero-based row offset for pagination.
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000000
+            default: 0
+        - name: status
+          in: query
+          required: false
+          description: Filter failed rows by status.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Paginated failed rows.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                rows:
+                  - id: b2c3d4e5-f6a7-8901-bcde-f12345678901
+                    row_index: 42
+                    status: failed
+                    lm_input:
+                      email: invalid-format
+                    lm_output: null
+                    error_message: "Invalid email format: invalid-format"
+                    http_status_code: 422
+                    response_time_ms: 45
+                    completed_at: 2026-07-09T14:30:06.000Z
+                limit: 100
+                offset: 0
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /bulk/jobs/{jobId}/events:
+    get:
+      summary: Get Bulk Job Events
+      description: Return the append-only event log for a bulk job.
+      operationId: bulk-job-events
+      tags:
+        - Bulk Jobs
+      parameters:
+        - $ref: '#/components/parameters/BulkJobId'
+        - name: limit
+          in: query
+          required: false
+          description: Events to return, newest first.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 2000
+            default: 200
+      responses:
+        "200":
+          description: Paginated job events.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                events:
+                  - event_id: e1f2g3h4-i5j6-7890-k1mn-opqrstuvwxyz
+                    job_id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                    event_type: row.failed
+                    source: queue-consumer
+                    level: error
+                    message: "Row 42 failed: Invalid email format"
+                    stage: enrichment
+                    status: processing
+                    details:
+                      row_index: 42
+                      error: Invalid email format
+                      http_status_code: 422
+                    created_at: 2026-07-09T14:30:06.000Z
+                limit: 50
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /bulk/jobs/{jobId}/stream:
+    get:
+      summary: Stream Bulk Job Progress
+      description: Open a server-sent events stream for real-time bulk job progress.
+      operationId: bulk-job-stream
+      tags:
+        - Bulk Jobs
+      parameters:
+        - $ref: '#/components/parameters/BulkJobId'
+        - name: token
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Server-sent event stream.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /bulk/jobs/{jobId}/pause:
+    post:
+      summary: Pause a Bulk Job
+      description: Pause a queued or running bulk job.
+      operationId: bulk-job-pause
+      tags:
+        - Bulk Jobs
+      parameters:
+        - $ref: '#/components/parameters/BulkJobId'
+      responses:
+        "200":
+          description: Job paused.
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /bulk/jobs/{jobId}/resume:
+    post:
+      summary: Resume a Bulk Job
+      description: Resume a paused bulk job.
+      operationId: bulk-job-resume
+      tags:
+        - Bulk Jobs
+      parameters:
+        - $ref: '#/components/parameters/BulkJobId'
+      responses:
+        "200":
+          description: Job resumed.
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /bulk/jobs/{jobId}/restart:
+    post:
+      summary: Restart a Bulk Job
+      description: Restart a bulk job in full, from failed rows, or from a specified position.
+      operationId: bulk-job-restart
+      tags:
+        - Bulk Jobs
+      parameters:
+        - $ref: '#/components/parameters/BulkJobId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mode:
+                  type: string
+                  description: Which rows to reprocess.
+                  enum:
+                    - full
+                    - failed_only
+                    - from_row
+                    - from_shard
+                  default: full
+                startRowIndex:
+                  type: integer
+                  description: Zero-based row to restart from. Required when `mode` is `from_row`.
+                  minimum: 0
+                startShardIndex:
+                  type: integer
+                  description: Zero-based shard to restart from. Required when `mode` is `from_shard`.
+                  minimum: 0
+      responses:
+        "200":
+          description: Restart accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                jobId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                restarted: true
+                newJobId: null
+                mode: failed_only
+                started: false
+                position: 1
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /bulk/jobs/{jobId}/priority:
+    patch:
+      summary: Update Bulk Job Priority
+      description: Change the processing priority of a queued or running bulk job.
+      operationId: bulk-job-priority
+      tags:
+        - Bulk Jobs
+      parameters:
+        - $ref: '#/components/parameters/BulkJobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - priority
+              properties:
+                priority:
+                  type: string
+                  enum:
+                    - low
+                    - normal
+                    - high
+      responses:
+        "200":
+          description: Priority updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                jobId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                priority: 100
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  # ============================================================
+  # Batch and Cost Control Endpoints ( /v1/batch/* )
+  # ============================================================
+  /v1/batch:
+    get:
+      summary: List Batches
+      description: List batches across all products for the authenticated organization.
+      operationId: batch-list
+      tags:
+        - Batch
+      parameters:
+        - name: product
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: client_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        "200":
+          description: Paginated batch list.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      summary: Submit a Mixed-Product Batch
+      description: Submit a batch containing items for one or more enrichment products.
+      operationId: batch-submit
+      tags:
+        - Batch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - items
+              properties:
+                items:
+                  type: array
+                  description: Batch items. Each item carries `product` (required for mixed-product batches), `input`, and optional `client_id`, `client_name`, and `metadata`.
+                  minItems: 1
+                  maxItems: 500
+                  items:
                     type: object
                     properties:
-                      campaign_name:
+                      product:
                         type: string
-                      start_date:
+                        description: Product to run this item against.
+                      input:
+                        type: object
+                        description: Product-specific input fields.
+                      client_id:
                         type: string
-                        format: date
-                      end_date:
-                        type:
-                        - string
-                        - 'null'
-                        format: date
-                  credits_consumed:
-                    type: integer
-                    examples:
-                    - 2
-                required:
-                - ad_id
-                - credits_consumed
-        '400':
-          description: Bad Request.
+                      client_name:
+                        type: string
+                      metadata:
+                        type: object
+                idempotencyKey:
+                  type: string
+                  description: Submitting the same key twice returns the original batch instead of creating a duplicate.
+                metadata:
+                  type: object
+                  description: Arbitrary metadata stored with the batch.
+                client_id:
+                  type: string
+                  description: Associate the whole batch with a client record.
+                client_name:
+                  type: string
+                  description: Client name recorded alongside the batch.
+                budget_user_id:
+                  type: string
+                  description: Charge the batch against this member's credit budget.
+                webhook_url:
+                  type: string
+                  format: uri
+                  description: HTTPS URL notified when the batch completes. SSRF-validated — must resolve to a public IP.
+                priority:
+                  type: string
+                  description: Queue priority for this batch.
+                  enum:
+                    - normal
+                    - low
+      responses:
+        "202":
+          description: Batch accepted.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-        '401':
-          description: Unauthorized - Invalid API key.
+                type: object
+                additionalProperties: true
+              example:
+                batchId: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                status: accepted
+                items_count: 2
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/batch/{batchId}:
+    get:
+      summary: Get Batch Status
+      description: Return status, progress, cost, and metadata for a mixed-product batch.
+      operationId: batch-status
+      tags:
+        - Batch
+      parameters:
+        - name: batchId
+          in: path
+          required: true
+          description: Identifier of the batch returned when it was submitted.
+          schema:
+            type: string
+          example: "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+      responses:
+        "200":
+          description: Batch status.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-tags:
-- name: Advertisements
-  description: Advertisement intelligence
-- name: Companies
-  description: Company information and enrichment
-- name: Credits
-  description: Credit management operations
-- name: Email
-  description: Email finding and validation
-- name: Jobs
-  description: Job posting search
-- name: Mobile
-  description: Mobile number finding
-- name: People
-  description: People enrichment and search
-- name: Profiles
-  description: Professional profile enrichment
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /v1/{product}/batch/{batchId}:
+    patch:
+      summary: Update Batch Metadata
+      description: Update batch metadata or its associated client within the mutable window.
+      operationId: batch-update
+      tags:
+        - Batch
+      parameters:
+        - name: product
+          in: path
+          required: true
+          description: Enrichment product slug, e.g. `email-finder`. Hyphens and underscores are both accepted.
+          schema:
+            type: string
+          example: "email-finder"
+        - name: batchId
+          in: path
+          required: true
+          description: Identifier of the batch returned when it was submitted.
+          schema:
+            type: string
+          example: "b1c2d3e4-f5a6-7890-bcde-f12345678901"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                metadata:
+                  type: object
+                  additionalProperties: true
+                client_id:
+                  type: string
+      responses:
+        "200":
+          description: Updated batch.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /v1/batch/campaign/{campaignId}/metrics:
+    get:
+      summary: Get Campaign Metrics
+      description: Aggregate usage and success metrics across batches in a campaign.
+      operationId: batch-campaign-metrics
+      tags:
+        - Batch
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          description: Campaign identifier used to group related batches.
+          schema:
+            type: string
+          example: "c1d2e3f4-a5b6-7890-cdef-123456789012"
+      responses:
+        "200":
+          description: Campaign metrics.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /v1/batch/clients:
+    get:
+      summary: List Batch Clients
+      description: List client records for the authenticated organization.
+      operationId: batch-client-list
+      tags:
+        - Batch
+      responses:
+        "200":
+          description: Client list.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      summary: Create a Batch Client
+      description: Create an organization-scoped client for segmenting downstream batch work.
+      operationId: batch-client-create
+      tags:
+        - Batch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  description: Unique client identifier (slug). Lowercase, alphanumeric with hyphens.
+                  example: "acme-corp"
+                display_name:
+                  type: string
+                  description: Human-readable display name.
+                  example: "Acme Corporation"
+                contact_email:
+                  type: string
+                  format: email
+                  description: Contact email for notifications.
+                billing_rate:
+                  type: number
+                  description: Optional billing rate applied to this client.
+                notes:
+                  type: string
+                  description: Internal notes.
+                industry:
+                  type: string
+                  description: Industry classification.
+                website:
+                  type: string
+                  description: Client website.
+                phone:
+                  type: string
+                  description: Phone number.
+                address:
+                  type: object
+                  description: Physical address object.
+                custom_fields:
+                  type: object
+                  description: Arbitrary custom fields stored with the client.
+      responses:
+        "201":
+          description: Client created.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/batch/clients/{clientId}/metrics:
+    get:
+      summary: Get Batch Client Metrics
+      description: Return aggregate batch usage and success metrics for a client.
+      operationId: batch-client-metrics
+      tags:
+        - Batch
+      parameters:
+        - name: clientId
+          in: path
+          required: true
+          description: UUID of the client record, returned when the client was created.
+          schema:
+            type: string
+            format: uuid
+          example: "d1e2f3a4-b5c6-7890-def1-234567890123"
+      responses:
+        "200":
+          description: Client metrics.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /v1/batch/clients/{clientId}/webhooks:
+    get:
+      summary: List Batch Client Webhooks
+      description: List delivery webhooks configured for a client.
+      operationId: batch-client-webhook-list
+      tags:
+        - Batch
+      parameters:
+        - name: clientId
+          in: path
+          required: true
+          description: UUID of the client record, returned when the client was created.
+          schema:
+            type: string
+            format: uuid
+          example: "d1e2f3a4-b5c6-7890-def1-234567890123"
+      responses:
+        "200":
+          description: Client webhook list.
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      summary: Create a Batch Client Webhook
+      description: Register a webhook for client batch lifecycle events.
+      operationId: batch-client-webhook-create
+      tags:
+        - Batch
+      parameters:
+        - name: clientId
+          in: path
+          required: true
+          description: UUID of the client record, returned when the client was created.
+          schema:
+            type: string
+            format: uuid
+          example: "d1e2f3a4-b5c6-7890-def1-234567890123"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "201":
+          description: Webhook created.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/batch/providers:
+    get:
+      summary: List External Batch Providers
+      description: List external enrichment providers registered by the organization.
+      operationId: batch-provider-list
+      tags:
+        - Batch
+      responses:
+        "200":
+          description: Provider list with credentials redacted.
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      summary: Create an External Batch Provider
+      description: Register an HTTPS external enrichment provider.
+      operationId: batch-provider-create
+      tags:
+        - Batch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - baseUrl
+                - authType
+                - authCredentialName
+                - authCredentialValue
+              properties:
+                name:
+                  type: string
+                  description: Display name for the provider.
+                  example: "acme-enrichment"
+                baseUrl:
+                  type: string
+                  format: uri
+                  description: HTTPS endpoint to call. Private IP addresses are rejected.
+                  example: "https://api.acme.com/enrich"
+                authType:
+                  type: string
+                  description: How the credential is presented to the provider.
+                  enum:
+                    - api_key
+                    - bearer
+                    - header
+                authCredentialName:
+                  type: string
+                  description: Header or parameter name carrying the credential.
+                  example: "X-API-Key"
+                authCredentialValue:
+                  type: string
+                  description: Credential value. Redacted in every response.
+                defaultMethod:
+                  type: string
+                  description: HTTP method used for provider calls.
+                  enum:
+                    - GET
+                    - POST
+                defaultHeaders:
+                  type: object
+                  description: Extra headers sent with every provider call.
+                rateLimitRpm:
+                  type: integer
+                  description: Requests per minute ceiling for this provider.
+                responseMapping:
+                  type: object
+                  description: Maps provider response fields onto LeadMagic output columns.
+                healthCheckUrl:
+                  type: string
+                  format: uri
+                  description: URL polled to determine provider health.
+                healthCheckExpectedStatus:
+                  type: integer
+                  description: HTTP status treated as healthy.
+                  example: 200
+      responses:
+        "201":
+          description: Provider created with credentials redacted.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/batch/preview-cost:
+    post:
+      summary: Preview Batch Cost
+      description: Estimate the credit cost and budget impact of a batch enrichment without reserving or consuming credits. FREE dry-run.
+      operationId: preview-cost-mixed
+      tags:
+        - Cost Control
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreviewCostRequest'
+            example:
+              items:
+                - product: email_finder
+                  input:
+                    profile_url: https://example.com/in/jane-doe
+              budget_user_id: user_abc123
+      responses:
+        "200":
+          description: Cost estimate returned (no credits consumed).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PreviewCostResponse'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+  /v1/batch/budgets:
+    post:
+      summary: Create Credit Budget
+      description: Create a new credit budget to cap spend per scope.
+      operationId: create-budget
+      tags:
+        - Cost Control
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - scope
+                - scope_value
+                - max_credits
+              properties:
+                scope:
+                  type: string
+                scope_value:
+                  type: string
+                max_credits:
+                  type: number
+                period:
+                  type: string
+                alert_threshold_pct:
+                  type: number
+                  minimum: 0
+                  exclusiveMinimum: 0
+                  maximum: 1
+                  exclusiveMaximum: 1
+                alert_email:
+                  type: string
+                  format: email
+            example:
+              scope: user
+              scope_value: user_abc123
+              max_credits: 10000
+              period: monthly
+              alert_threshold_pct: 0.8
+              alert_email: ops@example.com
+      responses:
+        "201":
+          description: Budget created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Budget'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "429":
+          $ref: '#/components/responses/RateLimitExceeded'
+    get:
+      summary: List Credit Budgets
+      description: List all credit budgets for the authenticated account.
+      operationId: list-budgets
+      tags:
+        - Cost Control
+      responses:
+        "200":
+          description: List of budgets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Budget'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/batch/budgets/status:
+    get:
+      summary: Get Budget Status
+      description: Consumption status for all budgets.
+      operationId: budget-status
+      tags:
+        - Cost Control
+      responses:
+        "200":
+          description: Budget consumption status.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BudgetStatus'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/batch/budgets/{id}:
+    patch:
+      summary: Update Credit Budget
+      description: Update max_credits, period, alert_threshold_pct, and/or alert_email.
+      operationId: update-budget
+      tags:
+        - Cost Control
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identifier of the credit budget.
+          schema:
+            type: string
+          example: "bg_4a7d2e9c1f60"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                max_credits:
+                  type: number
+                period:
+                  type: string
+                alert_threshold_pct:
+                  type: number
+                alert_email:
+                  type: string
+      responses:
+        "200":
+          description: Updated budget.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Budget'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+    delete:
+      summary: Delete Credit Budget
+      description: Hard-delete a credit budget.
+      operationId: delete-budget
+      tags:
+        - Cost Control
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Identifier of the credit budget.
+          schema:
+            type: string
+          example: "bg_4a7d2e9c1f60"
+      responses:
+        "200":
+          description: Budget deleted.
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "404":
+          $ref: '#/components/responses/NotFound'
+  /v1/batch/suppression-lists:
+    post:
+      summary: Create Suppression List
+      description: Create a new suppression list with initial emails. Emails are SHA-256 hashed server-side.
+      operationId: create-suppression-list
+      tags:
+        - Cost Control
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - list_id
+                - emails
+              properties:
+                list_id:
+                  type: string
+                emails:
+                  type: array
+                  items:
+                    type: string
+            example:
+              list_id: bounced-2026-q3
+              emails:
+                - bounced1@example.com
+      responses:
+        "201":
+          description: Suppression list created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuppressionList'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+    get:
+      summary: List Suppression Lists
+      description: List all suppression lists for the authenticated account.
+      operationId: list-suppression-lists
+      tags:
+        - Cost Control
+      responses:
+        "200":
+          description: List of suppression lists.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SuppressionList'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/batch/suppression-lists/{listId}:
+    get:
+      summary: Get Suppression List
+      description: Get list details and paginated email hashes.
+      operationId: get-suppression-list
+      tags:
+        - Cost Control
+      parameters:
+        - name: listId
+          in: path
+          required: true
+          description: Identifier of the suppression list.
+          schema:
+            type: string
+          example: "sl_9f2c1d7e4b8a"
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 200
+            maximum: 1000
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        "200":
+          description: List details with paginated hashes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuppressionList'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+    delete:
+      summary: Delete Suppression List
+      description: Delete an entire suppression list.
+      operationId: delete-suppression-list
+      tags:
+        - Cost Control
+      parameters:
+        - name: listId
+          in: path
+          required: true
+          description: Identifier of the suppression list.
+          schema:
+            type: string
+          example: "sl_9f2c1d7e4b8a"
+      responses:
+        "200":
+          description: List deleted.
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+  /v1/batch/suppression-lists/{listId}/emails:
+    post:
+      summary: Add Emails to Suppression List
+      description: Add emails to an existing suppression list. Emails are SHA-256 hashed server-side.
+      operationId: add-suppression-emails
+      tags:
+        - Cost Control
+      parameters:
+        - name: listId
+          in: path
+          required: true
+          description: Identifier of the suppression list.
+          schema:
+            type: string
+          example: "sl_9f2c1d7e4b8a"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - emails
+              properties:
+                emails:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        "200":
+          description: Emails added.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+    delete:
+      summary: Remove Emails from Suppression List
+      description: Remove emails from a suppression list.
+      operationId: remove-suppression-emails
+      tags:
+        - Cost Control
+      parameters:
+        - name: listId
+          in: path
+          required: true
+          description: Identifier of the suppression list.
+          schema:
+            type: string
+          example: "sl_9f2c1d7e4b8a"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - emails
+              properties:
+                emails:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        "200":
+          description: Emails removed.
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "401":
+          $ref: '#/components/responses/Unauthorized'

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16,15 +16,9 @@ Important: current public docs are not uniform about field naming. Some endpoint
 
 ## Current MCP Surface
 
-The hosted LeadMagic MCP exposes:
+The hosted LeadMagic MCP exposes 35+ tools covering the whole product: people/company/jobs search, decision-makers, email find/validate, mobile, account intelligence, technographics, competitors, job-change detection, ads research, bulk jobs, and credits — plus the `leadmagic://docs` resource and built-in prompts (`account_research`, `contact_lookup`). Tool reference: https://leadmagic.io/docs/mcp/tools
 
-- 10 tools (see README for the full mapping to REST endpoints)
-- 1 shared docs resource: `leadmagic://docs`
-- 2 built-in prompts (for example `account_research`, `contact_lookup`)
-
-The MCP surface currently covers credits, people enrichment, company research, technographics, competitors, job-change detection, and role lookup.
-
-Important distinction: ads endpoints and some jobs endpoints exist in the broader REST API and this OpenAPI snapshot, but they are not part of the current MCP tool surface.
+Unlimited search on Professional & Ultimate plans: POST /v3/people/search, /v3/companies/search, and /v3/jobs/search are credit-free with no volume cap (5 req/s Professional, 10 req/s Ultimate). Agent guide: https://leadmagic.io/docs/mcp/agent-guide
 
 ## Hosted MCP Sign-In
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,86 +1,90 @@
 # LeadMagic API
 
-> LeadMagic is a B2B data enrichment API. The live source of truth is `https://leadmagic.io/docs`, and current API routes are versioned under `/v1/...`.
+> LeadMagic is a B2B data enrichment and search API — 400M+ people profiles, 25M+ companies, 46M+ job postings, plus email finding/validation, mobile numbers, ads intelligence, and bulk CSV jobs. The live source of truth is `https://leadmagic.io/docs`. This repo's OpenAPI snapshot (`leadmagic-openapi-3.1.yaml`, 81 paths) is synced from that contract.
 
 Base URL: `https://api.leadmagic.io`
 
-Authentication: send `X-API-Key` on every request.
+Authentication: send `X-API-Key` on every request. Hosted MCP (`https://mcp.leadmagic.io/mcp`) uses OAuth instead — no key.
 
-Important: do not assume all responses use the same field naming style. Current public docs show a mix of snake_case and camelCase depending on the endpoint.
+Agent guide (hand this to your AI): `https://leadmagic.io/docs/mcp/agent-guide`
+Agent skills: `npx skills add LeadMagic/leadmagic-skills`
 
-## Core Routes In This Repo
+## Unlimited search on Professional & Ultimate plans
+
+`POST /v3/people/search`, `POST /v3/companies/search`, and `POST /v3/jobs/search` are **credit-free with no volume cap** on Professional (5 req/s sustained) and Ultimate (10 req/s) plans — rate-limited only. Other plans pay ~1 credit per returned row. Contact-detail unlocks, lookalikes, exports, and enrichment endpoints are credit-metered on every plan.
+
+## Cursor pagination (all v3 search endpoints)
+
+First page: filters + `limit` (≤50). Response returns `next_cursor` + `has_more`. Next page: identical filters + `cursor: <next_cursor>`. Never combine `cursor` with a nonzero `offset` (a cursor is only minted at offset 0). Stop when `has_more` is false.
+
+## Search (V3)
+
+### People — 400M+ profiles
+- [People Search](https://leadmagic.io/docs/api-reference/people-search): `POST /v3/people/search` — canonical; aliases `/v3/person/search`, `/v3/people/{company-search,full-search,mixed-search,icp-search,employees,by-title,contacts-by-title,lookalike}`
+
+### Companies — 25M+
+- [Company Search](https://leadmagic.io/docs/api-reference/company-search-v3): `POST /v3/companies/search` — aliases `/company-search`, `/lookup`, `/enrich`, `/domain-lookup`, `/funding`
+- [Company Lookalike](https://leadmagic.io/docs/api-reference/company-lookalike): `POST /v3/companies/lookalike` — aliases `/competitors`, `/competitors-search` (metered, 5 credits)
+
+### Jobs — 46M+ postings
+- [Job Search](https://leadmagic.io/docs/api-reference/job-search): `POST /v3/jobs/search` — modes: vector (default, `titles.vector`), facets (`includeFacets`), deep (`mode: "deep"`)
+- [Job Search Export](https://leadmagic.io/docs/api-reference/job-search-export): `POST /v3/jobs/search/export` — ≤5,000 rows, metered on all plans
+- [Resolve Filters](https://leadmagic.io/docs/api-reference/job-search-helpers): `POST /v3/jobs/search/resolve` — free
+- Free GET helpers: `/v3/jobs/search/{companies,titles,roles,tags,locations,occupation-taxonomy,catalogs,stats}`
+- [Search Stats](https://leadmagic.io/docs/api-reference/search-stats): `POST /v3/search/stats`
+
+## Enrichment (V1)
 
 ### Credits
-- [Check Credits](https://leadmagic.io/docs/v1/reference/check-credits): `GET /v1/credits`
+- [Check Credits](https://leadmagic.io/docs/api-reference/check-credits): `GET /v1/credits` — free
 
 ### People
-- [Email Validation](https://leadmagic.io/docs/v1/reference/email-validation): `POST /v1/people/email-validation`
-- [Email Finder](https://leadmagic.io/docs/v1/reference/email-finder): `POST /v1/people/email-finder`
-- [Personal Email Finder](https://leadmagic.io/docs/v1/reference/personal-email-finder): `POST /v1/people/personal-email-finder`
-- [B2B Social to Email](https://leadmagic.io/docs/v1/reference/profile-to-email): `POST /v1/people/b2b-profile-email`
-- [Email to B2B Profile](https://leadmagic.io/docs/v1/reference/email-to-profile): `POST /v1/people/b2b-profile`
-- [Mobile Finder](https://leadmagic.io/docs/v1/reference/mobile-finder): `POST /v1/people/mobile-finder`
-- [Profile Search](https://leadmagic.io/docs/v1/reference/profile-search): `POST /v1/people/profile-search`
-- [Role Finder](https://leadmagic.io/docs/v1/reference/role-finder): `POST /v1/people/role-finder`
-- [Employee Finder](https://leadmagic.io/docs/v1/reference/employee-finder): `POST /v1/people/employee-finder`
+- [Email Validation](https://leadmagic.io/docs/api-reference/email-validation): `POST /v1/people/email-validation` (0.25 credits)
+- [Email Finder](https://leadmagic.io/docs/api-reference/email-finder): `POST /v1/people/email-finder` (1)
+- [Personal Email Finder](https://leadmagic.io/docs/api-reference/personal-email-finder): `POST /v1/people/personal-email-finder` (2)
+- [B2B Profile to Email](https://leadmagic.io/docs/api-reference/profile-to-email): `POST /v1/people/b2b-profile-email` (5)
+- [Email to B2B Profile](https://leadmagic.io/docs/api-reference/email-to-profile): `POST /v1/people/b2b-profile` (10)
+- [Mobile Finder](https://leadmagic.io/docs/api-reference/mobile-finder): `POST /v1/people/mobile-finder` (5)
+- [Profile Search](https://leadmagic.io/docs/api-reference/profile-search): `POST /v1/people/profile-search` (1)
+- [Role Finder](https://leadmagic.io/docs/api-reference/role-finder): `POST /v1/people/role-finder` (2)
+- [Employee Finder](https://leadmagic.io/docs/api-reference/employee-finder): `POST /v1/people/employee-finder`
+- [Job Change Detector](https://leadmagic.io/docs/api-reference/job-change-detector): `POST /v1/people/job-change-detector`
 
 ### Companies
-- [Company Search](https://leadmagic.io/docs/v1/reference/company-search): `POST /v1/companies/company-search`
-- [Company Funding](https://leadmagic.io/docs/v1/reference/company-funding): `POST /v1/companies/company-funding`
+- [Company Search](https://leadmagic.io/docs/api-reference/company-search): `POST /v1/companies/company-search` (1)
+- [Company Funding](https://leadmagic.io/docs/api-reference/company-funding): `POST /v1/companies/company-funding` (4)
+- [Technographics](https://leadmagic.io/docs/api-reference/technographics): `POST /v1/companies/technographics`
+- [Competitors Search](https://leadmagic.io/docs/api-reference/competitors-search): `POST /v1/companies/competitors-search`
 
-### Jobs
-- [Jobs Finder](https://leadmagic.io/docs/v1/reference/jobs-finder): `POST /v1/jobs/jobs-finder`
-- [Job Country](https://leadmagic.io/docs/v1/reference/job-country): `GET /v1/jobs/countries`
-- [Job Type](https://leadmagic.io/docs/v1/reference/job-types): `GET /v1/jobs/job-types`
+### Jobs (V1)
+- [Jobs Finder](https://leadmagic.io/docs/api-reference/jobs-finder): `POST /v1/jobs/jobs-finder`
+- Catalogs: `GET /v1/jobs/{countries,regions,industries,job-types,company-types}`
 
 ### Ads
-- [Google Ads Search](https://leadmagic.io/docs/v1/reference/google-ads-search): `POST /v1/ads/google-ads-search`
-- [Meta Ads Search](https://leadmagic.io/docs/v1/reference/meta-ads-search): `POST /v1/ads/meta-ads-search`
-- [B2B Ads Search](https://leadmagic.io/docs/v1/reference/b2b-ads-search): `POST /v1/ads/b2b-ads-search`
-- [B2B Ad Details](https://leadmagic.io/docs/v1/reference/b2b-ad-details): `POST /v1/ads/b2b-ads-details`
+- [Google Ads Search](https://leadmagic.io/docs/api-reference/google-ads-search): `POST /v1/ads/google-ads-search`
+- [Meta Ads Search](https://leadmagic.io/docs/api-reference/meta-ads-search): `POST /v1/ads/meta-ads-search`
+- [B2B Ads Search](https://leadmagic.io/docs/api-reference/b2b-ads-search): `POST /v1/ads/b2b-ads-search`
+- [B2B Ad Details](https://leadmagic.io/docs/api-reference/b2b-ad-details): `POST /v1/ads/b2b-ads-details`
 
-## Current MCP Surface
+## Bulk & Batch
 
-The hosted LeadMagic MCP exposes:
+- [Bulk Submit](https://leadmagic.io/docs/api-reference/bulk-jobs-submit): `POST /bulk/submit` — plus job lifecycle under `GET /bulk/jobs/*` (status, results, errors, events, stream, progress) and `POST /bulk/validate`
+- Batch campaigns: `POST /v1/batch` — budgets, clients, suppression lists, webhooks, metrics under `/v1/batch/*`
 
-- 10 tools (see README for the full mapping to REST endpoints)
-- 1 shared docs resource: `leadmagic://docs`
-- 2 built-in prompts (for example `account_research`, `contact_lookup`)
+## Analytics
 
-The MCP surface covers credits, people enrichment, company research, technographics, competitors, job-change detection, and role lookup.
+- [Dashboard](https://leadmagic.io/docs/api-reference/analytics): `GET /v1/analytics/dashboard` — free usage/spend reporting
 
-Important distinction: ads endpoints and some jobs endpoints exist in the broader REST API and this snapshot, but they are not part of the current MCP tool surface.
+## Hosted MCP
 
-## Hosted MCP Sign-In
-
-- Entrypoint: `https://mcp.leadmagic.io/mcp` (streamable HTTP)
-- Per-client install snippets (canonical): `https://mcp.leadmagic.io/clients`
-- OAuth authorization server metadata: `https://mcp.leadmagic.io/.well-known/oauth-authorization-server`
-- OAuth protected resource metadata: `https://mcp.leadmagic.io/.well-known/oauth-protected-resource/mcp`
-- Registration endpoint (DCR): `https://mcp.leadmagic.io/oauth/register`
-- OAuth scopes: `openid profile email offline_access`
-- Static public OAuth client (no DCR): client ID `4b9eLjoGVCJ1Dvnc`, secret blank (PKCE, S256). This ID is public by design.
-- API-key fallback header: `x-leadmagic-key: <YOUR_API_KEY>`
-- Bearer fallback header: `Authorization: Bearer <YOUR_LEADMAGIC_TOKEN>`
-
-Supported clients (all streamable-HTTP against the same URL): Cursor, Claude Desktop / Code / claude.ai, ChatGPT Developer Mode + Responses API, VS Code / GitHub Copilot, Windsurf, Zed, Cline, Roo Code, OpenCode, Gemini CLI, JetBrains IDEs, Amazon Q Developer, GitHub Copilot Coding Agent, Continue, Amp, Augment Code, Vercel AI SDK.
-
-For Cursor specifically, prefer the official plugin at `https://github.com/LeadMagic/leadmagic-cursor-plugin` (ships `mcp.json`, rules, skills, agent, and commands). Manual alternative is a URL-only `.cursor/mcp.json` entry — Cursor v0.48+ handles OAuth + DCR internally.
-
-## Docs-Only Endpoints Not Yet Modeled Here
-
-- Analytics API
-- Job Change Detector
-- Technographics
-- Competitors Search
-- Job company types
-- Job industries
-- Job regions
-- Credits helper endpoints like refresh and health
+- Entrypoint: `https://mcp.leadmagic.io/mcp` (streamable HTTP, OAuth with dynamic client registration + PKCE)
+- Setup for every client (Claude, Claude Code, ChatGPT, Codex, Cursor, and more): `https://leadmagic.io/docs/mcp/setup`
+- 35+ tools: people/company/jobs search, decision-makers, email find/validate, mobile, account intel, ads research, bulk, credits
+- API-key fallback header: `Authorization: Bearer <key>` (only when OAuth is unavailable)
 
 ## Repository Files
 
-- [README](README.md): Current repo guidance
-- [llms-full.txt](llms-full.txt): Longer LLM-oriented reference
-- [OpenAPI YAML](leadmagic-openapi-3.1.yaml): Local OpenAPI snapshot
-- [OpenAPI JSON](leadmagic-openapi-3.1.json): Local JSON snapshot
+- [README](README.md): repo guidance
+- [OpenAPI YAML](leadmagic-openapi-3.1.yaml) / [JSON](leadmagic-openapi-3.1.json): the 81-path snapshot, synced from leadmagic.io/docs
+- [llms-full.txt](llms-full.txt): longer LLM-oriented reference
+- [test-api.ts](test-api.ts): live smoke tests (`npm run test:api`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
 				"@stoplight/spectral-cli": "6.16.3",
 				"@types/node": "25.3.3",
 				"tsx": "4.23.12",
-				"typescript": "5.9.3"
+				"typescript": "5.9.3",
+				"yaml": "2.9.0"
 			}
 		},
 		"node_modules/@asyncapi/specs": {
@@ -3923,6 +3924,22 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@stoplight/spectral-cli": "6.15.0",
+				"@stoplight/spectral-cli": "6.16.3",
 				"@types/node": "25.3.3",
-				"tsx": "4.21.0",
+				"tsx": "4.23.12",
 				"typescript": "5.9.3"
 			}
 		},
@@ -26,9 +26,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -43,9 +43,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
 			"cpu": [
 				"arm"
 			],
@@ -60,9 +60,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
 			"cpu": [
 				"arm64"
 			],
@@ -77,9 +77,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
 			"cpu": [
 				"x64"
 			],
@@ -94,9 +94,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
 			"cpu": [
 				"arm64"
 			],
@@ -111,9 +111,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
 			"cpu": [
 				"x64"
 			],
@@ -128,9 +128,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -145,9 +145,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
 			"cpu": [
 				"x64"
 			],
@@ -162,9 +162,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
 			"cpu": [
 				"arm"
 			],
@@ -179,9 +179,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
 			"cpu": [
 				"arm64"
 			],
@@ -196,9 +196,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -213,9 +213,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -230,9 +230,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -247,9 +247,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -264,9 +264,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -281,9 +281,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
 			"cpu": [
 				"s390x"
 			],
@@ -298,9 +298,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
 			"cpu": [
 				"x64"
 			],
@@ -315,9 +315,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
 			"cpu": [
 				"arm64"
 			],
@@ -332,9 +332,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
 			"cpu": [
 				"x64"
 			],
@@ -349,9 +349,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -366,9 +366,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
 			"cpu": [
 				"x64"
 			],
@@ -383,9 +383,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -400,9 +400,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
 			"cpu": [
 				"x64"
 			],
@@ -417,9 +417,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -434,9 +434,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
 			"cpu": [
 				"ia32"
 			],
@@ -451,9 +451,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
 			"cpu": [
 				"x64"
 			],
@@ -591,6 +591,14 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@scarf/scarf": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+			"integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/@stoplight/better-ajv-errors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@stoplight/better-ajv-errors/-/better-ajv-errors-1.0.3.tgz",
@@ -690,12 +698,13 @@
 			}
 		},
 		"node_modules/@stoplight/spectral-cli": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.15.0.tgz",
-			"integrity": "sha512-FVeQIuqQQnnLfa8vy+oatTKUve7uU+3SaaAfdjpX/B+uB1NcfkKRJYhKT9wMEehDRaMPL5AKIRYMCFerdEbIpw==",
+			"version": "6.16.3",
+			"resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.3.tgz",
+			"integrity": "sha512-corAOQ/WhGoPJOQ3Tcipyn64TgKYDkEhsDplS6vNSGys3kzi9+zzxiVOlbzk9mWuafovzoW+TpGCoNwIZvFf5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@scarf/scarf": "^1.4.0",
 				"@stoplight/json": "~3.21.0",
 				"@stoplight/path": "1.3.2",
 				"@stoplight/spectral-core": "^1.19.5",
@@ -710,7 +719,7 @@
 				"chalk": "4.1.2",
 				"fast-glob": "~3.2.12",
 				"hpagent": "~1.2.0",
-				"lodash": "~4.17.21",
+				"lodash": "^4.18.1",
 				"pony-cause": "^1.1.1",
 				"stacktracey": "^2.1.8",
 				"tslib": "^2.8.1",
@@ -770,13 +779,6 @@
 				"node": "^12.20 || >=14.13"
 			}
 		},
-		"node_modules/@stoplight/spectral-core/node_modules/lodash": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@stoplight/spectral-formats": {
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.8.2.tgz",
@@ -818,13 +820,6 @@
 				"node": "^16.20 || ^18.18 || >= 20.17"
 			}
 		},
-		"node_modules/@stoplight/spectral-formatters/node_modules/lodash": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@stoplight/spectral-functions": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.2.tgz",
@@ -847,13 +842,6 @@
 			"engines": {
 				"node": "^16.20 || ^18.18 || >= 20.17"
 			}
-		},
-		"node_modules/@stoplight/spectral-functions/node_modules/lodash": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@stoplight/spectral-parsers": {
 			"version": "1.0.5",
@@ -1006,13 +994,6 @@
 				"node": "^16.20 || ^18.18 || >= 20.17"
 			}
 		},
-		"node_modules/@stoplight/spectral-rulesets/node_modules/lodash": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@stoplight/spectral-runtime": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.5.tgz",
@@ -1031,13 +1012,6 @@
 			"engines": {
 				"node": "^16.20 || ^18.18 || >= 20.17"
 			}
-		},
-		"node_modules/@stoplight/spectral-runtime/node_modules/lodash": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@stoplight/types": {
 			"version": "13.20.0",
@@ -1350,9 +1324,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1782,9 +1756,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.7",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1795,32 +1769,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.7",
-				"@esbuild/android-arm": "0.27.7",
-				"@esbuild/android-arm64": "0.27.7",
-				"@esbuild/android-x64": "0.27.7",
-				"@esbuild/darwin-arm64": "0.27.7",
-				"@esbuild/darwin-x64": "0.27.7",
-				"@esbuild/freebsd-arm64": "0.27.7",
-				"@esbuild/freebsd-x64": "0.27.7",
-				"@esbuild/linux-arm": "0.27.7",
-				"@esbuild/linux-arm64": "0.27.7",
-				"@esbuild/linux-ia32": "0.27.7",
-				"@esbuild/linux-loong64": "0.27.7",
-				"@esbuild/linux-mips64el": "0.27.7",
-				"@esbuild/linux-ppc64": "0.27.7",
-				"@esbuild/linux-riscv64": "0.27.7",
-				"@esbuild/linux-s390x": "0.27.7",
-				"@esbuild/linux-x64": "0.27.7",
-				"@esbuild/netbsd-arm64": "0.27.7",
-				"@esbuild/netbsd-x64": "0.27.7",
-				"@esbuild/openbsd-arm64": "0.27.7",
-				"@esbuild/openbsd-x64": "0.27.7",
-				"@esbuild/openharmony-arm64": "0.27.7",
-				"@esbuild/sunos-x64": "0.27.7",
-				"@esbuild/win32-arm64": "0.27.7",
-				"@esbuild/win32-ia32": "0.27.7",
-				"@esbuild/win32-x64": "0.27.7"
+				"@esbuild/aix-ppc64": "0.28.2",
+				"@esbuild/android-arm": "0.28.2",
+				"@esbuild/android-arm64": "0.28.2",
+				"@esbuild/android-x64": "0.28.2",
+				"@esbuild/darwin-arm64": "0.28.2",
+				"@esbuild/darwin-x64": "0.28.2",
+				"@esbuild/freebsd-arm64": "0.28.2",
+				"@esbuild/freebsd-x64": "0.28.2",
+				"@esbuild/linux-arm": "0.28.2",
+				"@esbuild/linux-arm64": "0.28.2",
+				"@esbuild/linux-ia32": "0.28.2",
+				"@esbuild/linux-loong64": "0.28.2",
+				"@esbuild/linux-mips64el": "0.28.2",
+				"@esbuild/linux-ppc64": "0.28.2",
+				"@esbuild/linux-riscv64": "0.28.2",
+				"@esbuild/linux-s390x": "0.28.2",
+				"@esbuild/linux-x64": "0.28.2",
+				"@esbuild/netbsd-arm64": "0.28.2",
+				"@esbuild/netbsd-x64": "0.28.2",
+				"@esbuild/openbsd-arm64": "0.28.2",
+				"@esbuild/openbsd-x64": "0.28.2",
+				"@esbuild/openharmony-arm64": "0.28.2",
+				"@esbuild/sunos-x64": "0.28.2",
+				"@esbuild/win32-arm64": "0.28.2",
+				"@esbuild/win32-ia32": "0.28.2",
+				"@esbuild/win32-x64": "0.28.2"
 			}
 		},
 		"node_modules/escalade": {
@@ -1892,9 +1866,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2111,19 +2085,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-tsconfig": {
-			"version": "4.13.7",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-			"integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"resolve-pkg-maps": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
 		"node_modules/glob": {
@@ -2843,9 +2804,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3218,16 +3179,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/resolve-pkg-maps": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
 			}
 		},
 		"node_modules/reusify": {
@@ -3659,14 +3610,13 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
-			"version": "4.21.0",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"version": "4.23.12",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+			"integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "~0.27.0",
-				"get-tsconfig": "^4.7.5"
+				"esbuild": "~0.28.0"
 			},
 			"bin": {
 				"tsx": "dist/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@stoplight/spectral-cli": "6.15.0",
+		"@stoplight/spectral-cli": "6.16.3",
 		"@types/node": "25.3.3",
-		"tsx": "4.21.0",
+		"tsx": "4.23.12",
 		"typescript": "5.9.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"@stoplight/spectral-cli": "6.16.3",
 		"@types/node": "25.3.3",
 		"tsx": "4.23.12",
-		"typescript": "5.9.3"
+		"typescript": "5.9.3",
+		"yaml": "2.9.0"
 	}
 }

--- a/scripts/normalize-31-examples.mjs
+++ b/scripts/normalize-31-examples.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Normalize a synced OpenAPI document to strict 3.1 example style:
+ *
+ * - Schema objects:     example: v            -> examples: [v]        (JSON Schema keyword)
+ * - Parameter objects:  example: v            -> examples: {default: {value: v}}
+ * - Media type objects: example: v            -> examples: {default: {value: v}}
+ *
+ * The docs-site source spec keeps the 3.0-style singular `example` fields
+ * (its renderer expects them); this repo publishes the strict-3.1 form.
+ *
+ * Usage: node scripts/normalize-31-examples.mjs <in.yaml> <out.yaml> <out.json>
+ */
+import fs from "node:fs";
+import { parse, stringify } from "yaml";
+
+const [, , inFile, outYaml, outJson] = process.argv;
+if (!inFile || !outYaml || !outJson) {
+	console.error("usage: normalize-31-examples.mjs <in.yaml> <out.yaml> <out.json>");
+	process.exit(1);
+}
+
+const doc = parse(fs.readFileSync(inFile, "utf8"));
+let schemaCount = 0;
+let namedCount = 0;
+
+const MIME_RE = /^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+*-]+$/i;
+
+/**
+ * @param node       current object
+ * @param parentKey  the key this object lives under
+ * @param inSchema   true when inside a JSON Schema subtree
+ */
+function walk(node, parentKey, inSchema) {
+	if (Array.isArray(node)) {
+		// Parameter objects live in `parameters` arrays.
+		for (const item of node) walk(item, parentKey === "parameters" ? "@parameter" : parentKey, inSchema);
+		return;
+	}
+	if (!node || typeof node !== "object") return;
+
+	// A `properties` map's values are schemas, but its KEYS are field names —
+	// a field literally named "example" must not be rewritten.
+	const isPropertyMap = parentKey === "properties";
+
+	if (!isPropertyMap && Object.hasOwn(node, "example")) {
+		const isParameter = parentKey === "@parameter" && Object.hasOwn(node, "in");
+		const isMediaType = MIME_RE.test(parentKey ?? "");
+		if (inSchema && !isParameter && !isMediaType) {
+			node.examples = [node.example];
+			delete node.example;
+			schemaCount++;
+		} else if (isParameter || isMediaType) {
+			// `examples` may already exist; don't clobber.
+			if (!Object.hasOwn(node, "examples")) {
+				node.examples = { default: { value: node.example } };
+			}
+			delete node.example;
+			namedCount++;
+		}
+	}
+
+	for (const [key, value] of Object.entries(node)) {
+		if (key === "examples") continue; // never descend into example payloads
+		const childInSchema =
+			inSchema ||
+			key === "schema" ||
+			(isPropertyMap === false && (key === "properties" || key === "items" || key === "allOf" || key === "oneOf" || key === "anyOf" || key === "additionalProperties" || key === "prefixItems"));
+		walk(value, key, isPropertyMap ? true : childInSchema);
+	}
+}
+
+walk(doc.paths, "paths", false);
+// components.schemas entries ARE schemas; components.parameters entries ARE parameters.
+for (const schema of Object.values(doc.components?.schemas ?? {})) walk(schema, "schema", true);
+for (const param of Object.values(doc.components?.parameters ?? {})) walk(param, "@parameter", false);
+walk(doc.components?.responses ?? {}, "responses", false);
+walk(doc.components?.requestBodies ?? {}, "requestBodies", false);
+
+// Anything left (e.g. bare `example` outside recognized contexts) still needs
+// to satisfy the strict-3.1 CI check — report and fail loudly if any remain.
+let leftovers = 0;
+(function scan(node, parentKey) {
+	if (Array.isArray(node)) return node.forEach((n) => scan(n, parentKey));
+	if (!node || typeof node !== "object") return;
+	if (parentKey !== "properties" && Object.hasOwn(node, "example")) leftovers++;
+	for (const [key, value] of Object.entries(node)) {
+		if (key === "examples") continue;
+		scan(value, key);
+	}
+})(doc, null);
+
+fs.writeFileSync(outYaml, stringify(doc, { lineWidth: 0 }));
+fs.writeFileSync(outJson, `${JSON.stringify(doc, null, 2)}\n`);
+console.log(`schema examples: ${schemaCount}, named examples: ${namedCount}, leftovers: ${leftovers}`);
+if (leftovers > 0) process.exit(1);


### PR DESCRIPTION
- Syncs the OpenAPI snapshot from the live docs contract (81 paths: v3 search family with aliases, bulk, batch, analytics, ads) — replaces the stale 19-endpoint unversioned model
- Spectral lint: **0 errors** (was 4); remaining 22 warnings are kept-but-unreferenced components
- `npm audit`: **0 vulnerabilities** — clears all 9 open Dependabot alerts (fast-uri ×5, lodash ×2, brace-expansion, esbuild)
- `llms.txt` rewritten for the current surface incl. unlimited Professional/Ultimate search and cursor pagination
- README + `llms-full.txt`: corrected MCP surface (35+ tools incl. jobs/ads), SEO-oriented intro, unlimited-plan status section

🤖 Generated with [Claude Code](https://claude.com/claude-code)