### PR TITLE
ci: scope workflow token to contents:read and run validation on every PR

### DIFF
--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -5,13 +5,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    paths:
-      - 'leadmagic-openapi-3.1.yaml'
-      - 'leadmagic-openapi-3.1.json'
-      - 'test-api.ts'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
+
+# Least-privilege token for every job: the workflow only reads the checkout.
+permissions:
+  contents: read
 
 jobs:
   validate-spec:


### PR DESCRIPTION
## Summary

- Add a top-level `permissions: contents: read` to `.github/workflows/validate-openapi.yml` so all four jobs run with a least-privilege `GITHUB_TOKEN`. This clears the 4 medium `actions/missing-workflow-permissions` code-scanning alerts. No job writes to the repo, so nothing else is granted.
- Drop the `pull_request` `paths` filter. The `Validate OpenAPI Specification` check is about to become a required status check on `main`; a path-filtered required check would leave PRs that only touch workflows/docs/tooling permanently blocked. The jobs are cheap, so running them on every PR is fine.

## Verification

- `npm ci && npm run typecheck && npm run lint:openapi` unchanged (workflow-only change).
- Workflow YAML parses; this PR itself exercises the updated workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)