### PR TITLE
Require owner review and clarify MIT licensing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Jesse reviews changes to every file, including this ownership policy.
+* @jesseoue

--- a/LICENSE-NOTES.md
+++ b/LICENSE-NOTES.md
@@ -1,0 +1,11 @@
+# Licensing and contributions
+
+The helper code and original documentation in this repository are provided under the [MIT license](LICENSE). Existing copyright notices remain in place. MIT permits reuse, modification, and distribution subject to its notice requirements; it does not require separate permission from the maintainer to use a copy.
+
+Changes to the canonical LeadMagic repository require maintainer review under its GitHub protection settings. Opening a public pull request does not grant write access or authorize deployment or publication.
+
+Third-party dependencies, copied assets, and excerpts retain their own licenses and attribution requirements. A root MIT license does not relicense third-party material. Preserve upstream notices and document the source and license of any material you add. Do not contribute material you lack permission to distribute.
+
+An integration with a third-party service does not imply ownership of that service or endorsement by its provider. Repository licensing does not grant access to hosted services, API credentials, or customer data; service access is governed separately.
+
+Before distributing a bundled build, review the licenses of the dependencies and assets actually included in that artifact. Report a missing attribution or licensing concern to [support@leadmagic.io](mailto:support@leadmagic.io), with the affected file and public source.

--- a/README.md
+++ b/README.md
@@ -97,3 +97,7 @@ MIT licensed.
 ## Public examples and publication
 
 Examples are fictional unless an explicit public source is cited. See [PUBLICATION.md](PUBLICATION.md) for data, claims, attribution, and disclosure requirements.
+
+## License and contributions
+
+[MIT license](LICENSE) · [Third-party materials and contribution policy](LICENSE-NOTES.md). Reuse is allowed under the license; changes to this repository require maintainer review.


### PR DESCRIPTION
Assign all files, including ownership and workflow configuration, to @jesseoue for review. Preserve the existing MIT license and copyright notices, explain third-party licensing obligations, and separate permission to reuse a copy from permission to change the canonical repository. The organization-profile repository gains the missing standard MIT license.

Where applicable, pin workflow actions, remove unnecessary bot write access, and require the maintainer-controlled release environment before publication. Release references must belong to reviewed main history. Validation workflows run for every PR so required checks cannot be omitted by path filters.

Validation: ownership/license/public-file checks, n8n package contents, and generated GTM artifacts checked locally. No releases or paid API calls. GitHub protection settings are applied separately after these policy files are merged.
