### PR TITLE
Use consistent official LeadMagic icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LeadMagic OpenAPI: B2B Data Enrichment REST API
 
+<img src="https://raw.githubusercontent.com/LeadMagic/.github/main/profile/assets/leadmagic.svg" width="64" height="64" alt="LeadMagic logo">
+
 OpenAPI 3.1 JSON and YAML for the documented LeadMagic REST API: people and company enrichment, email finding and validation, search, jobs, advertising, and bulk workflows. Import the specification into API tooling or use it to generate a client.
 
 [LeadMagic B2B enrichment](https://leadmagic.io?utm_source=github&utm_medium=readme&utm_campaign=leadmagic-openapi&utm_content=readme-intro) · [API documentation](https://leadmagic.io/docs?utm_source=github&utm_medium=readme&utm_campaign=leadmagic-openapi&utm_content=readme-intro) · [Pricing and credits](https://leadmagic.io/pricing?utm_source=github&utm_medium=readme&utm_campaign=leadmagic-openapi&utm_content=readme-intro)


### PR DESCRIPTION
Display the current official LeadMagic icon at 64 by 64 pixels with descriptive alt text. The organization profile hosts the shared README asset; plugin logos remain local where required, and GTM keeps a local copy to respect its URL policy. Preserve the generated README through its source generator.

Official SVG files are copied unchanged from https://leadmagic.io/logo/icon.svg and checked for matching contents, valid XML, and no active or external content. Public-file checks, Cursor validation, and GTM generated-file validation pass. Existing n8n icons already match the artwork. No archived repository, license, or protection setting changes.
